### PR TITLE
Fix for #589 where the ball was bouncing off the left wall

### DIFF
--- a/pettingzoo/butterfly/pistonball/pistonball.py
+++ b/pettingzoo/butterfly/pistonball/pistonball.py
@@ -49,6 +49,7 @@ class raw_env(AECEnv, EzPickle):
 
     def __init__(self, n_pistons=20, time_penalty=-0.1, continuous=True, random_drop=True, random_rotate=True, ball_mass=0.75, ball_friction=0.3, ball_elasticity=1.5, max_cycles=125):
         EzPickle.__init__(self, n_pistons, time_penalty, continuous, random_drop, random_rotate, ball_mass, ball_friction, ball_elasticity, max_cycles)
+        self.dt = 1./20.
         self.n_pistons = n_pistons
         self.piston_head_height = 11
         self.piston_width = 40
@@ -408,10 +409,11 @@ class raw_env(AECEnv, EzPickle):
         else:
             self.move_piston(self.pistonList[self.agent_name_mapping[agent]], action - 1)
 
-        self.space.step(1 / 20.0)
+        self.space.step(self.dt)
         if self._agent_selector.is_last():
             ball_min_x = int(self.ball.position[0] - self.ball_radius)
-            if ball_min_x <= self.wall_width + 1:
+            ball_next_x = self.ball.position[0] - self.ball_radius + self.ball.velocity[0] * self.dt
+            if ball_next_x <= self.wall_width + 1:
                 self.done = True
             # ensures that the ball can't pass through the wall
             ball_min_x = max(self.wall_width, ball_min_x)

--- a/tutorials/manual_pistonball_policy.py
+++ b/tutorials/manual_pistonball_policy.py
@@ -12,9 +12,9 @@ def change_observation(obs):
     return obs
 
 
-DOWN = np.array([-1.])
-UP = np.array([1.])
-HOLD = np.array([0.])
+DOWN = np.array([-1.], dtype=np.float32)
+UP = np.array([1.], dtype=np.float32)
+HOLD = np.array([0.], dtype=np.float32)
 count = 0
 
 


### PR DESCRIPTION
Previous environment done check was done by checking the ball position in comparison with the left wall for every frame. This caused an aliasing issue where if at time t the ball didn't collide with the wall, at time t+0.5 the ball collides with the wall, and at time t+1 the ball is already away from the wall, the done was not triggered.

This PR fixes that issue by instead checking the position of the ball using a first order approximation using the ball velocity information. If next position is less than the wall position, done is triggered.