### PR TITLE
chess history trailing issue

### DIFF
--- a/pettingzoo/classic/chess/chess_env.py
+++ b/pettingzoo/classic/chess/chess_env.py
@@ -137,7 +137,9 @@ class raw_env(AECEnv):
         self.board_history = np.dstack(
             (next_board[:, :, 7:], self.board_history[:, :, :-13])
         )
-        self.agent_selection = self._agent_selector.next() # Give turn to the next agent
+        self.agent_selection = (
+            self._agent_selector.next()
+        )  # Give turn to the next agent
 
     def render(self, mode="human"):
         print(self.board)

--- a/pettingzoo/classic/chess/chess_env.py
+++ b/pettingzoo/classic/chess/chess_env.py
@@ -110,11 +110,6 @@ class raw_env(AECEnv):
             return self._was_done_step(action)
         current_agent = self.agent_selection
         current_index = self.agents.index(current_agent)
-        next_board = chess_utils.get_observation(self.board, current_agent)
-        self.board_history = np.dstack(
-            (next_board[:, :, 7:], self.board_history[:, :, :-13])
-        )
-        self.agent_selection = self._agent_selector.next()
 
         chosen_move = chess_utils.action_to_move(self.board, action, current_index)
         assert chosen_move in self.board.legal_moves
@@ -136,6 +131,13 @@ class raw_env(AECEnv):
             self.set_game_result(result_val)
 
         self._accumulate_rewards()
+
+        # Update board after applying action
+        next_board = chess_utils.get_observation(self.board, current_agent)
+        self.board_history = np.dstack(
+            (next_board[:, :, 7:], self.board_history[:, :, :-13])
+        )
+        self.agent_selection = self._agent_selector.next() # Give turn to the next agent
 
     def render(self, mode="human"):
         print(self.board)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #644

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
original code: self.board_history is updated before applying the action
modified code: update self.board_history after applying the action

you can check it through below simple snippet code
```
from` pettingzoo.classic import chess_v5

env = chess_v5.env()
env.reset()
env.step(77)
pawn1 = env.observe("player_1")["observation"][:,:,7] # check the black pawn is moved
pawn2 = env.observe("player_1")["observation"][:,:,13] # check the white pawn is not moved
print(env.render("ansi")) # check the black pawn is moved
env.step(77) 
pawn1 = env.observe("player_1")["observation"][:,:,7] # check the black pawn is moved
pawn2 = env.observe("player_1")["observation"][:,:,13] # check the white pawn is moved
pawn1_last = env.observe("player_1")["observation"][:,:,20] # check the black pawn is moved
pawn2_last = env.observe("player_1")["observation"][:,:,26] # check the white pawn is not moved
print(env.render("ansi")) # check the white pawn is moved
```