### PR TITLE
Temporarily remove waterworld from tests and also disable environment.

### DIFF
--- a/pettingzoo/sisl/waterworld/waterworld_base.py
+++ b/pettingzoo/sisl/waterworld/waterworld_base.py
@@ -161,6 +161,9 @@ class MAWaterWorld:
         speed_features=True,
         max_cycles=500,
     ):
+        raise AssertionError(
+            "Please do not use Waterworld, at its current state it is incredibly buggy and the soundness of the environment is not guaranteed."
+        )
         """
         n_pursuers: number of pursuing archea (agents)
         n_evaders: number of evader archea

--- a/test/all_modules.py
+++ b/test/all_modules.py
@@ -136,6 +136,6 @@ all_environments = {
     "mpe/simple_world_comm_v2": simple_world_comm_v2,
     "mpe/simple_v2": simple_v2,
     "sisl/multiwalker_v9": multiwalker_v9,
-    "sisl/waterworld_v3": waterworld_v3,
+    # "sisl/waterworld_v3": waterworld_v3,
     "sisl/pursuit_v4": pursuit_v4,
 }


### PR DESCRIPTION
# Description

New Scipy tests were introduced in Scipy 1.9, which resulted in our most buggy environment - WaterWorld, failing a bunch of the tests. Until we get the newer version of waterworld, it will be removed from tests and also prevented from running so as not to hold up other developments.
