### PR TITLE
Removed deprecated "local_ratio" word

### DIFF
--- a/tutorials/manual_pistonball_policy.py
+++ b/tutorials/manual_pistonball_policy.py
@@ -59,7 +59,7 @@ def policy(obs):
 
 
 def main():
-    env = pistonball_v5.env(n_pistons=20, local_ratio=0, time_penalty=-0.1, continuous=True, random_drop=True, random_rotate=True, ball_mass=0.75, ball_friction=0.3, ball_elasticity=1.5, max_cycles=125)
+    env = pistonball_v5.env(n_pistons=20, time_penalty=-0.1, continuous=True, random_drop=True, random_rotate=True, ball_mass=0.75, ball_friction=0.3, ball_elasticity=1.5, max_cycles=125)
     total_reward = 0
     obs_list = []
     NUM_RESETS = 1


### PR DESCRIPTION
Removed the `local_ratio` argument from this tutorial. It appears that this was removed at some point or another and broke this tutorial.