### PR TITLE
Fix simple_spread global reward

### DIFF
--- a/docs/mpe/simple_spread.md
+++ b/docs/mpe/simple_spread.md
@@ -10,7 +10,7 @@ observation-values: "(-inf,inf)"
 state-shape: "(54,)"
 state-values: "(-inf,inf)"
 average-total-reward: "-115.6"
-import: "from pettingzoo.mpe import simple_spread_v2"
+import: "from pettingzoo.mpe import simple_spread_v3"
 agent-labels: "agents= [agent_0, agent_1, agent_2]"
 ---
 
@@ -38,7 +38,7 @@ Agent action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_spread_v2.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False)
+simple_spread_v3.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False)
 ```
 
 

--- a/pettingzoo/mpe/scenarios/simple_spread.py
+++ b/pettingzoo/mpe/scenarios/simple_spread.py
@@ -78,8 +78,8 @@ class Scenario(BaseScenario):
 
     def global_reward(self, world):
         rew = 0
-        for l in world.landmarks:
-            dists = [np.sqrt(np.sum(np.square(a.state.p_pos - l.state.p_pos))) for a in world.agents]
+        for a in world.agents:
+            dists = [np.sqrt(np.sum(np.square(a.state.p_pos - l.state.p_pos))) for l in world.landmarks]
             rew -= min(dists)
         return rew
 

--- a/pettingzoo/mpe/simple_spread_v3.py
+++ b/pettingzoo/mpe/simple_spread_v3.py
@@ -10,7 +10,7 @@ class raw_env(SimpleEnv):
         scenario = Scenario()
         world = scenario.make_world(N)
         super().__init__(scenario, world, max_cycles, continuous_actions, local_ratio)
-        self.metadata['name'] = "simple_spread_v2"
+        self.metadata['name'] = "simple_spread_v3"
 
 
 env = make_env(raw_env)

--- a/test/all_modules.py
+++ b/test/all_modules.py
@@ -57,7 +57,7 @@ from pettingzoo.mpe import simple_crypto_v2
 from pettingzoo.mpe import simple_push_v2
 from pettingzoo.mpe import simple_reference_v2
 from pettingzoo.mpe import simple_speaker_listener_v3
-from pettingzoo.mpe import simple_spread_v2
+from pettingzoo.mpe import simple_spread_v3
 from pettingzoo.mpe import simple_tag_v2
 from pettingzoo.mpe import simple_world_comm_v2
 from pettingzoo.mpe import simple_v2
@@ -137,7 +137,7 @@ all_environments = {
     "mpe/simple_push_v2": simple_push_v2,
     "mpe/simple_reference_v2": simple_reference_v2,
     "mpe/simple_speaker_listener_v3": simple_speaker_listener_v3,
-    "mpe/simple_spread_v2": simple_spread_v2,
+    "mpe/simple_spread_v3": simple_spread_v3,
     "mpe/simple_tag_v2": simple_tag_v2,
     "mpe/simple_world_comm_v2": simple_world_comm_v2,
     "mpe/simple_v2": simple_v2,

--- a/test/all_parameter_combs.py
+++ b/test/all_parameter_combs.py
@@ -102,7 +102,7 @@ parameterized_envs = [
 
     (simple_adversary_v2, dict(N=4)),
     (simple_reference_v2, dict(local_ratio=0.2)),
-    (simple_spread_v2, dict(N=5)),
+    (simple_spread_v3, dict(N=5)),
     (simple_tag_v2, dict(num_good=5, num_adversaries=10, num_obstacles=4)),
     (simple_tag_v2, dict(num_good=1, num_adversaries=1, num_obstacles=1)),
     (simple_world_comm_v2, dict(num_good=5, num_adversaries=10, num_obstacles=4, num_food=3)),
@@ -110,7 +110,7 @@ parameterized_envs = [
 
     (simple_adversary_v2, dict(N=4, continuous_actions=True)),
     (simple_reference_v2, dict(local_ratio=0.2, continuous_actions=True)),
-    (simple_spread_v2, dict(N=5, continuous_actions=True)),
+    (simple_spread_v3, dict(N=5, continuous_actions=True)),
     (simple_tag_v2, dict(num_good=5, num_adversaries=10, num_obstacles=4, continuous_actions=True)),
     (simple_tag_v2, dict(num_good=1, num_adversaries=1, num_obstacles=1, continuous_actions=True)),
     (simple_world_comm_v2, dict(num_good=5, num_adversaries=10, num_obstacles=4, num_food=3, continuous_actions=True)),


### PR DESCRIPTION
Loop through agents to match with closest landmark instead of landmarks to match with closest agent. Noticed that some agents run away, while some cluster around the centroid of the landmarks with no incentive for the escaped agents to return back.

Rationale: If we loop through landmarks in a 3 agent env, and 2 agents escape while 1 sits in the centroid of the landmarks, there is no change in global reward, no matter how far the other two agents escape, thus previous function provided irrelevant reward signal.