### PR TITLE
Make CI depend on Supersuit from repo, not PyPI

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -4,6 +4,7 @@ on:
     - cron: "*/5 * * * *"
 jobs:
   automatic-approve:
+    if: github.repository == 'Farama-Foundation/PettingZoo'
     name: Automatic Approve
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,13 +1,15 @@
-name: Automatic approve
-on: pull_request_target
-
+name: Automatic Approve
+on:
+  schedule:
+    - cron: "*/5 * * * *"
 jobs:
-  build:
-    if: github.repository == 'FaramaFoundation/Pettingzoo'
+  automatic-approve:
+    name: Automatic Approve
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
-    - uses: hmarr/auto-approve-action@v2
-      with:
-        github-token: ${{ secrets.PAT }}
+      - name: Automatic Approve
+        uses: mheap/automatic-approve-action@v1
+        with:
+          token: ${{ secrets.PAT }}
+          workflows: "linux-test.yml,macos-test.yml"
+          dangerous_files: ""

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Automatic Approve
-        uses: mheap/automatic-approve-action@v2
+        uses: mheap/automatic-approve-action@v1
         with:
           token: ${{ secrets.PAT }}
           workflows: "linux-test.yml,macos-test.yml"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Automatic Approve
-        uses: mheap/automatic-approve-action@v1
+        uses: mheap/automatic-approve-action@v2
         with:
           token: ${{ secrets.PAT }}
           workflows: "linux-test.yml,macos-test.yml"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,16 +1,12 @@
-name: Automatic Approve
-on:
-  schedule:
-    - cron: "*/5 * * * *"
+name: Automatic approve
+on: pull_request_target
+
 jobs:
-  automatic-approve:
-    if: github.repository == 'Farama-Foundation/PettingZoo'
-    name: Automatic Approve
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - name: Automatic Approve
-        uses: mheap/automatic-approve-action@v1
-        with:
-          token: ${{ secrets.PAT }}
-          workflows: "linux-test.yml,macos-test.yml"
-          dangerous_files: ""
+    - uses: hmarr/auto-approve-action@v2
+      with:
+        github-token: ${{ secrets.PAT }}

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -3,6 +3,7 @@ on: pull_request_target
 
 jobs:
   build:
+    if: github.repository == 'FaramaFoundation/Pettingzoo'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -38,7 +38,9 @@ jobs:
       run: |
         if [[ $(python -c 'import sys; print(sys.version_info[1])') -lt 10 ]]
         then
-            pip install stable_baselines3 supersuit==3.4.0
+            pip install stable_baselines3
+            git clone https://github.com/Farama-Foundation/SuperSuit.git
+            pip install -e ./SuperSuit
             sed s/total_timesteps=2000000/total_timesteps=2000/g tutorials/13_lines.py | sed s/n_steps=256/n_steps=16/g | xvfb-run -s "-screen 0 1024x768x24" python -
         fi
     - name: Check code with pyright


### PR DESCRIPTION
# Description

This just makes CI depend on Supersuit from the dev repo, not PyPI.
The idea is that when some changes have both repos depend on each other, we no longer need to use releases to check if things actually work.