### PR TITLE
Minor deprecation handler fix

### DIFF
--- a/pettingzoo/utils/deprecated_module.py
+++ b/pettingzoo/utils/deprecated_module.py
@@ -10,7 +10,7 @@ class DeprecatedEnv(ImportError):
 class DeprecatedModule:
     def __init__(self, name, old_version, new_version):
         def env(*args, **kwargs):
-            raise DeprecatedEnv(f"{name}_{old_version} is now deprecated, use {name}_{new_version} instead")
+            raise DeprecatedEnv(f"{name}_v{old_version} is now deprecated, use {name}_v{new_version} instead")
 
         self.env = env
         self.raw_env = env


### PR DESCRIPTION
Fix deprecation warning to {env\_name}\_v{version} instead of {env\_name}\_{version}