### PR TITLE
Add EzPickle to MPE

### DIFF
--- a/pettingzoo/mpe/simple_adversary/simple_adversary.py
+++ b/pettingzoo/mpe/simple_adversary/simple_adversary.py
@@ -1,4 +1,5 @@
 import numpy as np
+from gym.utils import EzPickle
 
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
@@ -7,8 +8,14 @@ from .._mpe_utils.scenario import BaseScenario
 from .._mpe_utils.simple_env import SimpleEnv, make_env
 
 
-class raw_env(SimpleEnv):
+class raw_env(SimpleEnv, EzPickle):
     def __init__(self, N=2, max_cycles=25, continuous_actions=False):
+        EzPickle.__init__(
+            self,
+            N,
+            max_cycles,
+            continuous_actions,
+        )
         scenario = Scenario()
         world = scenario.make_world(N)
         super().__init__(scenario, world, max_cycles, continuous_actions)

--- a/pettingzoo/mpe/simple_crypto/simple_crypto.py
+++ b/pettingzoo/mpe/simple_crypto/simple_crypto.py
@@ -6,6 +6,7 @@ adversary to goal. Adversary is rewarded for its distance to the goal.
 
 
 import numpy as np
+from gym.utils import EzPickle
 
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
@@ -14,8 +15,13 @@ from .._mpe_utils.scenario import BaseScenario
 from .._mpe_utils.simple_env import SimpleEnv, make_env
 
 
-class raw_env(SimpleEnv):
+class raw_env(SimpleEnv, EzPickle):
     def __init__(self, max_cycles=25, continuous_actions=False):
+        EzPickle.__init__(
+            self,
+            max_cycles,
+            continuous_actions,
+        )
         scenario = Scenario()
         world = scenario.make_world()
         super().__init__(scenario, world, max_cycles, continuous_actions)

--- a/pettingzoo/mpe/simple_push/simple_push.py
+++ b/pettingzoo/mpe/simple_push/simple_push.py
@@ -1,4 +1,5 @@
 import numpy as np
+from gym.utils import EzPickle
 
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
@@ -7,8 +8,13 @@ from .._mpe_utils.scenario import BaseScenario
 from .._mpe_utils.simple_env import SimpleEnv, make_env
 
 
-class raw_env(SimpleEnv):
+class raw_env(SimpleEnv, EzPickle):
     def __init__(self, max_cycles=25, continuous_actions=False):
+        EzPickle.__init__(
+            self,
+            max_cycles,
+            continuous_actions,
+        )
         scenario = Scenario()
         world = scenario.make_world()
         super().__init__(scenario, world, max_cycles, continuous_actions)

--- a/pettingzoo/mpe/simple_reference/simple_reference.py
+++ b/pettingzoo/mpe/simple_reference/simple_reference.py
@@ -1,4 +1,5 @@
 import numpy as np
+from gym.utils import EzPickle
 
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
@@ -7,8 +8,14 @@ from .._mpe_utils.scenario import BaseScenario
 from .._mpe_utils.simple_env import SimpleEnv, make_env
 
 
-class raw_env(SimpleEnv):
+class raw_env(SimpleEnv, EzPickle):
     def __init__(self, local_ratio=0.5, max_cycles=25, continuous_actions=False):
+        EzPickle.__init__(
+            self,
+            local_ratio,
+            max_cycles,
+            continuous_actions,
+        )
         assert (
             0.0 <= local_ratio <= 1.0
         ), "local_ratio is a proportion. Must be between 0 and 1."

--- a/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
+++ b/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
@@ -1,4 +1,5 @@
 import numpy as np
+from gym.utils import EzPickle
 
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
@@ -7,8 +8,13 @@ from .._mpe_utils.scenario import BaseScenario
 from .._mpe_utils.simple_env import SimpleEnv, make_env
 
 
-class raw_env(SimpleEnv):
+class raw_env(SimpleEnv, EzPickle):
     def __init__(self, max_cycles=25, continuous_actions=False):
+        EzPickle.__init__(
+            self,
+            max_cycles,
+            continuous_actions,
+        )
         scenario = Scenario()
         world = scenario.make_world()
         super().__init__(scenario, world, max_cycles, continuous_actions)

--- a/pettingzoo/mpe/simple_spread/simple_spread.py
+++ b/pettingzoo/mpe/simple_spread/simple_spread.py
@@ -1,4 +1,5 @@
 import numpy as np
+from gym.utils import EzPickle
 
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
@@ -7,8 +8,15 @@ from .._mpe_utils.scenario import BaseScenario
 from .._mpe_utils.simple_env import SimpleEnv, make_env
 
 
-class raw_env(SimpleEnv):
+class raw_env(SimpleEnv, EzPickle):
     def __init__(self, N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False):
+        EzPickle.__init__(
+            self,
+            N,
+            local_ratio,
+            max_cycles,
+            continuous_actions,
+        )
         assert (
             0.0 <= local_ratio <= 1.0
         ), "local_ratio is a proportion. Must be between 0 and 1."

--- a/pettingzoo/mpe/simple_tag/simple_tag.py
+++ b/pettingzoo/mpe/simple_tag/simple_tag.py
@@ -1,4 +1,5 @@
 import numpy as np
+from gym.utils import EzPickle
 
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
@@ -7,7 +8,7 @@ from .._mpe_utils.scenario import BaseScenario
 from .._mpe_utils.simple_env import SimpleEnv, make_env
 
 
-class raw_env(SimpleEnv):
+class raw_env(SimpleEnv, EzPickle):
     def __init__(
         self,
         num_good=1,
@@ -16,6 +17,14 @@ class raw_env(SimpleEnv):
         max_cycles=25,
         continuous_actions=False,
     ):
+        EzPickle.__init__(
+            self,
+            num_good,
+            num_adversaries,
+            num_obstacles,
+            max_cycles,
+            continuous_actions,
+        )
         scenario = Scenario()
         world = scenario.make_world(num_good, num_adversaries, num_obstacles)
         super().__init__(scenario, world, max_cycles, continuous_actions)

--- a/pettingzoo/mpe/simple_world_comm/simple_world_comm.py
+++ b/pettingzoo/mpe/simple_world_comm/simple_world_comm.py
@@ -1,4 +1,5 @@
 import numpy as np
+from gym.utils import EzPickle
 
 from pettingzoo.utils.conversions import parallel_wrapper_fn
 
@@ -7,7 +8,7 @@ from .._mpe_utils.scenario import BaseScenario
 from .._mpe_utils.simple_env import SimpleEnv, make_env
 
 
-class raw_env(SimpleEnv):
+class raw_env(SimpleEnv, EzPickle):
     def __init__(
         self,
         num_good=2,
@@ -18,6 +19,15 @@ class raw_env(SimpleEnv):
         num_forests=2,
         continuous_actions=False,
     ):
+        EzPickle.__init__(
+            self,
+            num_good,
+            num_adversaries,
+            num_obstacles,
+            max_cycles,
+            num_forests,
+            continuous_actions,
+        )
         scenario = Scenario()
         world = scenario.make_world(
             num_good, num_adversaries, num_obstacles, num_food, num_forests


### PR DESCRIPTION
# Description

This adds EzPickle to MPE so that the ConcatVecEnvs from Supersuit works again ever since the change from pyglet to pygame as was done in #738.