### PR TITLE
Move Pyright to `pre-commit` + add `pydocstyle`

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -34,10 +34,3 @@ jobs:
       - name: Release Test
         run: |
           xvfb-run -s "-screen 0 1024x768x24" pytest -v --cov=pettingzoo --cov-report term
-      - name: Check code with pyright
-        uses: jakebailey/pyright-action@v1
-        with:
-          version: 1.1.244
-          python-platform: ${{ matrix.python-platform }}
-          python-version: ${{ matrix.python-version }}
-        continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,16 +38,19 @@ repos:
     hooks:
       - id: mixed-line-ending
         args: ["--fix=lf"]
-  # - repo: https://github.com/pycqa/pydocstyle
-  #   rev: 6.1.1
-  #   hooks:
-  #     - id: pydocstyle
-  #       args:
-  #         - --source
-  #         - --explain
-  #         - --convention=google
-  #         - --count
-  #       additional_dependencies: ["toml"]
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.1.1
+    hooks:
+      - id: pydocstyle
+        args:
+          - --source
+          - --explain
+          - --convention=google
+          - --count
+          # TODO: Remove ignoring rules D101, D102, D103, D105
+          - --add-ignore=D100,D107,D101,D102,D103,D105
+        exclude: "__init__.py$|^pettingzoo.test|^docs"
+        additional_dependencies: ["toml"]
   - repo: local
     hooks:
       - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/python/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
   - repo: https://github.com/codespell-project/codespell
@@ -28,13 +28,32 @@ repos:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
         # TODO: remove `--keep-runtime-typing` option
         args: ["--py37-plus", "--keep-runtime-typing"]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0  # Use the ref you want to point at
+    rev: v4.3.0
     hooks:
       - id: mixed-line-ending
         args: ["--fix=lf"]
+  # - repo: https://github.com/pycqa/pydocstyle
+  #   rev: 6.1.1
+  #   hooks:
+  #     - id: pydocstyle
+  #       args:
+  #         - --source
+  #         - --explain
+  #         - --convention=google
+  #         - --count
+  #       additional_dependencies: ["toml"]
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: pyright
+        language: node
+        pass_filenames: false
+        types: [python]
+        additional_dependencies: ["pyright"]

--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -41,8 +41,11 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
         max_cycles=100000,
         auto_rom_install_path=None,
     ):
-        """Frameskip should be either a tuple (indicating a random range to
-        choose from, with the top value exclude), or an int."""
+        """Initializes the `ParallelAtariEnv` class.
+
+        Frameskip should be either a tuple (indicating a random range to
+        choose from, with the top value exclude), or an int.
+        """
         EzPickle.__init__(
             self,
             game,
@@ -264,9 +267,12 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
             self._screen = None
 
     def clone_state(self):
-        """Clone emulator state w/o system state. Restoring this state will
-        *not* give an identical environment. For complete cloning and restoring
-        of the full state, see `{clone,restore}_full_state()`."""
+        """Clone emulator state w/o system state.
+
+        Restoring this state will *not* give an identical environment.
+        For complete cloning and restoring of the full state,
+        see `{clone,restore}_full_state()`.
+        """
         state_ref = self.ale.cloneState()
         state = self.ale.encodeState(state_ref)
         self.ale.deleteState(state_ref)
@@ -280,7 +286,9 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
 
     def clone_full_state(self):
         """Clone emulator state w/ system state including pseudorandomness.
-        Restoring this state will give an identical environment."""
+
+        Restoring this state will give an identical environment.
+        """
         state_ref = self.ale.cloneSystemState()
         state = self.ale.encodeState(state_ref)
         self.ale.deleteState(state_ref)

--- a/pettingzoo/butterfly/cooperative_pong/cake_paddle.py
+++ b/pettingzoo/butterfly/cooperative_pong/cake_paddle.py
@@ -71,20 +71,18 @@ class CakePaddle(pygame.sprite.Sprite):
         return True, b_rect, b_speed
 
     def process_collision(self, b_rect, b_speed, paddle_type):
-        """
+        """Returns if ball collides with paddle.
 
-        Parameters
-        ----------
-        b_rect : Ball rect
-        dx, dy : Ball speed along single axis
-        b_speed : Ball speed
-        ignore paddle type
+        Args:
+            b_rect : Ball rect
+            dx, dy : Ball speed along single axis
+            b_speed : Ball speed
+            ignore paddle type
 
-        Returns
-        -------
-        is_collision: 1 if ball collides with paddle
-        b_rect: new ball rect
-        b_speed: new ball speed
+        Returns:
+            is_collision: 1 if ball collides with paddle
+            b_rect: new ball rect
+            b_speed: new ball speed
 
         """
         if self.rect4.colliderect(b_rect):

--- a/pettingzoo/butterfly/cooperative_pong/cooperative_pong.py
+++ b/pettingzoo/butterfly/cooperative_pong/cooperative_pong.py
@@ -202,9 +202,7 @@ class CooperativePong:
         return observation
 
     def state(self):
-        """
-        Returns an observation of the global environment
-        """
+        """Returns an observation of the global environment."""
         state = pygame.surfarray.pixels3d(self.screen).copy()
         state = np.rot90(state, k=3)
         state = np.fliplr(state)

--- a/pettingzoo/butterfly/cooperative_pong/paddle.py
+++ b/pettingzoo/butterfly/cooperative_pong/paddle.py
@@ -28,19 +28,17 @@ class Paddle(pygame.sprite.Sprite):
                 self.rect = newpos
 
     def process_collision(self, b_rect, b_speed, paddle_type):
-        """
+        """Process a collision.
 
-        Parameters
-        ----------
-        b_rect : Ball rect
-        dx, dy : Ball speed along single axis
-        b_speed : Ball speed
+        Args:
+            b_rect : Ball rect
+            dx, dy : Ball speed along single axis
+            b_speed : Ball speed
 
-        Returns
-        -------
-        is_collision: 1 if ball collides with paddle
-        b_rect: new ball rect
-        b_speed: new ball speed
+        Returns:
+            is_collision: 1 if ball collides with paddle
+            b_rect: new ball rect
+            b_speed: new ball speed
 
         """
         if not self.rect.colliderect(b_rect):

--- a/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
@@ -389,9 +389,7 @@ class raw_env(AECEnv, EzPickle):
             return state
 
     def state(self):
-        """
-        Returns an observation of the global environment
-        """
+        """Returns an observation of the global environment."""
         if not self.vector_state:
             state = pygame.surfarray.pixels3d(self.WINDOW).copy()
             state = np.rot90(state, k=3)

--- a/pettingzoo/butterfly/pistonball/pistonball.py
+++ b/pettingzoo/butterfly/pistonball/pistonball.py
@@ -214,9 +214,7 @@ class raw_env(AECEnv, EzPickle):
         return observation
 
     def state(self):
-        """
-        Returns an observation of the global environment
-        """
+        """Returns an observation of the global environment."""
         state = pygame.surfarray.pixels3d(self.screen).copy()
         state = np.rot90(state, k=3)
         state = np.fliplr(state)

--- a/pettingzoo/classic/chess/chess_utils.py
+++ b/pettingzoo/classic/chess/chess_utils.py
@@ -165,7 +165,8 @@ def make_move_mapping(uci_move):
 
 
 def legal_moves(orig_board):
-    """
+    """Returns legal moves.
+
     action space is a 8x8x73 dimensional array
     Each of the 8×8
     positions identifies the square from which to “pick up” a piece. The first 56 planes encode
@@ -194,8 +195,9 @@ def legal_moves(orig_board):
 
 
 def get_observation(orig_board, player):
-    """
-    Observation is an 8x8x(P + L) dimensional array
+    """Returns observation array.
+
+    Observation is an 8x8x(P + L) dimensional array.
     P is going to be your pieces positions + your opponents pieces positions
     L is going to be some metadata such as repetition count,,
     """

--- a/pettingzoo/classic/go/go_base.py
+++ b/pettingzoo/classic/go/go_base.py
@@ -14,7 +14,8 @@
 
 # Code from: https://github.com/tensorflow/minigo
 
-"""
+"""Minimalist Go engine.
+
 A board is a NxN numpy array.
 A Coordinate is a tuple index into the board.
 A Move is a (Coordinate c | None).
@@ -85,8 +86,8 @@ def place_stones(board, color, stones):
 
 
 def replay_position(position, result):
-    """
-    Wrapper for a go.Position which replays its history.
+    """Wrapper for a go.Position which replays its history.
+
     Assumes an empty start position! (i.e. no handicap, and history must be exhaustive.)
 
     Result must be passed in, since a resign cannot be inferred from position
@@ -120,7 +121,7 @@ def find_reached(board, c):
 
 
 def is_koish(board, c):
-    "Check if c is surrounded on all sides by 1 color, and return that color"
+    """Check if c is surrounded on all sides by 1 color, and return that color."""
     if board[c] != EMPTY:
         return None
     neighbors = {board[n] for n in NEIGHBORS[c]}
@@ -131,7 +132,7 @@ def is_koish(board, c):
 
 
 def is_eyeish(board, c):
-    "Check if c is an eye, for the purpose of restricting MC rollouts."
+    """Check if c is an eye, for the purpose of restricting MC rollouts."""
     # pass is fine.
     if c is None:
         return
@@ -152,7 +153,8 @@ def is_eyeish(board, c):
 
 
 class Group(namedtuple("Group", ["id", "stones", "liberties", "color"])):
-    """
+    """Defines a Group.
+
     stones: a frozenset of Coordinates belonging to this group
     liberties: a frozenset of Coordinates that are empty and adjacent to this group.
     color: color of this group
@@ -325,7 +327,8 @@ class Position:
         board_deltas=None,
         to_play=BLACK,
     ):
-        """
+        """Initializes the `Position` class.
+
         board: a numpy array
         n: an int representing moves played so far
         komi: a float, representing points given to the second player.
@@ -435,7 +438,7 @@ class Position:
         return not potential_libs
 
     def is_move_legal(self, move):
-        "Checks that a move is on an empty space, not on ko, and not suicide"
+        """Checks that a move is on an empty space, not on ko, and not suicide."""
         if move is None:
             return True
         if self.board[move] != EMPTY:
@@ -448,7 +451,7 @@ class Position:
         return True
 
     def all_legal_moves(self):
-        "Returns a np.array of size go.N**2 + 1, with 1 = legal, 0 = illegal"
+        """Returns a np.array of size go.N**2 + 1, with 1 = legal, 0 = illegal."""
         # by default, every move is legal
         legal_moves = np.ones([N, N], dtype=np.int8)
         # ...unless there is already a stone there
@@ -566,7 +569,7 @@ class Position:
         )
 
     def score(self):
-        "Return score from B perspective. If W is winning, score is negative."
+        """Return score from B perspective. If W is winning, score is negative."""
         working_board = np.copy(self.board)
         while EMPTY in working_board:
             unassigned_spaces = np.where(working_board == EMPTY)

--- a/pettingzoo/classic/hanabi/hanabi.py
+++ b/pettingzoo/classic/hanabi/hanabi.py
@@ -76,7 +76,8 @@ class raw_env(AECEnv, EzPickle):
         observation_type: int = 1,
         random_start_player: bool = False,
     ):
-        """
+        """Initializes the `raw_env` class.
+
         Parameter descriptions :
               - colors: int, Number of colors in [2,5].
               - ranks: int, Number of ranks in [2,5].
@@ -266,13 +267,12 @@ class raw_env(AECEnv, EzPickle):
 
     # ToDo: Fix Return value
     def reset(self, seed=None, return_info=False, options=None):
-        """Resets the environment for a new game and returns observations of current player as List of ints
+        """Resets the environment for a new game and returns observations of current player as List of ints.
 
         Returns:
             observation: Optional list of integers of length self.observation_vector_dim, describing observations of
             current agent (agent_selection).
         """
-
         if seed is not None:
             self.seed(seed=seed)
 
@@ -290,7 +290,6 @@ class raw_env(AECEnv, EzPickle):
 
     def _reset_agents(self, player_number: int):
         """Rearrange self.agents as pyhanabi starts a different player after each reset()."""
-
         # Shifts self.agents list as long order starting player is not according to player_number
         while not self.agents[0] == "player_" + str(player_number):
             self.agents = self.agents[1:] + [self.agents[0]]
@@ -358,8 +357,7 @@ class raw_env(AECEnv, EzPickle):
     def _process_latest_observations(
         self, obs: Dict, reward: Optional[float] = 0, done: Optional[bool] = False
     ):
-        """Updates internal state"""
-
+        """Updates internal state."""
         self.latest_observations = obs
         self.rewards = {a: reward for a in self.agents}
         self.dones = {player_name: done for player_name in self.agents}
@@ -380,9 +378,9 @@ class raw_env(AECEnv, EzPickle):
         }
 
     def render(self, mode="human"):
-        """Supports console print only. Prints player's data.
+        """Prints player's data.
 
-        Example:
+        Supports console print only.
         """
         player_data = self.latest_observations["player_observations"]
         print(

--- a/pettingzoo/classic/rps/rps.py
+++ b/pettingzoo/classic/rps/rps.py
@@ -41,8 +41,10 @@ parallel_env = parallel_wrapper_fn(env)
 
 class raw_env(AECEnv):
     """Two-player environment for rock paper scissors.
+
     Expandable environment to rock paper scissors lizard spock action_6 action_7 ...
-    The observation is simply the last opponent action."""
+    The observation is simply the last opponent action.
+    """
 
     metadata = {
         "render_modes": ["human", "rgb_array"],

--- a/pettingzoo/magent/magent_env.py
+++ b/pettingzoo/magent/magent_env.py
@@ -211,9 +211,7 @@ class magent_parallel_env(ParallelEnv):
         }
 
     def state(self):
-        """
-        Returns an observation of the global environment
-        """
+        """Returns an observation of the global environment."""
         state = np.copy(self.base_state)
 
         for handle in self._all_handles:

--- a/pettingzoo/mpe/simple_crypto/simple_crypto.py
+++ b/pettingzoo/mpe/simple_crypto/simple_crypto.py
@@ -1,4 +1,5 @@
-"""
+"""Simple crypto environment.
+
 Scenario:
 1 speaker, 2 listeners (one of which is an adversary). Good agents rewarded for proximity to goal, and distance from
 adversary to goal. Adversary is rewarded for its distance to the goal.

--- a/pettingzoo/sisl/multiwalker/multiwalker_base.py
+++ b/pettingzoo/sisl/multiwalker/multiwalker_base.py
@@ -307,7 +307,8 @@ class MultiWalkerEnv:
         terrain_length=TERRAIN_LENGTH,
         max_cycles=500,
     ):
-        """
+        """Initializes the `MultiWalkerEnv` class.
+
         n_walkers: number of bipedal walkers in environment
         position_noise: noise applied to agent positional sensor observations
         angle_noise: noise applied to agent rotational sensor observations
@@ -319,7 +320,6 @@ class MultiWalkerEnv:
         terrain_length: length of terrain in number of steps
         max_cycles: after max_cycles steps all agents will return done
         """
-
         self.n_walkers = n_walkers
         self.position_noise = position_noise
         self.angle_noise = angle_noise

--- a/pettingzoo/sisl/pursuit/pursuit_base.py
+++ b/pettingzoo/sisl/pursuit/pursuit_base.py
@@ -31,8 +31,8 @@ class Pursuit:
         surround: bool = True,
         constraint_window: float = 1.0,
     ):
-        """
-        In evade pursuit a set of pursuers must 'tag' a set of evaders
+        """In evade pursuit a set of pursuers must 'tag' a set of evaders.
+
         Required arguments:
             x_size, y_size: World size
             shared_reward: whether the rewards should be shared between all agents
@@ -53,7 +53,6 @@ class Pursuit:
         surround: toggles surround condition for evader removal
         constraint_window: window in which agents can randomly spawn
         """
-
         self.x_size = x_size
         self.y_size = y_size
         self.map_matrix = two_d_maps.rectangle_map(self.x_size, self.y_size)
@@ -505,8 +504,9 @@ class Pursuit:
         return xlo, xhi + 1, ylo, yhi + 1, xolo, xohi + 1, yolo, yohi + 1
 
     def remove_agents(self):
-        """
-        Remove agents that are caught. Return tuple (n_evader_removed, n_pursuer_removed, purs_sur)
+        """Remove agents that are caught.
+
+        Return tuple (n_evader_removed, n_pursuer_removed, purs_sur)
         purs_sur: bool array, which pursuers surrounded an evader
         """
         n_pursuer_removed = 0
@@ -569,7 +569,8 @@ class Pursuit:
         return n_evader_removed, n_pursuer_removed, purs_sur
 
     def need_to_surround(self, x, y):
-        """
+        """Compute the number of surrounding grid cells.
+
         Compute the number of surrounding grid cells in x,y position that are open
         (no wall or obstacle)
         """

--- a/pettingzoo/sisl/pursuit/utils/agent_layer.py
+++ b/pettingzoo/sisl/pursuit/utils/agent_layer.py
@@ -7,7 +7,8 @@ import numpy as np
 
 class AgentLayer:
     def __init__(self, xs, ys, allies, seed=1):
-        """
+        """Initializes the AgentLayer class.
+
         xs: x size of map
         ys: y size of map
         allies: list of ally agents
@@ -19,7 +20,6 @@ class AgentLayer:
         - nactions()
         - set_position(x, y)
         """
-
         self.allies = allies
         self.nagents = len(allies)
         self.global_state = np.zeros((xs, ys), dtype=np.int32)
@@ -34,9 +34,7 @@ class AgentLayer:
         self.allies[agent_idx].set_position(x, y)
 
     def get_position(self, agent_idx):
-        """
-        Returns the position of the given agent
-        """
+        """Returns the position of the given agent."""
         return self.allies[agent_idx].current_position()
 
     def get_nactions(self, agent_idx):
@@ -48,8 +46,8 @@ class AgentLayer:
         self.nagents -= 1
 
     def get_state_matrix(self):
-        """
-        Returns a matrix representing the positions of all allies
+        """Returns a matrix representing the positions of all allies.
+
         Example: matrix contains the number of allies at give (x,y) position
         0 0 0 1 0 0 0
         0 2 0 2 0 0 0

--- a/pettingzoo/sisl/pursuit/utils/agent_utils.py
+++ b/pettingzoo/sisl/pursuit/utils/agent_utils.py
@@ -16,8 +16,8 @@ def create_agents(
     randinit=False,
     constraints=None,
 ):
-    """
-    Initializes the agents on a map (map_matrix)
+    """Initializes the agents on a map (map_matrix).
+
     -nagents: the number of agents to put on the map
     -randinit: if True will place agents in random, feasible locations
                if False will place all agents at 0
@@ -47,9 +47,7 @@ def create_agents(
 
 
 def feasible_position_exp(randomizer, map_matrix, expanded_mat, constraints=None):
-    """
-    Returns a feasible position on map (map_matrix)
-    """
+    """Returns a feasible position on map (map_matrix)."""
     xs, ys = map_matrix.shape
     while True:
         if constraints is None:

--- a/pettingzoo/sisl/pursuit/utils/two_d_maps.py
+++ b/pettingzoo/sisl/pursuit/utils/two_d_maps.py
@@ -3,12 +3,11 @@ from scipy.ndimage import zoom
 
 
 def rectangle_map(xs, ys, xb=0.3, yb=0.2):
-    """
-    Returns a 2D 'map' with a rectangle building centered in the middle
+    """Returns a 2D 'map' with a rectangle building centered in the middle.
+
     Map is a 2D numpy array
     xb and yb are buffers for each dim representing the raio of the map to leave open on each side
     """
-
     rmap = np.zeros((xs, ys), dtype=np.int32)
     for i in range(xs):
         for j in range(ys):
@@ -21,8 +20,8 @@ def rectangle_map(xs, ys, xb=0.3, yb=0.2):
 
 
 def complex_map(xs, ys):
-    """
-    Returns a 2D 'map' with a four different obstacles
+    """Returns a 2D 'map' with a four different obstacles.
+
     Map is a 2D numpy array
     """
     cmap = np.zeros((xs, ys), dtype=np.int32)
@@ -70,8 +69,8 @@ def multi_scale_map(
 
 
 def add_rectangle(input_map, xc, yc, xl, yl):
-    """
-    Add a rectangle to the input map
+    """Add a rectangle to the input map.
+
     centered a xc, yc with dimensions xl, yl.
     Input specs are normalized wrt the map.
     """

--- a/pettingzoo/sisl/waterworld/waterworld_base.py
+++ b/pettingzoo/sisl/waterworld/waterworld_base.py
@@ -81,7 +81,7 @@ class Archea(Agent):
         return self._sensors
 
     def sensed(self, object_coord, object_radius, same=False):
-        """Whether object would be sensed by the pursuers"""
+        """Whether object would be sensed by the pursuers."""
         relative_coord = object_coord - np.expand_dims(self.position, 0)
         # Projection of object coordinate in direction of sensor
         sensorvals = self.sensors.dot(relative_coord.T)
@@ -164,7 +164,8 @@ class MAWaterWorld:
         raise AssertionError(
             "Please do not use Waterworld, at its current state it is incredibly buggy and the soundness of the environment is not guaranteed."
         )
-        """
+        """Initializes the `MAWaterWorld` class.
+
         n_pursuers: number of pursuing archea (agents)
         n_evaders: number of evader archea
         n_poison: number of poison archea
@@ -337,7 +338,7 @@ class MAWaterWorld:
         return obs_list[0]
 
     def _caught(self, is_colliding_x_y, n_coop):
-        """Check whether collision results in catching the object
+        """Check whether collision results in catching the object.
 
         This is because you need `n_coop` agents to collide with the object to actually catch it
         """
@@ -354,7 +355,7 @@ class MAWaterWorld:
         return caught_y, x_caught_y
 
     def _closest_dist(self, closest_object_idx, input_sensorvals):
-        """Closest distances according to `idx`"""
+        """Closest distances according to `idx`."""
         sensorvals = []
 
         for pursuer_idx in range(self.n_pursuers):

--- a/pettingzoo/utils/agent_selector.py
+++ b/pettingzoo/utils/agent_selector.py
@@ -1,6 +1,7 @@
 class agent_selector:
-    """
-    Outputs an agent in the given order whenever agent_select is called. Can reinitialize to a new order
+    """Outputs an agent in the given order whenever agent_select is called.
+
+    Can reinitialize to a new order
     """
 
     def __init__(self, agent_order):
@@ -21,9 +22,7 @@ class agent_selector:
         return self.selected_agent
 
     def is_last(self):
-        """
-        Does not work as expected if you change the order
-        """
+        """Does not work as expected if you change the order."""
         return self.selected_agent == self.agent_order[-1]
 
     def is_first(self):

--- a/pettingzoo/utils/average_total_reward.py
+++ b/pettingzoo/utils/average_total_reward.py
@@ -14,6 +14,7 @@ def average_total_reward(env, max_episodes=100, max_steps=10000000000):
     total_reward = 0
     total_steps = 0
     done = False
+    num_episodes = 0
 
     for episode in range(max_episodes):
         if total_steps >= max_steps:

--- a/pettingzoo/utils/average_total_reward.py
+++ b/pettingzoo/utils/average_total_reward.py
@@ -4,11 +4,10 @@ import numpy as np
 
 
 def average_total_reward(env, max_episodes=100, max_steps=10000000000):
-    """
-    Runs an env object with random actions until either max_episodes or
-    max_steps is reached. Calculates the average total reward over the
-    episodes.
+    """Calculates the average total reward over the episodes.
 
+    Runs an env object with random actions until either max_episodes or
+    max_steps is reached.
     Reward is summed across all agents, making it unsuited for use in zero-sum
     games.
     """

--- a/pettingzoo/utils/capture_stdout.py
+++ b/pettingzoo/utils/capture_stdout.py
@@ -3,7 +3,8 @@ import sys
 
 
 class capture_stdout:
-    """
+    """Class allowing to capture stdout.
+
     usage:
 
     with capture_stdout() as var:

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -260,7 +260,8 @@ class parallel_to_aec_wrapper(AECEnv):
     def step(self, action):
         if self.dones[self.agent_selection]:
             del self._actions[self.agent_selection]
-            return self._was_done_step(action)  # type: ignore
+            assert action is None
+            return self._was_done_step(action)
         self._actions[self.agent_selection] = action  # type: ignore
         if self._agent_selector.is_last():
             obss, rews, dones, infos = self.env.step(self._actions)

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -257,12 +257,11 @@ class parallel_to_aec_wrapper(AECEnv):
         self.rewards[new_agent] = 0
         self._cumulative_rewards[new_agent] = 0
 
-    def step(self, action):
+    def step(self, action: None):
         if self.dones[self.agent_selection]:
             del self._actions[self.agent_selection]
-            assert action is None
             return self._was_done_step(action)
-        self._actions[self.agent_selection] = action  # type: ignore
+        self._actions[self.agent_selection] = action
         if self._agent_selector.is_last():
             obss, rews, dones, infos = self.env.step(self._actions)
 

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -1,10 +1,15 @@
 import copy
 import warnings
 from collections import defaultdict
+from typing import Dict, Optional
 
 from pettingzoo.utils import agent_selector
 from pettingzoo.utils.env import AECEnv, ParallelEnv
 from pettingzoo.utils.wrappers import OrderEnforcingWrapper
+
+ActionType = Optional[int]
+AgentID = str
+ActionDict = Dict[AgentID, ActionType]
 
 
 def parallel_wrapper_fn(env_fn):
@@ -231,7 +236,7 @@ class parallel_to_aec_wrapper(AECEnv):
         self._observations = self.env.reset(seed=seed, options=options)
         self.agents = self.env.agents[:]
         self._live_agents = self.agents[:]
-        self._actions = {agent: None for agent in self.agents}
+        self._actions: ActionDict = {agent: None for agent in self.agents}
         self._agent_selector = agent_selector(self._live_agents)
         self.agent_selection = self._agent_selector.reset()
         self.dones = {agent: False for agent in self.agents}
@@ -257,9 +262,12 @@ class parallel_to_aec_wrapper(AECEnv):
         self.rewards[new_agent] = 0
         self._cumulative_rewards[new_agent] = 0
 
-    def step(self, action: None):
+    def step(self, action: ActionType):
+        if action is not None:
+            action = int(action)
         if self.dones[self.agent_selection]:
             del self._actions[self.agent_selection]
+            assert action is None
             return self._was_done_step(action)
         self._actions[self.agent_selection] = action
         if self._agent_selector.is_last():

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -260,8 +260,8 @@ class parallel_to_aec_wrapper(AECEnv):
     def step(self, action):
         if self.dones[self.agent_selection]:
             del self._actions[self.agent_selection]
-            return self._was_done_step(action)
-        self._actions[self.agent_selection] = action
+            return self._was_done_step(action)  # type: ignore
+        self._actions[self.agent_selection] = action  # type: ignore
         if self._agent_selector.is_last():
             obss, rews, dones, infos = self.env.step(self._actions)
 

--- a/pettingzoo/utils/deprecated_module.py
+++ b/pettingzoo/utils/deprecated_module.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 import pkgutil
 import re
 
@@ -46,8 +46,10 @@ def deprecated_handler(env_name, module_path, module_name):
                         )
 
     # This constructs the module but doesn't execute its code
+    assert spec
     module = importlib.util.module_from_spec(spec)
     # This executes the module and will raise any exceptions
     # that would typically be raised by just `import blah`
+    assert spec.loader
     spec.loader.exec_module(module)
     return module

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -8,7 +8,7 @@ import numpy as np  # type: ignore
 
 ObsType = TypeVar("ObsType")
 ActionType = TypeVar("ActionType")
-AgentID = Optional[str]
+AgentID = str
 
 ObsDict = Dict[AgentID, ObsType]
 ActionDict = Dict[AgentID, ActionType]
@@ -235,6 +235,7 @@ class AECEnv:
                 self._skip_agent_selection = self.agent_selection
             self.agent_selection = _dones_order[0]
         else:
+            assert self._skip_agent_selection is not None
             if getattr(self, "_skip_agent_selection", None) is not None:
                 self.agent_selection = self._skip_agent_selection
             self._skip_agent_selection = None

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -8,7 +8,7 @@ import numpy as np
 
 ObsType = TypeVar("ObsType") | None
 ActionType = TypeVar("ActionType")
-AgentID = str | None
+AgentID = Optional[str]
 
 ObsDict = Dict[AgentID, ObsType]
 ActionDict = Dict[AgentID, ActionType]

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, TypeVar
 import gym
 import numpy as np
 
-ObsType = TypeVar("ObsType")
+ObsType = TypeVar("ObsType") | None
 ActionType = TypeVar("ActionType")
-AgentID = str
+AgentID = str | None
 
 ObsDict = Dict[AgentID, ObsType]
 ActionDict = Dict[AgentID, ActionType]
@@ -36,10 +36,10 @@ class AECEnv:
     agents: List[AgentID]  # Agents active at any given time
 
     observation_spaces: Dict[
-        AgentID, gym.spaces.Space
+        AgentID, gym.spaces.Space  # type: ignore
     ]  # Observation space for each agent
     # Action space for each agent
-    action_spaces: Dict[AgentID, gym.spaces.Space]
+    action_spaces: Dict[AgentID, gym.spaces.Space]  # type: ignore
 
     # Whether each agent has just reached a terminal state
     dones: Dict[AgentID, bool]
@@ -114,7 +114,7 @@ class AECEnv:
         """
         pass
 
-    def observation_space(self, agent: str) -> gym.Space:
+    def observation_space(self, agent: AgentID) -> gym.Space:
         """
         Takes in agent and returns the observation space for that agent.
 
@@ -185,6 +185,7 @@ class AECEnv:
         Returns observation, cumulative reward, done, info   for the current agent (specified by self.agent_selection)
         """
         agent = self.agent_selection
+        assert agent
         observation = self.observe(agent) if observe else None
         return (
             observation,
@@ -354,7 +355,7 @@ class ParallelEnv:
         warnings.warn(
             "Your environment should override the observation_space function. Attempting to use the observation_spaces dict attribute."
         )
-        return self.observation_spaces[agent]
+        return self.observation_spaces[agent]  # type: ignore
 
     def action_space(self, agent: AgentID) -> gym.Space:
         """
@@ -367,7 +368,7 @@ class ParallelEnv:
         warnings.warn(
             "Your environment should override the action_space function. Attempting to use the action_spaces dict attribute."
         )
-        return self.action_spaces[agent]
+        return self.action_spaces[agent]  # type: ignore
 
     @property
     def num_agents(self) -> int:

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import warnings
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, TypeVar
 
-import gym  # type: ignore
-import numpy as np  # type: ignore
+import gym
+import numpy as np
 
 ObsType = TypeVar("ObsType")
 ActionType = TypeVar("ActionType")

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -23,10 +23,10 @@ See docs/dev_docs.md for additional documentation and an example environment.
 
 
 class AECEnv:
-    """
-    The AECEnv steps agents one at a time. If you are unsure if you
-    have implemented a AECEnv correctly, try running the `api_test` documented in
-    the Developer documentation on the website.
+    """The AECEnv steps agents one at a time.
+
+    If you are unsure if you have implemented a AECEnv correctly, try running
+    the `api_test` documented in the Developer documentation on the website.
     """
 
     metadata: Dict[str, Any]  # Metadata for the environment
@@ -56,9 +56,9 @@ class AECEnv:
         pass
 
     def step(self, action: ActionType) -> None:
-        """
-        Accepts and executes the action of the current agent_selection
-        in the environment, automatically switches control to the next agent.
+        """Accepts and executes the action of the current agent_selection in the environment.
+
+        Automatically switches control to the next agent.
         """
         raise NotImplementedError
 
@@ -68,28 +68,25 @@ class AECEnv:
         return_info: bool = False,
         options: Optional[dict] = None,
     ) -> None:
-        """
-        Resets the environment to a starting state.
-        """
+        """Resets the environment to a starting state."""
         raise NotImplementedError
 
     def seed(self, seed: Optional[int] = None) -> None:
-        """
-        Reseeds the environment (making the resulting environment deterministic).
-        """
+        """Reseeds the environment (making the resulting environment deterministic)."""
         raise NotImplementedError(
             "Calling seed externally is deprecated; call reset(seed=seed) instead"
         )
 
     def observe(self, agent: str) -> Optional[ObsType]:
-        """
-        Returns the observation an agent currently can make. `last()` calls this function.
+        """Returns the observation an agent currently can make.
+
+        `last()` calls this function.
         """
         raise NotImplementedError
 
     def render(self, mode: str = "human") -> None | np.ndarray | str:
-        """
-        Displays a rendered frame from the environment, if supported.
+        """Displays a rendered frame from the environment, if supported.
+
         Alternate render modes in the default environments are `'rgb_array'`
         which returns a numpy array and is supported by all environments outside of classic,
         and `'ansi'` which returns the strings printed (specific to classic environments).
@@ -97,9 +94,9 @@ class AECEnv:
         raise NotImplementedError
 
     def state(self) -> np.ndarray:
-        """
-        State returns a global view of the environment appropriate for
-        centralized training decentralized execution methods like QMIX
+        """State returns a global view of the environment.
+
+        It is appropriate for centralized training decentralized execution methods like QMIX
         """
         raise NotImplementedError(
             "state() method has not been implemented in the environment {}.".format(
@@ -108,15 +105,15 @@ class AECEnv:
         )
 
     def close(self):
-        """
-        Closes the rendering window, subprocesses, network connections, or any other resources
-        that should be released.
+        """Closes any resources that should be released.
+
+        Closes the rendering window, subprocesses, network connections,
+        or any other resources that should be released.
         """
         pass
 
     def observation_space(self, agent: AgentID) -> gym.Space:
-        """
-        Takes in agent and returns the observation space for that agent.
+        """Takes in agent and returns the observation space for that agent.
 
         MUST return the same value for the same agent name
 
@@ -128,8 +125,7 @@ class AECEnv:
         return self.observation_spaces[agent]
 
     def action_space(self, agent: str) -> gym.Space:
-        """
-        Takes in agent and returns the action space for that agent.
+        """Takes in agent and returns the action space for that agent.
 
         MUST return the same value for the same agent name
 
@@ -149,9 +145,10 @@ class AECEnv:
         return len(self.possible_agents)
 
     def _dones_step_first(self) -> AgentID:
-        """
-        Makes .agent_selection point to first done agent. Stores old value of agent_selection
-        so that _was_done_step can restore the variable after the done agent steps.
+        """Makes .agent_selection point to first done agent.
+
+        Stores old value of agent_selection so that _was_done_step
+        can restore the variable after the done agent steps.
         """
         _dones_order = [agent for agent in self.agents if self.dones[agent]]
         if _dones_order:
@@ -160,31 +157,31 @@ class AECEnv:
         return self.agent_selection
 
     def _clear_rewards(self) -> None:
-        """
-        Clears all items in .rewards
-        """
+        """Clears all items in .rewards."""
         for agent in self.rewards:
             self.rewards[agent] = 0
 
     def _accumulate_rewards(self) -> None:
-        """
-        Adds .rewards dictionary to ._cumulative_rewards dictionary. Typically
-        called near the end of a step() method
+        """Adds .rewards dictionary to ._cumulative_rewards dictionary.
+
+        Typically called near the end of a step() method
         """
         for agent, reward in self.rewards.items():
             self._cumulative_rewards[agent] += reward
 
     def agent_iter(self, max_iter: int = 2**63) -> AECIterable:
-        """
-        Yields the current agent (self.agent_selection) when used in a loop where you step() each iteration.
+        """Yields the current agent (self.agent_selection).
+
+        Needs to be used in a loop where you step() each iteration.
         """
         return AECIterable(self, max_iter)
 
     def last(
         self, observe: bool = True
     ) -> Tuple[Optional[ObsType], float, bool, Dict[str, Any]]:
-        """
-        Returns observation, cumulative reward, done, info   for the current agent (specified by self.agent_selection)
+        """Returns observation, cumulative reward, done, info.
+
+        This is for the current agent (specified by self.agent_selection)
         """
         agent = self.agent_selection
         assert agent
@@ -197,8 +194,7 @@ class AECEnv:
         )
 
     def _was_done_step(self, action: None) -> None:
-        """
-        Helper function that performs step() for done agents.
+        """Helper function that performs step() for done agents.
 
         Does the following:
 
@@ -206,13 +202,14 @@ class AECEnv:
         2. Loads next agent into .agent_selection: if another agent is done, loads that one, otherwise load next live agent
         3. Clear the rewards dict
 
-        Highly recommended to use at the beginning of step as follows:
+        Examples:
+            Highly recommended to use at the beginning of step as follows:
 
-        def step(self, action):
-            if self.dones[self.agent_selection]:
-                self._was_done_step()
-                return
-            # main contents of step
+            def step(self, action):
+                if self.dones[self.agent_selection]:
+                    self._was_done_step()
+                    return
+                # main contents of step
         """
         if action is not None:
             raise ValueError("when an agent is done, the only valid action is None")
@@ -242,9 +239,7 @@ class AECEnv:
         self._clear_rewards()
 
     def __str__(self) -> str:
-        """
-        returns a name which looks like: "space_invaders_v1"
-        """
+        """Returns a name which looks like: `space_invaders_v1`."""
         if hasattr(self, "metadata"):
             return self.metadata.get("name", self.__class__.__name__)
         else:
@@ -280,8 +275,9 @@ class AECIterator(Iterator):
 
 
 class ParallelEnv:
-    """
-    The Parallel environment steps every live agent at once. If you are unsure if you
+    """Parallel environment class.
+
+    It steps every live agent at once. If you are unsure if you
     have implemented a ParallelEnv correctly, try running the `parallel_api_test` in
     the Developer documentation on the website.
     """
@@ -297,15 +293,14 @@ class ParallelEnv:
         return_info: bool = False,
         options: Optional[dict] = None,
     ) -> ObsDict:
-        """
-        Resets the environment and returns a dictionary of observations (keyed by the agent name)
+        """Resets the environment.
+
+        And returns a dictionary of observations (keyed by the agent name)
         """
         raise NotImplementedError
 
     def seed(self, seed=None):
-        """
-        Reseeds the environment (making it deterministic).
-        """
+        """Reseeds the environment (making it deterministic)."""
         raise NotImplementedError(
             "Calling seed externally is deprecated; call reset(seed=seed) instead"
         )
@@ -313,16 +308,16 @@ class ParallelEnv:
     def step(
         self, actions: ActionDict
     ) -> Tuple[ObsDict, Dict[str, float], Dict[str, bool], Dict[str, dict]]:
-        """
-        receives a dictionary of actions keyed by the agent name.
+        """Receives a dictionary of actions keyed by the agent name.
+
         Returns the observation dictionary, reward dictionary, done dictionary,
         and info dictionary, where each dictionary is keyed by the agent.
         """
         raise NotImplementedError
 
     def render(self, mode="human") -> None | np.ndarray | str:
-        """
-        Displays a rendered frame from the environment, if supported.
+        """Displays a rendered frame from the environment, if supported.
+
         Alternate render modes in the default environments are `'rgb_array'`
         which returns a numpy array and is supported by all environments outside
         of classic, and `'ansi'` which returns the strings printed
@@ -331,13 +326,12 @@ class ParallelEnv:
         raise NotImplementedError
 
     def close(self):
-        """
-        Closes the rendering window.
-        """
+        """Closes the rendering window."""
         pass
 
     def state(self) -> np.ndarray:
-        """
+        """Returns the state.
+
         State returns a global view of the environment appropriate for
         centralized training decentralized execution methods like QMIX
         """
@@ -348,8 +342,7 @@ class ParallelEnv:
         )
 
     def observation_space(self, agent: AgentID) -> gym.Space:
-        """
-        Takes in agent and returns the observation space for that agent.
+        """Takes in agent and returns the observation space for that agent.
 
         MUST return the same value for the same agent name
 
@@ -361,8 +354,7 @@ class ParallelEnv:
         return self.observation_spaces[agent]  # type: ignore
 
     def action_space(self, agent: AgentID) -> gym.Space:
-        """
-        Takes in agent and returns the action space for that agent.
+        """Takes in agent and returns the action space for that agent.
 
         MUST return the same value for the same agent name
 
@@ -382,8 +374,9 @@ class ParallelEnv:
         return len(self.possible_agents)
 
     def __str__(self) -> str:
-        """
-        returns a name which looks like: "space_invaders_v1" by default
+        """Returns the name.
+
+        Which looks like: "space_invaders_v1" by default
         """
         if hasattr(self, "metadata"):
             return self.metadata.get("name", self.__class__.__name__)

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import warnings
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, TypeVar
 
-import gym  # type: ignore
-import numpy as np  # type: ignore
+import gym.spaces
+import numpy as np
 
 ObsType = TypeVar("ObsType")
 ActionType = TypeVar("ActionType")
@@ -36,10 +36,10 @@ class AECEnv:
     agents: List[AgentID]  # Agents active at any given time
 
     observation_spaces: Dict[
-        AgentID, gym.spaces.Space  # type: ignore
+        AgentID, gym.spaces.Space
     ]  # Observation space for each agent
     # Action space for each agent
-    action_spaces: Dict[AgentID, gym.spaces.Space]  # type: ignore
+    action_spaces: Dict[AgentID, gym.spaces.Space]
 
     # Whether each agent has just reached a terminal state
     dones: Dict[AgentID, bool]
@@ -112,7 +112,7 @@ class AECEnv:
         """
         pass
 
-    def observation_space(self, agent: AgentID) -> gym.Space:
+    def observation_space(self, agent: AgentID) -> gym.spaces.Space:
         """Takes in agent and returns the observation space for that agent.
 
         MUST return the same value for the same agent name
@@ -124,7 +124,7 @@ class AECEnv:
         )
         return self.observation_spaces[agent]
 
-    def action_space(self, agent: str) -> gym.Space:
+    def action_space(self, agent: str) -> gym.spaces.Space:
         """Takes in agent and returns the action space for that agent.
 
         MUST return the same value for the same agent name
@@ -286,6 +286,10 @@ class ParallelEnv:
 
     agents: List[AgentID]
     possible_agents: List[AgentID]
+    observation_spaces: Dict[
+        AgentID, gym.spaces.Space
+    ]  # Observation space for each agent
+    action_spaces: Dict[AgentID, gym.spaces.Space]
 
     def reset(
         self,
@@ -341,7 +345,7 @@ class ParallelEnv:
             )
         )
 
-    def observation_space(self, agent: AgentID) -> gym.Space:
+    def observation_space(self, agent: AgentID) -> gym.spaces.Space:
         """Takes in agent and returns the observation space for that agent.
 
         MUST return the same value for the same agent name
@@ -351,9 +355,9 @@ class ParallelEnv:
         warnings.warn(
             "Your environment should override the observation_space function. Attempting to use the observation_spaces dict attribute."
         )
-        return self.observation_spaces[agent]  # type: ignore
+        return self.observation_spaces[agent]
 
-    def action_space(self, agent: AgentID) -> gym.Space:
+    def action_space(self, agent: AgentID) -> gym.spaces.Space:
         """Takes in agent and returns the action space for that agent.
 
         MUST return the same value for the same agent name
@@ -363,7 +367,7 @@ class ParallelEnv:
         warnings.warn(
             "Your environment should override the action_space function. Attempting to use the action_spaces dict attribute."
         )
-        return self.action_spaces[agent]  # type: ignore
+        return self.action_spaces[agent]
 
     @property
     def num_agents(self) -> int:

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -232,8 +232,8 @@ class AECEnv:
                 self._skip_agent_selection = self.agent_selection
             self.agent_selection = _dones_order[0]
         else:
-            assert self._skip_agent_selection is not None
             if getattr(self, "_skip_agent_selection", None) is not None:
+                assert self._skip_agent_selection is not None
                 self.agent_selection = self._skip_agent_selection
             self._skip_agent_selection = None
         self._clear_rewards()

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import warnings
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, TypeVar
 
-import gym
-import numpy as np
+import gym  # type: ignore
+import numpy as np  # type: ignore
 
 ObsType = TypeVar("ObsType")
 ActionType = TypeVar("ActionType")

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -77,6 +77,7 @@ class AECEnv:
             "Calling seed externally is deprecated; call reset(seed=seed) instead"
         )
 
+    # TODO: Remove `Optional` type below
     def observe(self, agent: str) -> Optional[ObsType]:
         """Returns the observation an agent currently can make.
 

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, TypeVar
 import gym
 import numpy as np
 
-ObsType = TypeVar("ObsType") | None
+ObsType = TypeVar("ObsType")
 ActionType = TypeVar("ActionType")
 AgentID = Optional[str]
 
@@ -81,7 +81,7 @@ class AECEnv:
             "Calling seed externally is deprecated; call reset(seed=seed) instead"
         )
 
-    def observe(self, agent: str) -> ObsType:
+    def observe(self, agent: str) -> Optional[ObsType]:
         """
         Returns the observation an agent currently can make. `last()` calls this function.
         """
@@ -180,7 +180,9 @@ class AECEnv:
         """
         return AECIterable(self, max_iter)
 
-    def last(self, observe: bool = True) -> Tuple[ObsType, float, bool, Dict[str, Any]]:
+    def last(
+        self, observe: bool = True
+    ) -> Tuple[Optional[ObsType], float, bool, Dict[str, Any]]:
         """
         Returns observation, cumulative reward, done, info   for the current agent (specified by self.agent_selection)
         """

--- a/pettingzoo/utils/random_demo.py
+++ b/pettingzoo/utils/random_demo.py
@@ -4,10 +4,7 @@ import numpy as np
 
 
 def random_demo(env, render=True, episodes=1):
-    """
-    Runs an env object with random actions.
-    """
-
+    """Runs an env object with random actions."""
     total_reward = 0
     done = False
     completed_episodes = 0

--- a/pettingzoo/utils/save_observation.py
+++ b/pettingzoo/utils/save_observation.py
@@ -1,6 +1,6 @@
 import os
 
-import gym
+import gym.spaces
 import numpy as np
 
 

--- a/pettingzoo/utils/wrappers/assert_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/assert_out_of_bounds.py
@@ -4,8 +4,8 @@ from .base import BaseWrapper
 
 
 class AssertOutOfBoundsWrapper(BaseWrapper):
-    """
-    this wrapper crashes for out of bounds actions
+    """This wrapper crashes for out of bounds actions.
+
     Should be used for Discrete spaces
     """
 

--- a/pettingzoo/utils/wrappers/base.py
+++ b/pettingzoo/utils/wrappers/base.py
@@ -4,9 +4,9 @@ from pettingzoo.utils.env import AECEnv
 
 
 class BaseWrapper(AECEnv):
-    """
-    Creates a wrapper around `env` parameter. Extend this class
-    to create a useful wrapper.
+    """Creates a wrapper around `env` parameter.
+
+    Extend this class to create a useful wrapper.
     """
 
     def __init__(self, env):
@@ -108,7 +108,5 @@ class BaseWrapper(AECEnv):
         self._cumulative_rewards = self.env._cumulative_rewards
 
     def __str__(self):
-        """
-        returns a name which looks like: "max_observation<space_invaders_v1>"
-        """
+        """Returns a name which looks like: "max_observation<space_invaders_v1>"."""
         return f"{type(self).__name__}<{str(self.env)}>"

--- a/pettingzoo/utils/wrappers/clip_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/clip_out_of_bounds.py
@@ -6,9 +6,7 @@ from .base import BaseWrapper
 
 
 class ClipOutOfBoundsWrapper(BaseWrapper):
-    """
-    this wrapper crops out of bounds actions for Box spaces
-    """
+    """This wrapper crops out of bounds actions for Box spaces."""
 
     def __init__(self, env):
         super().__init__(env)

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -4,8 +4,7 @@ from .base import BaseWrapper
 
 
 class OrderEnforcingWrapper(BaseWrapper):
-    """
-    check all call orders:
+    """Check all call orders.
 
     * error on getting rewards, dones, infos, agent_selection before reset
     * error on calling step, observe before reset
@@ -21,9 +20,9 @@ class OrderEnforcingWrapper(BaseWrapper):
         super().__init__(env)
 
     def __getattr__(self, value):
-        """
-        raises an error message when data is gotten from the env
-        which should only be gotten after reset
+        """Raises an error message when data is gotten from the env.
+
+        Should only be gotten after reset
         """
         if value == "unwrapped":
             return self.env.unwrapped

--- a/pettingzoo/utils/wrappers/terminate_illegal.py
+++ b/pettingzoo/utils/wrappers/terminate_illegal.py
@@ -29,6 +29,7 @@ class TerminateIllegalWrapper(BaseWrapper):
         current_agent = self.agent_selection
         if self._prev_obs is None:
             self.observe(self.agent_selection)
+        assert self._prev_obs
         assert (
             "action_mask" in self._prev_obs
         ), "action_mask must always be part of environment observation as an element in a dictionary observation to use the TerminateIllegalWrapper"

--- a/pettingzoo/utils/wrappers/terminate_illegal.py
+++ b/pettingzoo/utils/wrappers/terminate_illegal.py
@@ -3,11 +3,9 @@ from .base import BaseWrapper
 
 
 class TerminateIllegalWrapper(BaseWrapper):
-    """
-    this wrapper terminates the game with the current player losing
-    in case of illegal values
+    """This wrapper terminates the game with the current player losing in case of illegal values.
 
-    parameters:
+    Parameters:
         - illegal_reward: number that is the value of the player making an illegal move.
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ strict = [
 ]
 verboseOutput = true
 typeCheckingMode = "basic"
+reportMissingImports = false
 
 [tool.pytest.ini_options]
 norecursedirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,17 @@
 [tool.pyright]
 
 # add any files/directories with type declaration to include
-include = ["pettingzoo/utils/env.py"]
-exclude = [
-    "**/node_modules",
-    "**/__pycache__",
+include = [
+    "pettingzoo/utils/env.py"
 ]
-strict = ["pettingzoo/utils/env.py"]
-
-reportMissingImports = true
-reportMissingTypeStubs = false
+exclude = [
+]
+strict = [
+]
+# reportMissingImports = true
 verboseOutput = true
+# typeCheckingMode = "basic"
+# pythonVersion = "3.7"
 
 [tool.pytest.ini_options]
 norecursedirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ strict = [
 verboseOutput = true
 # typeCheckingMode = "basic"
 # pythonVersion = "3.7"
+# reportMissingTypeStubs = false
 
 [tool.pytest.ini_options]
 norecursedirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,11 +8,8 @@ exclude = [
 ]
 strict = [
 ]
-# reportMissingImports = true
 verboseOutput = true
-# typeCheckingMode = "basic"
-# pythonVersion = "3.7"
-# reportMissingTypeStubs = false
+typeCheckingMode = "basic"
 
 [tool.pytest.ini_options]
 norecursedirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,16 @@
 
 # add any files/directories with type declaration to include
 include = [
-    "pettingzoo/utils/env.py"
+    "pettingzoo/",
 ]
 exclude = [
+    "pettingzoo/atari/",
+    "pettingzoo/butterfly/",
+    "pettingzoo/classic/",
+    "pettingzoo/magent/",
+    "pettingzoo/mpe/",
+    "pettingzoo/sisl/",
+    "pettingzoo/test/",
 ]
 strict = [
 ]

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ extras = {
         "bandit",
         "pytest",
         "pytest-cov",
+        "pre-commit",
     ],
 }
 


### PR DESCRIPTION
# Description

This PR moves the Pyright checks from CI only to `pre-commit` (both local + CI), fixes some typing issues, and add also `pydocstyle` to `pre-commit`.


## Type of change

- Refactoring/maintenance

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
