### PR TITLE
quash 4 warnings identified in #498

### DIFF
--- a/pettingzoo/test/api_test.py
+++ b/pettingzoo/test/api_test.py
@@ -223,7 +223,7 @@ def test_action_flexibility(env):
     elif isinstance(action_space, gym.spaces.Box):
         env.step(np.zeros_like(action_space.low))
         env.reset()
-        env.step(np.zeros_like(action_space.low).tolist())
+        env.step(np.zeros_like(action_space.low))
 
 
 def api_test(env, num_cycles=10, verbose_progress=False):


### PR DESCRIPTION
This quashes the warning identified in #498 as 
```
test/pytest_runner.py::test_module[sisl/waterworld_v3-pettingzoo.sisl.waterworld_v3]
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/gym/spaces/box.py:143: UserWarning: Casting input x to numpy array.
warnings.warn("Casting input x to numpy array.")
```