### PR TITLE
Add functionality to specify custom path to roms for the Atari envs

### DIFF
--- a/docs/atari.md
+++ b/docs/atari.md
@@ -52,7 +52,7 @@ env = frame_skip(env, 4)
 All the Atari environments have the following environment parameters:
 
 ```python
-<atari_game>.env(obs_type='rgb_image', full_action_space=True, max_frames=100000)
+<atari_game>.env(obs_type='rgb_image', full_action_space=True, max_frames=100000, rom_path=None)
 ```
 
 `obs_type`:  There are three possible values for this parameter:
@@ -64,6 +64,8 @@ All the Atari environments have the following environment parameters:
 `full_action_space`:  the effective action space of the Atari games is often smaller than the full space of 18 moves. Setting this to `False` shrinks the available action space to that smaller space.
 
 `max_frames`:  the number of frames (the number of steps that each agent can take) until game terminates.
+
+`rom_path`: The path to your rom. If this is not specified (has value `None`), then the library looks for roms installed with the [PettingZoo-Team/AutoROM](https://github.com/PettingZoo-Team/AutoROM) tool. 
 
 ### Citation
 

--- a/docs/atari.md
+++ b/docs/atari.md
@@ -52,7 +52,7 @@ env = frame_skip(env, 4)
 All the Atari environments have the following environment parameters:
 
 ```python
-<atari_game>.env(obs_type='rgb_image', full_action_space=True, max_frames=100000, rom_path=None)
+<atari_game>.env(obs_type='rgb_image', full_action_space=True, max_frames=100000, auto_rom_install_path=None)
 ```
 
 `obs_type`:  There are three possible values for this parameter:
@@ -65,7 +65,15 @@ All the Atari environments have the following environment parameters:
 
 `max_frames`:  the number of frames (the number of steps that each agent can take) until game terminates.
 
-`rom_path`: The path to your rom. If this is not specified (has value `None`), then the library looks for roms installed with the [PettingZoo-Team/AutoROM](https://github.com/PettingZoo-Team/AutoROM) tool. 
+`auto_rom_install_path`: The path to your AutoROM installation, installed
+with the [PettingZoo-Team/AutoROM](https://github.com/PettingZoo-Team/AutoROM) tool.
+This is the path you specified when installing AutoROM. For example, if
+you're using the boxing Atari environment, then the library will look for
+the rom at 
+`/auto_rom_install_path/ROM/boxing/boxing.bin`.
+If this is not specified (has value `None`), then the library looks for roms
+installed at the default AutoROM path.
+
 
 ### Citation
 

--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -38,7 +38,7 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
             obs_type='rgb_image',
             full_action_space=True,
             max_frames=100000,
-            rom_path=None):
+            auto_rom_install_path=None):
         """Frameskip should be either a tuple (indicating a random range to
         choose from, with the top value exclude), or an int."""
         EzPickle.__init__(
@@ -50,7 +50,7 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
             obs_type,
             full_action_space,
             max_frames,
-            rom_path,
+            auto_rom_install_path,
         )
 
         assert obs_type in ('ram', 'rgb_image', "grayscale_image"), "obs_type must  either be 'ram' or 'rgb_image' or 'grayscale_image'"
@@ -64,10 +64,10 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
 
         self.ale.setFloat(b'repeat_action_probability', 0.)
 
-        if rom_path is None:
+        if auto_rom_install_path is None:
             start = Path(multi_agent_ale_py.__file__).parent
         else:
-            start = Path(rom_path).resolve()
+            start = Path(auto_rom_install_path).resolve()
 
         final = start / "ROM" / game / f"{game}.bin"
 

--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -75,7 +75,6 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
                           "or specify and double-check the path to your Atari rom using the `rom_path` argument.")
 
         self.rom_path = str(final)
-        print(self.rom_path)
         self.ale.loadROM(self.rom_path)
 
         all_modes = self.ale.getAvailableModes(num_players)

--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -1,5 +1,4 @@
 import multi_agent_ale_py
-import os
 from pathlib import Path
 from pettingzoo import AECEnv
 import gym

--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -66,9 +66,10 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
 
         if rom_path is None:
             start = Path(multi_agent_ale_py.__file__).parent
-            final = start / "ROM" / game / f"{game}.bin"
         else:
-            final = Path(rom_path).resolve()
+            start = Path(rom_path).resolve()
+
+        final = start / "ROM" / game / f"{game}.bin"
 
         if not final.exists():
             raise IOError(f"rom {game} is not installed. Please install roms using AutoROM tool (https://github.com/PettingZoo-Team/AutoROM) "


### PR DESCRIPTION
The argument `rom_path` was added with a default value of `None`. If a custom path is not specified, then the library looks for roms installed with the AutoROM tool. 

Tested with and without specifying a `rom_path`. The pytests tests and style check test passed locally.