### PR TITLE
Account for "render_modes" or "render.modes" in metadata 

### DIFF
--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -58,7 +58,7 @@ class OrderEnforcingWrapper(BaseWrapper):
     def render(self, mode="human"):
         if not self._has_reset:
             EnvLogger.error_render_before_reset()
-        assert mode in self.metadata["render_modes"]
+        assert mode in self.metadata["render.modes"]
         self._has_rendered = True
         return super().render(mode)
 

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -58,7 +58,10 @@ class OrderEnforcingWrapper(BaseWrapper):
     def render(self, mode="human"):
         if not self._has_reset:
             EnvLogger.error_render_before_reset()
-        assert mode in self.metadata["render.modes"]
+        if "render_modes" in self.metadata:
+            assert mode in self.metadata["render_modes"]
+        if "render.modes" in self.metadata:
+            assert mode in self.metadata["render.modes"]
         self._has_rendered = True
         return super().render(mode)
 


### PR DESCRIPTION
# Description

I ran into a bug wherein my environments where the metadata's keys for  my environment (which is wrapped as a `SB3VecEnvWrapper`) where not "render_modes" but "render.modes". And so I made a quick fix as can be seen below. 

I have not tested this extensively, however it seems a pretty inconsequential quick fix that might be helpful to others. 

Fixes # (issue), Depends on # (pull request)

## Type of change

- Bug fix (non-breaking change which fixes an issue)



