### PR TITLE
Update RLlib examples for Ray 2.0.0

### DIFF
--- a/tutorials/render_rllib_leduc_holdem.py
+++ b/tutorials/render_rllib_leduc_holdem.py
@@ -1,9 +1,9 @@
 import argparse
 import os
+import pickle
 from pathlib import Path
 
 import numpy as np
-import pickle
 import ray
 from ray.rllib.algorithms.dqn import DQN, DQNConfig
 from ray.rllib.env.wrappers.pettingzoo_env import PettingZooEnv

--- a/tutorials/render_rllib_leduc_holdem.py
+++ b/tutorials/render_rllib_leduc_holdem.py
@@ -1,13 +1,11 @@
 import argparse
 import os
-from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
-import pickle5 as pickle
+import pickle
 import ray
-from ray.rllib.agents.dqn import DQNTrainer
-from ray.rllib.agents.registry import get_agent_class
+from ray.rllib.algorithms.dqn import DQN, DQNConfig
 from ray.rllib.env.wrappers.pettingzoo_env import PettingZooEnv
 from ray.rllib.models import ModelCatalog
 from ray.tune.registry import register_env
@@ -43,14 +41,11 @@ def env_creator():
 
 num_cpus = 1
 
-config = deepcopy(get_agent_class(alg_name)._default_config)
+config = DQNConfig().to_dict()
 
 register_env("leduc_holdem", lambda config: PettingZooEnv(env_creator()))
 
 env = env_creator()
-# obs_space = env.observation_space
-# print(obs_space)
-# act_space = test_env.action_space
 
 with open(params_path, "rb") as f:
     config = pickle.load(f)
@@ -59,7 +54,7 @@ with open(params_path, "rb") as f:
     del config["num_gpus"]
 
 ray.init(num_cpus=8, num_gpus=0)
-DQNAgent = DQNTrainer(env="leduc_holdem", config=config)
+DQNAgent = DQN(env="leduc_holdem", config=config)
 DQNAgent.restore(checkpoint_path)
 
 reward_sums = {a: 0 for a in env.possible_agents}

--- a/tutorials/render_rllib_pistonball.py
+++ b/tutorials/render_rllib_pistonball.py
@@ -6,7 +6,7 @@ import pickle5 as pickle
 import ray
 import supersuit as ss
 from PIL import Image
-from ray.rllib.agents.ppo import PPOTrainer
+from ray.rllib.algorithms.ppo import PPO
 from ray.rllib.env.wrappers.pettingzoo_env import PettingZooEnv
 from ray.rllib.models import ModelCatalog
 from ray.tune.registry import register_env
@@ -63,7 +63,7 @@ with open(params_path, "rb") as f:
     del config["num_gpus"]
 
 ray.init(num_cpus=8, num_gpus=1)
-PPOagent = PPOTrainer(env=env_name, config=config)
+PPOagent = PPO(env=env_name, config=config)
 PPOagent.restore(checkpoint_path)
 
 

--- a/tutorials/rllib_leduc_holdem.py
+++ b/tutorials/rllib_leduc_holdem.py
@@ -2,8 +2,8 @@ import os
 
 from gym.spaces import Box
 from ray import tune
-from ray.rllib.algorithms.dqn.dqn_torch_model import DQNTorchModel
 from ray.rllib.algorithms.dqn import DQNConfig
+from ray.rllib.algorithms.dqn.dqn_torch_model import DQNTorchModel
 from ray.rllib.env import PettingZooEnv
 from ray.rllib.models import ModelCatalog
 from ray.rllib.models.torch.fcnet import FullyConnectedNetwork as TorchFC
@@ -75,12 +75,15 @@ if __name__ == "__main__":
         .environment(env="leduc_holdem")
         .rollouts(num_rollout_workers=1, rollout_fragment_length=30, horizon=200)
         .training(
-            train_batch_size=200, hiddens=[], dueling=False, model={"custom_model": "pa_model"}
+            train_batch_size=200,
+            hiddens=[],
+            dueling=False,
+            model={"custom_model": "pa_model"},
         )
         .multi_agent(
             policies={
-            "player_0": (None, obs_space, act_space, {}),
-            "player_1": (None, obs_space, act_space, {}),
+                "player_0": (None, obs_space, act_space, {}),
+                "player_1": (None, obs_space, act_space, {}),
             },
             policy_mapping_fn=lambda agent_id: agent_id,
         )


### PR DESCRIPTION
# Description

Ray+RLlib 2.0.0 is currently being released as an `rc0`. I've updated all four RLlib examples to work with the new paths for algorithms, renamed imports, etc. and migrated the `leduc_holdem` and `pistonball` examples to use RLlib's config objects API.

This PR should be kept as a draft until Ray 2.0.0 is released on PyPI (next week or so).

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
