### PR TITLE
fix teleport bug

### DIFF
--- a/pettingzoo/butterfly/cooperative_pong/cake_paddle.py
+++ b/pettingzoo/butterfly/cooperative_pong/cake_paddle.py
@@ -34,7 +34,14 @@ class CakePaddle(pygame.sprite.Sprite):
         pygame.draw.rect(screen, (255, 255, 255), self.rect3)
         pygame.draw.rect(screen, (255, 255, 255), self.rect4)
 
-    def update(self, area, action):
+    def update(self, area, action, b_rect):
+        # update vertical relationship with ball
+        # since [process_collision] is called later,
+        # we can guarantee there is no collision here
+        self.was_ball_on_top = False
+        if self.rect4.top >= b_rect.bottom:
+            self.was_ball_on_top = True
+
         # action: 1 - up, 2 - down
         movepos = [0, 0]
         if action == 1:
@@ -72,51 +79,59 @@ class CakePaddle(pygame.sprite.Sprite):
             if dx > 0:
                 b_rect.right = self.rect4.left
                 b_speed[0] = -b_speed[0]
-            # top or bottom edge
-            elif dy > 0:
+            # @FIX: The vertical position of ball
+            # should be determined based on the 
+            # relative position before update,
+            # not based on its vertical speed.
+            elif self.was_ball_on_top:
                 b_rect.bottom = self.rect4.top
-                b_speed[1] = -b_speed[1]
-            elif dy < 0:
+                if b_speed[1] > 0:
+                    b_speed[1] = -b_speed[1]
+            elif not self.was_ball_on_top:
                 b_rect.top = self.rect4.bottom
-                b_speed[1] = -b_speed[1]
+                if b_speed[1] < 0:
+                    b_speed[1] = -b_speed[1]
             return is_collision, b_rect, b_speed
         elif self.rect3.colliderect(b_rect):
             is_collision = True
             if dx > 0:
                 b_rect.right = self.rect3.left
                 b_speed[0] = -b_speed[0]
-            # top or bottom edge
-            elif dy > 0:
+            elif self.was_ball_on_top:
                 b_rect.bottom = self.rect3.top
-                b_speed[1] = -b_speed[1]
-            elif dy < 0:
+                if b_speed[1] > 0:
+                    b_speed[1] = -b_speed[1]
+            elif not self.was_ball_on_top:
                 b_rect.top = self.rect3.bottom
-                b_speed[1] = -b_speed[1]
+                if b_speed[1] < 0:
+                    b_speed[1] = -b_speed[1]
             return is_collision, b_rect, b_speed
         elif self.rect2.colliderect(b_rect):
             is_collision = True
             if dx > 0:
                 b_rect.right = self.rect2.left
                 b_speed[0] = -b_speed[0]
-            # top or bottom edge
-            elif dy > 0:
+            elif self.was_ball_on_top:
                 b_rect.bottom = self.rect2.top
-                b_speed[1] = -b_speed[1]
-            elif dy < 0:
+                if b_speed[1] > 0:
+                    b_speed[1] = -b_speed[1]
+            elif not self.was_ball_on_top:
                 b_rect.top = self.rect2.bottom
-                b_speed[1] = -b_speed[1]
+                if b_speed[1] < 0:
+                    b_speed[1] = -b_speed[1]
             return is_collision, b_rect, b_speed
         elif self.rect.colliderect(b_rect):
             is_collision = True
             if dx > 0:
                 b_rect.right = self.rect.left
                 b_speed[0] = -b_speed[0]
-            # top or bottom edge
-            elif dy > 0:
+            elif self.was_ball_on_top:
                 b_rect.bottom = self.rect.top
-                b_speed[1] = -b_speed[1]
-            elif dy < 0:
+                if b_speed[1] > 0:
+                    b_speed[1] = -b_speed[1]
+            elif not self.was_ball_on_top:
                 b_rect.top = self.rect.bottom
-                b_speed[1] = -b_speed[1]
+                if b_speed[1] < 0:
+                    b_speed[1] = -b_speed[1]
             return is_collision, b_rect, b_speed
         return False, b_rect, b_speed

--- a/pettingzoo/butterfly/cooperative_pong/cooperative_pong.py
+++ b/pettingzoo/butterfly/cooperative_pong/cooperative_pong.py
@@ -317,7 +317,7 @@ class CooperativePong:
             self.rewards = {a: 0 for a in self.agents}
             self.p0.update(self.area, action)
         elif agent == self.agents[1]:
-            self.p1.update(self.area, action)
+            self.p1.update(self.area, action, self.ball.rect)
 
             # do the rest if not done
             if not self.done:


### PR DESCRIPTION
Fixed cooperative pong teleport bug from #523.

This was because when there is collision between ball and paddle, the code resolved the collision by moving the ball right at the top or bottom of the paddle based on the vertical speed of the ball. If the ball was moving upward, it assumed that the lower part of paddle collided with the upper part of the ball. However, even when the ball is moving upward, upper part of the paddle can collide with the lower part of the ball, as shown in #523.

So modified the code to relocate the ball based on the vertical relationship between the ball and the paddle right before the collision. That means that if the ball was at above the paddle, even after the collision handling, it should remain above the paddle.