### PR TITLE
Add human enabled control

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -194,6 +194,43 @@ from pettingzoo.utils import random_demo
 random_demo(env, render=True, episodes=1)
 ```
 
+### Playing Alongside Trained Policies
+
+Sometimes, you may want to control a singular agent and let the other agents be controlled by trained policies.
+Some games support this via:
+
+``` python
+import time
+from pettingzoo.butterfly import knights_archers_zombies_v8
+
+env = knights_archers_zombies_v8.env()
+env.reset()
+
+manual_policy = knights_archers_zombies_v8.ManualPolicy(env)
+
+for agent in env.agent_iter():
+    observation, reward, done, info = env.last()
+
+    if agent == manual_policy.agent:
+        action = manual_policy(observation, agent)
+    else:
+        action = policy(observation, agent)
+
+    env.step(action)
+
+    env.render()
+    time.sleep(0.05)
+
+    if done:
+        env.reset()
+```
+
+`ManualPolicy` accepts several default arguments:
+
+`agent_id`: Accepts an integer for the agent in the environment that will be controlled via the keyboard. Use `manual_policy.availabla_agents` to query what agents are available and what are their indices.
+
+`show_obs`: Is a boolean which shows the observation from the currently selected agent, if available.
+
 ### Observation Saving
 
 If the agents in a game make observations that are images then the observations can be saved to an image file. This function takes in the environment, along with a specified agent. If no `agent` is specified, then the current selected agent for the environment is chosen. If `all_agents` is passed in as `True`, then the observations of all agents in the environment is saved. By default, the images are saved to the current working directory in a folder matching the environment name. The saved image will match the name of the observing agent. If `save_dir` is passed in, a new folder is created where images will be saved to. This function can be called during training/evaluation if desired, which is why environments have to be reset before it can be used.

--- a/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
@@ -12,6 +12,7 @@ from pettingzoo.utils import agent_selector, wrappers
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 from .manual_control import manual_control
+from .manual_policy import ManualPolicy
 from .src import constants as const
 from .src.img import get_image
 from .src.players import Archer, Knight

--- a/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
@@ -15,11 +15,11 @@ class ManualPolicy:
         if True:
             self.default_action = 5
             self.action_mapping = dict()
-            self.action_mapping[pygame.K_w] = 0 # front
-            self.action_mapping[pygame.K_s] = 1 # back
-            self.action_mapping[pygame.K_q] = 2 # rotate left
-            self.action_mapping[pygame.K_e] = 3 # rotate right
-            self.action_mapping[pygame.K_f] = 4 # weapon
+            self.action_mapping[pygame.K_w] = 0  # front
+            self.action_mapping[pygame.K_s] = 1  # back
+            self.action_mapping[pygame.K_q] = 2  # rotate left
+            self.action_mapping[pygame.K_e] = 3  # rotate right
+            self.action_mapping[pygame.K_f] = 4  # weapon
 
     def __call__(self, observation, agent):
         # only trigger when we are the correct agent

--- a/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
@@ -17,9 +17,9 @@ class ManualPolicy:
             self.action_mapping = dict()
             self.action_mapping[pygame.K_w] = 0  # front
             self.action_mapping[pygame.K_s] = 1  # back
-            self.action_mapping[pygame.K_q] = 2  # rotate left
-            self.action_mapping[pygame.K_e] = 3  # rotate right
-            self.action_mapping[pygame.K_f] = 4  # weapon
+            self.action_mapping[pygame.K_a] = 2  # rotate left
+            self.action_mapping[pygame.K_d] = 3  # rotate right
+            self.action_mapping[pygame.K_SPACE] = 4  # weapon
 
     def __call__(self, observation, agent):
         # only trigger when we are the correct agent

--- a/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
@@ -2,7 +2,7 @@ import pygame
 
 
 class ManualPolicy:
-    def __init__(self, env, agent_id=0, show_obs=False):
+    def __init__(self, env, agent_id: int = 0, show_obs: bool = False):
 
         self.env = env
         self.agent_id = agent_id
@@ -46,7 +46,7 @@ class ManualPolicy:
 
     @property
     def available_agents(self):
-        return self.env.agents
+        return self.env.agent_name_mapping
 
 
 if __name__ == "__main__":

--- a/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
@@ -7,9 +7,9 @@ class ManualPolicy:
         self.env = env
         self.agent_id = agent_id
         self.agent = self.env.agents[self.agent_id]
-        self.show_obs = show_obs
 
-        self.action_space = env.action_space(env.agents[agent_id])
+        # TO-DO: show current agent observation if this is True
+        self.show_obs = show_obs
 
         # action mappings for all agents are the same
         if True:

--- a/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
@@ -1,0 +1,54 @@
+import os
+import time
+
+import pygame
+
+from typing import Callable, Any
+
+class ManualPolicy():
+    def __init__(self, env, agent_id=0, show_obs=False):
+
+        self.env = env
+        self.agent_id = agent_id
+        self.agent = self.env.agents[self.agent_id]
+        self.show_obs = show_obs
+
+        self.clock = pygame.time.Clock()
+        self.clock.tick(env.metadata['video.frames_per_second'])
+
+        self.action_space = env.action_space(env.agents[agent_id])
+
+        # action mappings for all agents are the same
+        if True:
+            self.default_action = 5
+            self.action_mapping = dict()
+            self.action_mapping[pygame.K_w] = 0
+            self.action_mapping[pygame.K_s] = 1
+            self.action_mapping[pygame.K_a] = 2
+            self.action_mapping[pygame.K_d] = 3
+            self.action_mapping[pygame.K_SPACE] = 4
+
+    def forward(self, observation, agent):
+        # only triger when we are the correct agent
+        assert agent == self.agent, f'Manual Policy only applied to agent: {self.agent}, but got tag for {agent}.'
+
+        # set the default action
+        action = self.default_action
+
+        # if we get a key, override action using the dict
+        for event in pygame.event.get():
+            if event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_ESCAPE:
+                    # escape to end
+                    exit()
+                if event.key == pygame.K_BACKSPACE:
+                    # backspace to reset
+                    self.env.reset()
+
+                action = self.action_mapping[event.key]
+
+        return action
+
+    @property
+    def available_agents(self):
+        return self.env.agents

--- a/pettingzoo/butterfly/knights_archers_zombies_v8.py
+++ b/pettingzoo/butterfly/knights_archers_zombies_v8.py
@@ -1,2 +1,2 @@
-from .knights_archers_zombies.knights_archers_zombies import (env, manual_control, parallel_env,
-                                                              raw_env)
+from .knights_archers_zombies.knights_archers_zombies import (env, manual_control, ManualPolicy,
+                                                              parallel_env, raw_env)

--- a/pettingzoo/butterfly/knights_archers_zombies_v8.py
+++ b/pettingzoo/butterfly/knights_archers_zombies_v8.py
@@ -1,2 +1,2 @@
-from .knights_archers_zombies.knights_archers_zombies import (env, manual_control, ManualPolicy,
+from .knights_archers_zombies.knights_archers_zombies import (ManualPolicy, env, manual_control,
                                                               parallel_env, raw_env)


### PR DESCRIPTION
This PR is a response to and closes #547.

As a preliminary, it has been only added to KAZ. Once the format is satisfactory and scalable, I will add it to the other environments too.

## How do thing
Simply run `python3 pettingzoo/butterfly/knights_archers_zombies/manual_policy.py` to get a demo.

## Known Bugs
- At the moment, there is a bug in the agent movements that is fixed in [this line of code](https://github.com/Farama-Foundation/PettingZoo/pull/618/files#diff-6e39d112e7fbf8e3dca08424ae78348c4c9916ef57c1ce0d2f45271b15393890R58).
- ~~Issue from #636 preventing CI from passing~~