### PR TITLE
bump supersuit resize wrapper version

### DIFF
--- a/docs/atari.md
+++ b/docs/atari.md
@@ -46,7 +46,7 @@ env = supersuit.sticky_actions_v0(env, repeat_action_probability=0.25)
 env = supersuit.frame_skip_v0(env, 4)
 
 # downscale observation for faster processing
-env = supersuit.resize_v0(env, 84, 84)
+env = supersuit.resize_v1(env, 84, 84)
 
 # allow agent to see everything on the screen despite Atari's flickering screen problem
 env = supersuit.frame_stack_v1(env, 4)

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -51,7 +51,7 @@ Supersuit includes the following wrappers:
 
 `reshape_v0(env, shape)` reshapes observations into given shape.
 
-`resize_v0(env, x_size, y_size, linear_interp=False)` Performs interpolation to up-size or down-size observation image using area interpolation by default. Linear interpolation is also available by setting `linear_interp=True` (it's faster and better for up-sizing). This wrapper is only available for 2D or 3D observations, and only makes sense if the observation is an image.
+`resize_v1(env, x_size, y_size, linear_interp=False)` Performs interpolation to up-size or down-size observation image using area interpolation by default. Linear interpolation is also available by setting `linear_interp=True` (it's faster and better for up-sizing). This wrapper is only available for 2D or 3D observations, and only makes sense if the observation is an image.
 
 `nan_noop_v0(env)` If an action is a NaN value for a step, the following wrapper will trigger a warning and perform a no operation action in its place. The noop action is accepted as an argument in the `step(action, no_op_action)` function.
 
@@ -113,7 +113,7 @@ from pettingzoo.butterfly import pistonball_v6
 import supersuit as ss
 env = pistonball_v6.parallel_env()
 env = ss.color_reduction_v0(env, mode='B')
-env = ss.resize_v0(env, x_size=84, y_size=84)
+env = ss.resize_v1(env, x_size=84, y_size=84)
 env = ss.frame_stack_v1(env, 3)
 env = ss.pettingzoo_env_to_vec_env_v0(env)
 env = ss.concat_vec_envs_v0(env, 8, num_cpus=4, base_class='stable_baselines3')

--- a/tutorials/render_rllib_pistonball.py
+++ b/tutorials/render_rllib_pistonball.py
@@ -46,7 +46,7 @@ def env_creator():
     )
     env = ss.color_reduction_v0(env, mode="B")
     env = ss.dtype_v0(env, "float32")
-    env = ss.resize_v0(env, x_size=84, y_size=84)
+    env = ss.resize_v1(env, x_size=84, y_size=84)
     env = ss.normalize_obs_v0(env, env_min=0, env_max=1)
     env = ss.frame_stack_v1(env, 3)
     return env

--- a/tutorials/rllib_pistonball.py
+++ b/tutorials/rllib_pistonball.py
@@ -50,7 +50,7 @@ def env_creator(args):
     )
     env = ss.color_reduction_v0(env, mode="B")
     env = ss.dtype_v0(env, "float32")
-    env = ss.resize_v0(env, x_size=84, y_size=84)
+    env = ss.resize_v1(env, x_size=84, y_size=84)
     env = ss.frame_stack_v1(env, 3)
     env = ss.normalize_obs_v0(env, env_min=0, env_max=1)
     return env


### PR DESCRIPTION
# Description

Bumping the supersuit resize wrapper version to v1, as v0 is deprecated. Fixes #709 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `./release_test.sh` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `./release_test.sh` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
