### PR TITLE
Update rllib_pistonball.py

### DIFF
--- a/tutorials/rllib_pistonball.py
+++ b/tutorials/rllib_pistonball.py
@@ -71,7 +71,7 @@ def env_creator(args):
 
 
 if __name__ == "__main__":
-    shutdown()
+    # shutdown()
     
     env_name = "pistonball_v4"
 

--- a/tutorials/rllib_pistonball.py
+++ b/tutorials/rllib_pistonball.py
@@ -1,7 +1,6 @@
 from ray import tune
 from ray.rllib.models import ModelCatalog
 from ray.tune.registry import register_env
-# from ray.rllib.utils import try_import_tf
 from ray.rllib.env.wrappers.pettingzoo_env import ParallelPettingZooEnv
 from pettingzoo.butterfly import pistonball_v4
 import supersuit as ss
@@ -52,7 +51,6 @@ class CNNModelV2(TorchModelV2, nn.Module):
 
 def env_creator(args):
     env = pistonball_v4.parallel_env(n_pistons=20,
-                                     # local_ratio=0,
                                      time_penalty=-0.1,
                                      continuous=True,
                                      random_drop=True,
@@ -66,13 +64,12 @@ def env_creator(args):
     env = ss.resize_v0(env, x_size=84, y_size=84)
     env = ss.frame_stack_v1(env, 3)
     env = ss.normalize_obs_v0(env, env_min=0, env_max=1)
-    #env = ss.flatten_v0(env)
     return env
 
 
 if __name__ == "__main__":
-    # shutdown()
-    
+    shutdown()
+
     env_name = "pistonball_v4"
 
     register_env(env_name, lambda config: ParallelPettingZooEnv(env_creator(config)))
@@ -130,7 +127,7 @@ if __name__ == "__main__":
             "sgd_minibatch_size": 64,
             "num_sgd_iter": 10, # epoc
             'rollout_fragment_length': 512,
-            "train_batch_size": 512*4,
+            "train_batch_size": 512,
             'lr': 2e-05,
             "clip_actions": True,
 

--- a/tutorials/rllib_pistonball.py
+++ b/tutorials/rllib_pistonball.py
@@ -7,6 +7,8 @@ from pettingzoo.butterfly import pistonball_v4
 import supersuit as ss
 import torch
 from torch import nn
+from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
+from ray import shutdown
 
 
 class CNNModelV2(TorchModelV2, nn.Module):
@@ -49,7 +51,16 @@ class CNNModelV2(TorchModelV2, nn.Module):
 
 
 def env_creator(args):
-    env = pistonball_v4.parallel_env(n_pistons=20, local_ratio=0, time_penalty=-0.1, continuous=True, random_drop=True, random_rotate=True, ball_mass=0.75, ball_friction=0.3, ball_elasticity=1.5, max_cycles=125)
+    env = pistonball_v4.parallel_env(n_pistons=20,
+                                     # local_ratio=0,
+                                     time_penalty=-0.1,
+                                     continuous=True,
+                                     random_drop=True,
+                                     random_rotate=True,
+                                     ball_mass=0.75,
+                                     ball_friction=0.3,
+                                     ball_elasticity=1.5,
+                                     max_cycles=125)
     env = ss.color_reduction_v0(env, mode='B')
     env = ss.dtype_v0(env, 'float32')
     env = ss.resize_v0(env, x_size=84, y_size=84)
@@ -60,6 +71,8 @@ def env_creator(args):
 
 
 if __name__ == "__main__":
+    shutdown()
+    
     env_name = "pistonball_v4"
 
     register_env(env_name, lambda config: ParallelPettingZooEnv(env_creator(config)))


### PR DESCRIPTION
Added ray's shutdown to prevent leftover ray instances
commented out local_ratio, as it errors otherwise
formatted params of the parallel env to be more readable