### PR TITLE
fixed action space initialization

### DIFF
--- a/pettingzoo/butterfly/pistonball/manual_control.py
+++ b/pettingzoo/butterfly/pistonball/manual_control.py
@@ -23,7 +23,7 @@ def manual_control(**kwargs):
     num_agents = len(env.agents)  # 20
     while not done:
         clock.tick(60)
-        action_list = np.array([1 for _ in range(num_agents)])
+        action_list = np.ones((num_agents,1))
         for event in pygame.event.get():
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_ESCAPE:


### PR DESCRIPTION
[Issue #499](https://github.com/Farama-Foundation/PettingZoo/issues/499)

Got it to run the pygame, wasn't able to play using W,A,S,D keys but also had a similar experience with `manual_control.py` in butterfly.prison.

pistonball warnings:
`[WARNING]: Received an action [1.] that was outside action space Box([-1.], [1.], (1,), float32). Environment is clipping to space`

prison warning:
`raise ValueError("when an agent is done, the only valid action is None")
ValueError: when an agent is done, the only valid action is None`