### PR TITLE
Parallel API Test Improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,11 @@ If you're thinking about creating submitting a new environment, please contact u
 Contributing code is done through standard github methods:
 
 1. Fork this repo
-1. Commit your code
-1. Submit a pull request. It will be reviewed by maintainers and they'll give feedback or make requests as applicable
+3. Commit your code
+4. Submit a pull request. It will be reviewed by maintainers and they'll give feedback or make requests as applicable
 
 #### Considerations
-- Make sure existing tests pass (run `pytest pettingzoo/tests/pytest_runner.py`)
+- Make sure existing tests pass (`pip install -r requirements.txt` and then run `pytest test/pytest_runner.py` -- may also need to apt-get/brew install swig)
 - Make sure linter passes (run `check_style.sh`)
 - Make sure your new code is properly tested and fully-covered
 - Any fixes to environments should include fixes to the appropriate documentation

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -5,6 +5,7 @@ from pettingzoo.utils.wrappers import BaseWrapper
 
 from .api_test import missing_attr_warning
 
+
 def parallel_api_test(par_env, num_cycles=10):
     if not hasattr(par_env, 'possible_agents'):
         warnings.warn(missing_attr_warning.format(name='possible_agents'))
@@ -33,21 +34,21 @@ def parallel_api_test(par_env, num_cycles=10):
             assert isinstance(info, dict)
 
             agents_set = set(live_agents)
-            keys       = 'observation reward done info'.split()
-            vals       = [obs, rew, done, info]
+            keys = 'observation reward done info'.split()
+            vals = [obs, rew, done, info]
             for k, v in zip(keys, vals):
                 if set(v.keys()) == agents_set:
                     continue
                 warnings.warn('Agent was given: {} but was done last turn'.format(k))
 
             if hasattr(par_env, 'possible_agents'):
-               assert set(par_env.agents).issubset(set(par_env.possible_agents)), "possible_agents defined but does not contain all agents"
+                assert set(par_env.agents).issubset(set(par_env.possible_agents)), "possible_agents defined but does not contain all agents"
 
-               has_finished |= {agent for agent, d in done.items() if d}
-               if not par_env.agents and has_finished != set(par_env.possible_agents):
-                   warnings.warn('No agents present but not all possible_agents are done')
+                has_finished |= {agent for agent, d in done.items() if d}
+                if not par_env.agents and has_finished != set(par_env.possible_agents):
+                    warnings.warn('No agents present but not all possible_agents are done')
             elif not par_env.agents:
-               warnings.warn('No agents present')
+                warnings.warn('No agents present')
 
             for agent in par_env.agents:
                 assert par_env.observation_space(agent) is par_env.observation_space(agent), "observation_space should return the exact same space object (not a copy) for an agent. Consider decorating your observation_space(self, agent) method with @functools.lru_cache(maxsize=None)"

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -5,7 +5,6 @@ from pettingzoo.utils.wrappers import BaseWrapper
 
 from .api_test import missing_attr_warning
 
-
 def parallel_api_test(par_env, num_cycles=10):
     if not hasattr(par_env, 'possible_agents'):
         warnings.warn(missing_attr_warning.format(name='possible_agents'))
@@ -18,7 +17,6 @@ def parallel_api_test(par_env, num_cycles=10):
         obs = par_env.reset()
         assert isinstance(obs, dict)
         assert set(obs.keys()) == (set(par_env.agents))
-
         done = {agent: False for agent in par_env.agents}
         live_agents = set(par_env.agents[:])
         has_finished = set()
@@ -28,15 +26,29 @@ def parallel_api_test(par_env, num_cycles=10):
             for agent in par_env.agents:
                 if agent not in live_agents:
                     live_agents.add(agent)
+
             assert isinstance(obs, dict)
             assert isinstance(rew, dict)
             assert isinstance(done, dict)
             assert isinstance(info, dict)
-            assert set(obs.keys()) == (set(live_agents)), "agents should not be given an observation if they were done last turn"
-            assert set(rew.keys()) == (set(live_agents)), "agents should not be given a reward if they were done last turn"
-            assert set(done.keys()) == (set(live_agents)), "agents should not be given a done if they were done last turn"
-            assert set(info.keys()) == (set(live_agents)), "agents should not be given a info if they were done last turn"
-            assert not hasattr(par_env, 'possible_agents') or set(par_env.agents).issubset(set(par_env.possible_agents)), "possible agents should include all agents always if it exists"
+
+            agents_set = set(live_agents)
+            keys       = 'observation reward done info'.split()
+            vals       = [obs, rew, done, info]
+            for k, v in zip(keys, vals):
+                if set(v.keys()) == agents_set:
+                    continue
+                warnings.warn('Agent was given: {} but was done last turn'.format(k))
+
+            if hasattr(par_env, 'possible_agents'):
+               assert set(par_env.agents).issubset(set(par_env.possible_agents)), "possible_agents defined but does not contain all agents"
+
+               has_finished |= {agent for agent, d in done.items() if d}
+               if not par_env.agents and has_finished != set(par_env.possible_agents):
+                   warnings.warn('No agents present but not all possible_agents are done')
+            elif not par_env.agents:
+               warnings.warn('No agents present')
+
             for agent in par_env.agents:
                 assert par_env.observation_space(agent) is par_env.observation_space(agent), "observation_space should return the exact same space object (not a copy) for an agent. Consider decorating your observation_space(self, agent) method with @functools.lru_cache(maxsize=None)"
                 assert par_env.action_space(agent) is par_env.action_space(agent), "action_space should return the exact same space object (not a copy) for an agent (ensures that action space seeding works as expected). Consider decorating your action_space(self, agent) method with @functools.lru_cache(maxsize=None)"
@@ -44,8 +56,5 @@ def parallel_api_test(par_env, num_cycles=10):
             for agent, d in done.items():
                 if d:
                     live_agents.remove(agent)
+
             assert set(par_env.agents) == live_agents
-            has_finished |= {agent for agent, d in done.items() if d}
-            if not par_env.agents:
-                assert has_finished == set(par_env.possible_agents), "not all agents finished, some were skipped over"
-                break


### PR DESCRIPTION
Replaces several of the Parallel API test assertions with warnings. Ideally, API-conformant envs should pass with no warnings, but this is a decent first step. In particular:

- Removes a breaking assumption that possible_agents exists in all environments
- Assert -> warning: Environment is not done but contains no agents
- Assert -> warning: Environment contains no agents and not all possible_agents are done
- Assert -> warning: Agents will never respawn after marked done

Also fixed a typo in the contributor guidelines and added some details on setup. Passes linter and all tests except those dependent upon Atari ROM -- I could not figure out the correct install path for AutoROM