### PR TITLE
Turn based wrapper

### DIFF
--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -1,28 +1,41 @@
 import warnings
+import random
+import numpy as np
 
-from pettingzoo.utils.conversions import from_parallel_wrapper, to_parallel_wrapper
+from pettingzoo.utils.conversions import from_parallel_wrapper, to_parallel_wrapper, turn_based_to_parallel_wrapper
 from pettingzoo.utils.wrappers import BaseWrapper
 
 from .api_test import missing_attr_warning
+
+
+def sample_action(env, obs, agent):
+    agent_obs = obs[agent]
+    if "action_mask" in agent_obs:
+        legal_actions = np.flatnonzero(agent_obs["action_mask"])
+        if len(legal_actions) == 0:
+            return 0
+        return random.choice(legal_actions)
+    return env.action_space(agent).sample()
 
 
 def parallel_api_test(par_env, num_cycles=10):
     if not hasattr(par_env, 'possible_agents'):
         warnings.warn(missing_attr_warning.format(name='possible_agents'))
 
+    assert not isinstance(par_env.unwrapped, turn_based_to_parallel_wrapper)
     assert not isinstance(par_env.unwrapped, to_parallel_wrapper)
     assert not isinstance(par_env.unwrapped, from_parallel_wrapper)
     assert not isinstance(par_env.unwrapped, BaseWrapper)
     MAX_RESETS = 2
-    for n_resets in range(MAX_RESETS):
+    for _ in range(MAX_RESETS):
         obs = par_env.reset()
         assert isinstance(obs, dict)
         assert set(obs.keys()) == (set(par_env.agents))
         done = {agent: False for agent in par_env.agents}
         live_agents = set(par_env.agents[:])
         has_finished = set()
-        for i in range(num_cycles):
-            actions = {agent: par_env.action_space(agent).sample() for agent in par_env.agents if agent in done and not done[agent]}
+        for _ in range(num_cycles):
+            actions = {agent: sample_action(par_env, obs, agent) for agent in par_env.agents if agent in done and not done[agent]}
             obs, rew, done, info = par_env.step(actions)
             for agent in par_env.agents:
                 assert agent not in has_finished, "agent cannot be revived once done"
@@ -39,9 +52,13 @@ def parallel_api_test(par_env, num_cycles=10):
             keys = 'observation reward done info'.split()
             vals = [obs, rew, done, info]
             for k, v in zip(keys, vals):
-                if set(v.keys()) == agents_set:
+                key_set = set(v.keys())
+                if key_set == agents_set:
                     continue
-                warnings.warn('Agent was given: {} but was done last turn'.format(k))
+                if len(key_set) < len(agents_set):
+                    warnings.warn('Live agent was not given {}'.format(k))
+                else:
+                    warnings.warn('Agent was given {} but was done last turn'.format(k))
 
             if hasattr(par_env, 'possible_agents'):
                 assert set(par_env.agents).issubset(set(par_env.possible_agents)), "possible_agents defined but does not contain all agents"

--- a/pettingzoo/utils/__init__.py
+++ b/pettingzoo/utils/__init__.py
@@ -1,6 +1,6 @@
 from .agent_selector import agent_selector
 from .average_total_reward import average_total_reward
-from .conversions import from_parallel, to_parallel
+from .conversions import from_parallel, to_parallel, turn_based_to_parallel
 from .env import AECEnv, ParallelEnv
 from .random_demo import random_demo
 from .save_observation import save_observation

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -258,6 +258,8 @@ class turn_based_to_parallel_wrapper(to_parallel_wrapper):
             rewards = defaultdict(int)
             dones = dict(**self.aec_env.dones)
             infos = dict(**self.aec_env.infos)
+            for agent in self.aec_env.agents:
+                infos[agent]["active_agent"] = self.aec_env.agent_selection
             observations = {agent: self.aec_env.observe(agent) for agent in self.aec_env.agents}
             return observations, rewards, dones, infos
         self.aec_env.step(actions[self.aec_env.agent_selection])
@@ -282,5 +284,7 @@ class turn_based_to_parallel_wrapper(to_parallel_wrapper):
             else:
                 break
 
+        for agent in self.aec_env.agents:
+            infos[agent]["active_agent"] = self.aec_env.agent_selection
         self.agents = self.aec_env.agents
         return observations, rewards, dones, infos


### PR DESCRIPTION
This probably needs a thorough review by @benblack769 but it passes the (modified) parallel API test. 

The reason for creating the turn_based_to_parallel wrapper is because some applications require the parallel API for simultaneous games, and would preferably also be able to use the same API for classic games. However, in a two-player game, the current API gives the same observation to player1 and player2 when accepting actions, which is unfair to player2 who should receive an updated observation after player1 takes an action.

The turn-based version of the parallel API still accepts actions for each player, but only plays the action for the active player. It also adds the "active_agent" to each agent's info dict.

I also made modifications to the parallel API to allow it to safely sample legal actions from classic games, and added a more descriptive warning for an issue I ran into.