### PR TITLE
Force updated supersuit version

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -45,6 +45,6 @@ jobs:
       run: |
         if [[ $(python -c 'import sys; print(sys.version_info[1])') -lt 10 ]]
         then
-            pip install stable_baselines3 supersuit
+            pip install stable_baselines3 supersuit==3.3.2
             sed s/total_timesteps=2000000/total_timesteps=2000/g tutorials/13_lines.py | sed s/n_steps=256/n_steps=16/g | xvfb-run -s "-screen 0 1024x768x24" python -
         fi


### PR DESCRIPTION
Update supersuit version to support `pettingzoo_env_to_vec_env_v1` in supersuit. With the conflicting `gym` requirements, pip will only install a compatible version of supersuit (which is missing the mentioned updated method).