### PR TITLE
[in progress] Truncation update for mpe

### DIFF
--- a/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
@@ -577,7 +577,7 @@ class raw_env(AECEnv, EzPickle):
         self.rewards[self.agent_selection] = next_agent.score
 
         self._accumulate_rewards()
-        self._dones_step_first()
+        self._deads_step_first()
 
     def enable_render(self):
         self.WINDOW = pygame.display.set_mode([const.SCREEN_WIDTH, const.SCREEN_HEIGHT])

--- a/pettingzoo/classic/rlcard_envs/rlcard_base.py
+++ b/pettingzoo/classic/rlcard_envs/rlcard_base.py
@@ -105,7 +105,7 @@ class RLCardBase(AECEnv):
         self._cumulative_rewards[self.agent_selection] = 0
         self.agent_selection = next_player
         self._accumulate_rewards()
-        self._dones_step_first()
+        self._deads_step_first()
 
     def reset(self, seed=None, return_info=False, options=None):
         if seed is not None:

--- a/pettingzoo/mpe/_mpe_utils/simple_env.py
+++ b/pettingzoo/mpe/_mpe_utils/simple_env.py
@@ -226,7 +226,10 @@ class SimpleEnv(AECEnv):
         assert len(action) == 0
 
     def step(self, action):
-        if (self.terminations[self.agent_selection] or self.truncations[self.agent_selection]):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             return self._was_dead_step(action)
         cur_agent = self.agent_selection
         current_idx = self._index_map[self.agent_selection]

--- a/pettingzoo/mpe/_mpe_utils/simple_env.py
+++ b/pettingzoo/mpe/_mpe_utils/simple_env.py
@@ -143,7 +143,8 @@ class SimpleEnv(AECEnv):
         self.agents = self.possible_agents[:]
         self.rewards = {name: 0.0 for name in self.agents}
         self._cumulative_rewards = {name: 0.0 for name in self.agents}
-        self.dones = {name: False for name in self.agents}
+        self.terminations = {name: False for name in self.agents}
+        self.truncations = {name: False for name in self.agents}
         self.infos = {name: {} for name in self.agents}
 
         self.agent_selection = self._agent_selector.reset()
@@ -225,8 +226,8 @@ class SimpleEnv(AECEnv):
         assert len(action) == 0
 
     def step(self, action):
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if (self.terminations[self.agent_selection] or self.truncations[self.agent_selection]):
+            return self._was_dead_step(action)
         cur_agent = self.agent_selection
         current_idx = self._index_map[self.agent_selection]
         next_idx = (current_idx + 1) % self.num_agents
@@ -239,7 +240,7 @@ class SimpleEnv(AECEnv):
             self.steps += 1
             if self.steps >= self.max_cycles:
                 for a in self.agents:
-                    self.dones[a] = True
+                    self.truncations[a] = True
         else:
             self._clear_rewards()
 

--- a/pettingzoo/sisl/multiwalker/multiwalker.py
+++ b/pettingzoo/sisl/multiwalker/multiwalker.py
@@ -109,5 +109,5 @@ class raw_env(AECEnv, EzPickle):
 
         self._cumulative_rewards[agent] = 0
         self._accumulate_rewards()
-        self._dones_step_first()
+        self._deads_step_first()
         self.steps += 1

--- a/pettingzoo/test/api_test.py
+++ b/pettingzoo/test/api_test.py
@@ -200,11 +200,14 @@ def test_reward(reward):
             assert False, "Reward NumPy array is not a numeric dtype"
 
 
-def test_rewards_dones(env, agent_0):
+def test_rewards_terminations_truncations(env, agent_0):
     for agent in env.agents:
         assert isinstance(
-            env.dones[agent], bool
-        ), "Agent's values in dones must be True or False"
+            env.terminations[agent], bool
+        ), "Agent's values in terminations must be True or False"
+        assert isinstance(
+            env.truncations[agent], bool
+        ), "Agent's values in truncations must be True or False"
         float(
             env.rewards[agent]
         )  # "Rewards for each agent must be convertible to float
@@ -218,13 +221,14 @@ def play_test(env, observation_0, num_cycles):
     consistent. In particular it checks:
 
     * Whether the reward returned by last is the accumulated reward
-    * Whether the agents list shrinks when agents are done
-    * Whether the keys of the rewards, dones, infos are equal to the agents list
+    * Whether the agents list shrinks when agents are terminated or truncated
+    * Whether the keys of the rewards, terminations, truncations, infos are equal to the agents list
     * tests that the observation is in bounds.
     """
     env.reset()
 
-    done = {agent: False for agent in env.agents}
+    terminated = {agent: False for agent in env.agents}
+    truncated = {agent: False for agent in env.agents}
     live_agents = set(env.agents[:])
     has_finished = set()
     generated_agents = set()
@@ -237,8 +241,8 @@ def play_test(env, observation_0, num_cycles):
         assert isinstance(
             env.infos[agent], dict
         ), "an environment agent's info must be a dictionary"
-        prev_observe, reward, done, info = env.last()
-        if done:
+        prev_observe, reward, terminated, truncated, info = env.last()
+        if terminated or truncated:
             action = None
         elif isinstance(prev_observe, dict) and "action_mask" in prev_observe:
             action = random.choice(np.flatnonzero(prev_observe["action_mask"]))
@@ -252,7 +256,7 @@ def play_test(env, observation_0, num_cycles):
             set(env.agents)
         ), "environment must delete agents as the game continues"
 
-        if done:
+        if terminated or truncated:
             live_agents.remove(agent)
             has_finished.add(agent)
 
@@ -271,13 +275,16 @@ def play_test(env, observation_0, num_cycles):
         ), "env.num_agents is not equal to len(env.agents)"
         assert set(env.rewards.keys()) == (
             set(env.agents)
-        ), "agents should not be given a reward if they were done last turn"
-        assert set(env.dones.keys()) == (
+        ), "agents should not be given a reward if they were terminated or truncated last turn"
+        assert set(env.terminations.keys()) == (
             set(env.agents)
-        ), "agents should not be given a done if they were done last turn"
+        ), "agents should not be given a termination if they were terminated or truncated last turn"
+        assert set(env.truncations.keys()) == (
+            set(env.agents)
+        ), "agents should not be given a truncation if they were terminated or truncated last turn"
         assert set(env.infos.keys()) == (
             set(env.agents)
-        ), "agents should not be given an info if they were done last turn"
+        ), "agents should not be given an info if they were terminated or truncated last turn"
         if hasattr(env, "possible_agents"):
             assert set(env.agents).issubset(
                 set(env.possible_agents)
@@ -308,17 +315,21 @@ def play_test(env, observation_0, num_cycles):
 
     env.reset()
     for agent in env.agent_iter(env.num_agents * 2):
-        obs, reward, done, info = env.last()
-        if done:
+        obs, reward, terminated, truncated, info = env.last()
+        if terminated or truncated:
             action = None
         elif isinstance(obs, dict) and "action_mask" in obs:
             action = random.choice(np.flatnonzero(obs["action_mask"]))
         else:
             action = env.action_space(agent).sample()
-        assert isinstance(done, bool), "Done from last is not True or False"
+        assert isinstance(terminated, bool), "terminated from last is not True or False"
+        assert isinstance(truncated, bool), "terminated from last is not True or False"
         assert (
-            done == env.dones[agent]
-        ), "Done from last() and dones[agent] do not match"
+            terminated == env.terminations[agent]
+        ), "terminated from last() and terminations[agent] do not match"
+        assert (
+                truncated == env.truncations[agent]
+        ), "truncated from last() and truncations[agent] do not match"
         assert (
             info == env.infos[agent]
         ), "Info from last() and infos[agent] do not match"
@@ -335,8 +346,8 @@ def test_action_flexibility(env):
     agent = env.agent_selection
     action_space = env.action_space(agent)
     if isinstance(action_space, gym.spaces.Discrete):
-        obs, reward, done, info = env.last()
-        if done:
+        obs, reward, terminated, truncated, info = env.last()
+        if terminated or truncated:
             action = None
         elif isinstance(obs, dict) and "action_mask" in obs:
             action = random.choice(np.flatnonzero(obs["action_mask"]))
@@ -368,17 +379,18 @@ def api_test(env, num_cycles=1000, verbose_progress=False):
     ), "Env must be an instance of pettingzoo.AECEnv"
 
     env.reset()
-    assert not any(env.dones.values()), "dones must all be False after reset"
+    assert not any(env.terminations.values()), "terminations must all be False after reset"
+    assert not any(env.truncations.values()), "truncations must all be False after reset"
 
     assert isinstance(env.num_agents, int), "num_agents must be an integer"
     assert env.num_agents != 0, "An environment should have a nonzero number of agents"
     assert env.num_agents > 0, "An environment should have a positive number of agents"
 
     env.reset()
-    observation_0, _, _, _ = env.last()
+    observation_0, _, _, _, _ = env.last()
     test_observation(observation_0, observation_0)
 
-    non_observe, _, _, _ = env.last(observe=False)
+    non_observe, _, _, _, _ = env.last(observe=False)
     assert non_observe is None, "last must return a None when observe=False"
 
     progress_report("Finished test_observation")
@@ -394,18 +406,19 @@ def api_test(env, num_cycles=1000, verbose_progress=False):
     progress_report("Finished play test")
 
     assert isinstance(env.rewards, dict), "rewards must be a dict"
-    assert isinstance(env.dones, dict), "dones must be a dict"
+    assert isinstance(env.terminations, dict), "terminations must be a dict"
+    assert isinstance(env.truncations, dict), "truncations must be a dict"
     assert isinstance(env.infos, dict), "infos must be a dict"
 
     assert (
-        len(env.rewards) == len(env.dones) == len(env.infos) == len(env.agents)
-    ), "rewards, dones, infos and agents must have the same length"
+        len(env.rewards) == len(env.terminations) == len(env.truncations) == len(env.infos) == len(env.agents)
+    ), "rewards, terminations, truncations, infos and agents must have the same length"
 
-    test_rewards_dones(env, agent_0)
+    test_rewards_terminations_truncations(env, agent_0)
 
     test_action_flexibility(env)
 
-    progress_report("Finished test_rewards_dones")
+    progress_report("Finished test_rewards_terminations_truncations")
 
     # checks unwrapped attribute
     assert not isinstance(env.unwrapped, aec_to_parallel_wrapper)

--- a/pettingzoo/test/api_test.py
+++ b/pettingzoo/test/api_test.py
@@ -328,7 +328,7 @@ def play_test(env, observation_0, num_cycles):
             terminated == env.terminations[agent]
         ), "terminated from last() and terminations[agent] do not match"
         assert (
-                truncated == env.truncations[agent]
+            truncated == env.truncations[agent]
         ), "truncated from last() and truncations[agent] do not match"
         assert (
             info == env.infos[agent]
@@ -379,8 +379,12 @@ def api_test(env, num_cycles=1000, verbose_progress=False):
     ), "Env must be an instance of pettingzoo.AECEnv"
 
     env.reset()
-    assert not any(env.terminations.values()), "terminations must all be False after reset"
-    assert not any(env.truncations.values()), "truncations must all be False after reset"
+    assert not any(
+        env.terminations.values()
+    ), "terminations must all be False after reset"
+    assert not any(
+        env.truncations.values()
+    ), "truncations must all be False after reset"
 
     assert isinstance(env.num_agents, int), "num_agents must be an integer"
     assert env.num_agents != 0, "An environment should have a nonzero number of agents"
@@ -411,7 +415,11 @@ def api_test(env, num_cycles=1000, verbose_progress=False):
     assert isinstance(env.infos, dict), "infos must be a dict"
 
     assert (
-        len(env.rewards) == len(env.terminations) == len(env.truncations) == len(env.infos) == len(env.agents)
+        len(env.rewards)
+        == len(env.terminations)
+        == len(env.truncations)
+        == len(env.infos)
+        == len(env.agents)
     ), "rewards, terminations, truncations, infos and agents must have the same length"
 
     test_rewards_terminations_truncations(env, agent_0)

--- a/pettingzoo/test/example_envs/generated_agents_env_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_v0.py
@@ -111,7 +111,7 @@ class raw_env(AECEnv):
         self.rewards[self.np_random.choice(self.agents)] = 1
 
         self._accumulate_rewards()
-        self._dones_step_first()
+        self._deads_step_first()
 
     def render(self, mode="human"):
         print(self.agents)

--- a/pettingzoo/test/max_cycles_test.py
+++ b/pettingzoo/test/max_cycles_test.py
@@ -26,7 +26,7 @@ def max_cycles_test(mod):
         if all([x or y for x, y in zip(terminations.values(), truncations.values())]):
             break
 
-    # pstep = step + 1  # todo: fix bug where syep is 1 more rgan max cycles
+    pstep = step + 1
 
     env = mod.env(max_cycles=max_cycles)
     env.reset()
@@ -46,7 +46,7 @@ def max_cycles_test(mod):
         #     raise ValueError(a, env.terminations, env.truncations)
         env.step(action)
 
-    # assert max_cycles == pstep  # todo: BUG 2
+    assert max_cycles == pstep
     # does not check the minimum value because some agents might be killed before
     # all the steps are complete. However, most agents should still be alive
     # given a short number of cycles

--- a/pettingzoo/test/max_cycles_test.py
+++ b/pettingzoo/test/max_cycles_test.py
@@ -15,10 +15,7 @@ def max_cycles_test(mod):
         actions = {
             agent: parallel_env.action_space(agent).sample()
             for agent in parallel_env.agents
-            if not {
-                x[0]: x[1] or y[1]
-                for x, y in zip(terminations.items(), truncations.items())
-            }[agent]
+            if not (terminations[agent] or truncations[agent])
         }
         observations, rewards, terminations, truncations, infos = parallel_env.step(
             actions

--- a/pettingzoo/test/max_cycles_test.py
+++ b/pettingzoo/test/max_cycles_test.py
@@ -6,7 +6,8 @@ def max_cycles_test(mod):
     parallel_env = mod.parallel_env(max_cycles=max_cycles)
 
     observations = parallel_env.reset()
-    dones = {agent: False for agent in parallel_env.agents}
+    terminations = {agent: False for agent in parallel_env.agents}
+    truncations = {agent: False for agent in parallel_env.agents}
     test_cycles = (
         max_cycles + 10
     )  # allows environment to do more than max_cycles if it so wishes
@@ -14,13 +15,13 @@ def max_cycles_test(mod):
         actions = {
             agent: parallel_env.action_space(agent).sample()
             for agent in parallel_env.agents
-            if not dones[agent]
+            if not (terminations[agent] or truncations[agent])
         }
-        observations, rewards, dones, infos = parallel_env.step(actions)
-        if all(dones.values()):
+        observations, rewards, terminations, truncations, infos = parallel_env.step(actions)
+        if all(terminations.values() or truncations.values()):
             break
 
-    pstep = step + 1
+    pstep = step + 1  # todo: fix bug where syep is 1 more rgan max cycles
 
     env = mod.env(max_cycles=max_cycles)
     env.reset()
@@ -30,10 +31,13 @@ def max_cycles_test(mod):
         aidx = env.possible_agents.index(a)
         agent_counts[aidx] += 1
 
-        action = env.action_space(a).sample() if not env.dones[a] else None
+        #raise ValueError(a, env.agent_iter(), env.terminations, env.truncations)
+        action = env.action_space(a).sample() if not (env.terminations[a] or env.truncations[a]) else None
+        # except:
+        #     raise ValueError(a, env.terminations, env.truncations)
         env.step(action)
 
-    assert max_cycles == pstep
+    #assert max_cycles == pstep  # todo: BUG 2
     # does not check the minimum value because some agents might be killed before
     # all the steps are complete. However, most agents should still be alive
     # given a short number of cycles

--- a/pettingzoo/test/max_cycles_test.py
+++ b/pettingzoo/test/max_cycles_test.py
@@ -17,11 +17,13 @@ def max_cycles_test(mod):
             for agent in parallel_env.agents
             if not (terminations[agent] or truncations[agent])
         }
-        observations, rewards, terminations, truncations, infos = parallel_env.step(actions)
+        observations, rewards, terminations, truncations, infos = parallel_env.step(
+            actions
+        )
         if all(terminations.values() or truncations.values()):
             break
 
-    pstep = step + 1  # todo: fix bug where syep is 1 more rgan max cycles
+    # pstep = step + 1  # todo: fix bug where syep is 1 more rgan max cycles
 
     env = mod.env(max_cycles=max_cycles)
     env.reset()
@@ -31,13 +33,17 @@ def max_cycles_test(mod):
         aidx = env.possible_agents.index(a)
         agent_counts[aidx] += 1
 
-        #raise ValueError(a, env.agent_iter(), env.terminations, env.truncations)
-        action = env.action_space(a).sample() if not (env.terminations[a] or env.truncations[a]) else None
+        # raise ValueError(a, env.agent_iter(), env.terminations, env.truncations)
+        action = (
+            env.action_space(a).sample()
+            if not (env.terminations[a] or env.truncations[a])
+            else None
+        )
         # except:
         #     raise ValueError(a, env.terminations, env.truncations)
         env.step(action)
 
-    #assert max_cycles == pstep  # todo: BUG 2
+    # assert max_cycles == pstep  # todo: BUG 2
     # does not check the minimum value because some agents might be killed before
     # all the steps are complete. However, most agents should still be alive
     # given a short number of cycles

--- a/pettingzoo/test/max_cycles_test.py
+++ b/pettingzoo/test/max_cycles_test.py
@@ -15,12 +15,15 @@ def max_cycles_test(mod):
         actions = {
             agent: parallel_env.action_space(agent).sample()
             for agent in parallel_env.agents
-            if not ([x or y for x, y in zip(terminations, truncations)][agent])
+            if not {
+                x[0]: x[1] or y[1]
+                for x, y in zip(terminations.items(), truncations.items())
+            }[agent]
         }
         observations, rewards, terminations, truncations, infos = parallel_env.step(
             actions
         )
-        if all(terminations.values() or truncations.values()):
+        if all([x or y for x, y in zip(terminations.values(), truncations.values())]):
             break
 
     # pstep = step + 1  # todo: fix bug where syep is 1 more rgan max cycles

--- a/pettingzoo/test/max_cycles_test.py
+++ b/pettingzoo/test/max_cycles_test.py
@@ -15,7 +15,7 @@ def max_cycles_test(mod):
         actions = {
             agent: parallel_env.action_space(agent).sample()
             for agent in parallel_env.agents
-            if not (terminations[agent] or truncations[agent])
+            if not ([x or y for x, y in zip(terminations, truncations)][agent])
         }
         observations, rewards, terminations, truncations, infos = parallel_env.step(
             actions

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -115,7 +115,7 @@ def parallel_api_test(par_env, num_cycles=1000):
                 if d:
                     live_agents.remove(agent)
 
-            # assert set(par_env.agents) == live_agents  # todo: BUG 1
+            assert set(par_env.agents) == live_agents
 
             if len(live_agents) == 0:
                 break

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -86,7 +86,12 @@ def parallel_api_test(par_env, num_cycles=1000):
                 ), "possible_agents defined but does not contain all agents"
 
                 has_finished |= {
-                    agent for agent, d in (terminated.items() or truncated.items()) if d
+                    agent
+                    for agent, d in [
+                        (x[0], x[1] or y[1])
+                        for x, y in zip(terminated.items(), truncated.items())
+                    ]
+                    if d
                 }
                 if not par_env.agents and has_finished != set(par_env.possible_agents):
                     warnings.warn(
@@ -103,7 +108,10 @@ def parallel_api_test(par_env, num_cycles=1000):
                     agent
                 ), "action_space should return the exact same space object (not a copy) for an agent (ensures that action space seeding works as expected). Consider decorating your action_space(self, agent) method with @functools.lru_cache(maxsize=None)"
 
-            for agent, d in terminated.items() or truncated.items():
+            for agent, d in [
+                (x[0], x[1] or y[1])
+                for x, y in zip(terminated.items(), truncated.items())
+            ]:
                 if d:
                     live_agents.remove(agent)
 

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -42,30 +42,32 @@ def parallel_api_test(par_env, num_cycles=1000):
         obs = par_env.reset()
         assert isinstance(obs, dict)
         assert set(obs.keys()) == (set(par_env.agents))
-        done = {agent: False for agent in par_env.agents}
+        terminated = {agent: False for agent in par_env.agents}
+        truncated = {agent: False for agent in par_env.agents}
         live_agents = set(par_env.agents[:])
         has_finished = set()
         for _ in range(num_cycles):
             actions = {
                 agent: sample_action(par_env, obs, agent)
                 for agent in par_env.agents
-                if agent in done and not done[agent]
+                if ((agent in terminated and not terminated[agent]) or (agent in truncated and not truncated[agent]))
             }
-            obs, rew, done, info = par_env.step(actions)
+            obs, rew, terminated, truncated, info = par_env.step(actions)
             for agent in par_env.agents:
-                assert agent not in has_finished, "agent cannot be revived once done"
+                assert agent not in has_finished, "agent cannot be revived once dead"
 
                 if agent not in live_agents:
                     live_agents.add(agent)
 
             assert isinstance(obs, dict)
             assert isinstance(rew, dict)
-            assert isinstance(done, dict)
+            assert isinstance(terminated, dict)
+            assert isinstance(truncated, dict)
             assert isinstance(info, dict)
 
             agents_set = set(live_agents)
-            keys = "observation reward done info".split()
-            vals = [obs, rew, done, info]
+            keys = "observation reward terminated truncated info".split()
+            vals = [obs, rew, terminated, truncated, info]
             for k, v in zip(keys, vals):
                 key_set = set(v.keys())
                 if key_set == agents_set:
@@ -73,14 +75,14 @@ def parallel_api_test(par_env, num_cycles=1000):
                 if len(key_set) < len(agents_set):
                     warnings.warn(f"Live agent was not given {k}")
                 else:
-                    warnings.warn(f"Agent was given {k} but was done last turn")
+                    warnings.warn(f"Agent was given {k} but was dead last turn")
 
             if hasattr(par_env, "possible_agents"):
                 assert set(par_env.agents).issubset(
                     set(par_env.possible_agents)
                 ), "possible_agents defined but does not contain all agents"
 
-                has_finished |= {agent for agent, d in done.items() if d}
+                has_finished |= {agent for agent, d in (terminated.items() or truncated.items()) if d}
                 if not par_env.agents and has_finished != set(par_env.possible_agents):
                     warnings.warn(
                         "No agents present but not all possible_agents are done"
@@ -96,11 +98,11 @@ def parallel_api_test(par_env, num_cycles=1000):
                     agent
                 ), "action_space should return the exact same space object (not a copy) for an agent (ensures that action space seeding works as expected). Consider decorating your action_space(self, agent) method with @functools.lru_cache(maxsize=None)"
 
-            for agent, d in done.items():
+            for agent, d in (terminated.items() or truncated.items()):
                 if d:
                     live_agents.remove(agent)
 
-            assert set(par_env.agents) == live_agents
+            #assert set(par_env.agents) == live_agents  # todo: BUG 1
 
             if len(live_agents) == 0:
                 break

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -50,7 +50,10 @@ def parallel_api_test(par_env, num_cycles=1000):
             actions = {
                 agent: sample_action(par_env, obs, agent)
                 for agent in par_env.agents
-                if ((agent in terminated and not terminated[agent]) or (agent in truncated and not truncated[agent]))
+                if (
+                    (agent in terminated and not terminated[agent])
+                    or (agent in truncated and not truncated[agent])
+                )
             }
             obs, rew, terminated, truncated, info = par_env.step(actions)
             for agent in par_env.agents:
@@ -82,7 +85,9 @@ def parallel_api_test(par_env, num_cycles=1000):
                     set(par_env.possible_agents)
                 ), "possible_agents defined but does not contain all agents"
 
-                has_finished |= {agent for agent, d in (terminated.items() or truncated.items()) if d}
+                has_finished |= {
+                    agent for agent, d in (terminated.items() or truncated.items()) if d
+                }
                 if not par_env.agents and has_finished != set(par_env.possible_agents):
                     warnings.warn(
                         "No agents present but not all possible_agents are done"
@@ -98,11 +103,11 @@ def parallel_api_test(par_env, num_cycles=1000):
                     agent
                 ), "action_space should return the exact same space object (not a copy) for an agent (ensures that action space seeding works as expected). Consider decorating your action_space(self, agent) method with @functools.lru_cache(maxsize=None)"
 
-            for agent, d in (terminated.items() or truncated.items()):
+            for agent, d in terminated.items() or truncated.items():
                 if d:
                     live_agents.remove(agent)
 
-            #assert set(par_env.agents) == live_agents  # todo: BUG 1
+            # assert set(par_env.agents) == live_agents  # todo: BUG 1
 
             if len(live_agents) == 0:
                 break

--- a/pettingzoo/test/render_test.py
+++ b/pettingzoo/test/render_test.py
@@ -10,8 +10,8 @@ def collect_render_results(env, mode):
     for i in range(5):
         if i > 0:
             for agent in env.agent_iter(env.num_agents // 2 + 1):
-                obs, reward, done, info = env.last()
-                if done:
+                obs, reward, terminated, truncated, info = env.last()
+                if terminated or truncated:
                     action = None
                 elif isinstance(obs, dict) and "action_mask" in obs:
                     action = random.choice(np.flatnonzero(obs["action_mask"]))

--- a/pettingzoo/test/seed_test.py
+++ b/pettingzoo/test/seed_test.py
@@ -24,8 +24,8 @@ def calc_hash(new_env, rand_issue, max_env_iters):
             random.randint(0, 1000)
             np.random.normal(size=100)
         for agent in new_env.agent_iter(max_env_iters):
-            obs, rew, done, info = new_env.last()
-            if done:
+            obs, rew, terminated, truncated, info = new_env.last()
+            if terminated or truncated:
                 action = None
             elif isinstance(obs, dict) and "action_mask" in obs:
                 action = sampler.choice(np.flatnonzero(obs["action_mask"]))

--- a/pettingzoo/test/state_test.py
+++ b/pettingzoo/test/state_test.py
@@ -47,8 +47,8 @@ def test_state(env, num_cycles):
     env.reset()
     state_0 = env.state()
     for agent in env.agent_iter(env.num_agents * num_cycles):
-        observation, reward, done, info = env.last(observe=False)
-        if done:
+        observation, reward, terminated, truncated, info = env.last(observe=False)
+        if terminated or truncated:
             action = None
         else:
             action = env.action_space(agent).sample()

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -123,7 +123,7 @@ class aec_to_parallel_wrapper(ParallelEnv):
         observations = {
             agent: self.aec_env.observe(agent)
             for agent in self.aec_env.agents
-            if not self.aec_env.dones[agent]
+            if not (self.aec_env.terminations[agent] or self.aec_env.truncations[agent])
         }
 
         if not return_info:

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -134,34 +134,36 @@ class aec_to_parallel_wrapper(ParallelEnv):
 
     def step(self, actions):
         rewards = defaultdict(int)
-        dones = {}
+        terminations = {}
+        truncations = {}
         infos = {}
         observations = {}
         for agent in self.aec_env.agents:
             if agent != self.aec_env.agent_selection:
-                if self.aec_env.dones[agent]:
+                if (self.aec_env.terminations[agent] or self.aec_env.truncations[agent]):
                     raise AssertionError(
-                        f"expected agent {agent} got done agent {self.aec_env.agent_selection}. Parallel environment wrapper expects all agent termination (setting an agent's self.dones entry to True) to happen only at the end of a cycle."
+                        f"expected agent {agent} got termination or truncation agent {self.aec_env.agent_selection}. Parallel environment wrapper expects all agent death (setting an agent's self.terminations or self.truncations entry to True) to happen only at the end of a cycle."
                     )
                 else:
                     raise AssertionError(
                         f"expected agent {agent} got agent {self.aec_env.agent_selection}, Parallel environment wrapper expects agents to step in a cycle."
                     )
-            obs, rew, done, info = self.aec_env.last()
+            obs, rew, termination, truncation, info = self.aec_env.last()
             self.aec_env.step(actions[agent])
             for agent in self.aec_env.agents:
                 rewards[agent] += self.aec_env.rewards[agent]
 
-        dones = dict(**self.aec_env.dones)
+        terminations = dict(**self.aec_env.terminations)
+        truncations = dict(**self.aec_env.truncations)
         infos = dict(**self.aec_env.infos)
         observations = {
             agent: self.aec_env.observe(agent) for agent in self.aec_env.agents
         }
-        while self.aec_env.agents and self.aec_env.dones[self.aec_env.agent_selection]:
+        while self.aec_env.agents and (self.aec_env.terminations[self.aec_env.agent_selection] or self.aec_env.truncations[self.aec_env.agent_selection]):
             self.aec_env.step(None)
 
         self.agents = self.aec_env.agents
-        return observations, rewards, dones, infos
+        return observations, rewards, terminations, truncations, infos
 
     def render(self, mode="human"):
         return self.aec_env.render(mode)
@@ -234,7 +236,8 @@ class parallel_to_aec_wrapper(AECEnv):
         self._actions = {agent: None for agent in self.agents}
         self._agent_selector = agent_selector(self._live_agents)
         self.agent_selection = self._agent_selector.reset()
-        self.dones = {agent: False for agent in self.agents}
+        self.terminations = {agent: False for agent in self.agents}
+        self.truncations = {agent: False for agent in self.agents}
         self.infos = {agent: {} for agent in self.agents}
         self.rewards = {agent: 0 for agent in self.agents}
         self._cumulative_rewards = {agent: 0 for agent in self.agents}
@@ -252,21 +255,23 @@ class parallel_to_aec_wrapper(AECEnv):
         self._agent_selector.agent_order.append(new_agent)
         self.agent_selection = self._agent_selector.next()
         self.agents.append(new_agent)
-        self.dones[new_agent] = False
+        self.terminations[new_agent] = False
+        self.truncations[new_agent] = False
         self.infos[new_agent] = {}
         self.rewards[new_agent] = 0
         self._cumulative_rewards[new_agent] = 0
 
     def step(self, action):
-        if self.dones[self.agent_selection]:
+        if (self.terminations[self.agent_selection] or self.truncations[self.agent_selection]):
             del self._actions[self.agent_selection]
-            return self._was_done_step(action)
+            return self._was_dead_step(action)
         self._actions[self.agent_selection] = action
         if self._agent_selector.is_last():
-            obss, rews, dones, infos = self.env.step(self._actions)
+            obss, rews, terminations, truncations, infos = self.env.step(self._actions)
 
             self._observations = copy.copy(obss)
-            self.dones = copy.copy(dones)
+            self.terminations = copy.copy(terminations)
+            self.truncations = copy.copy(truncations)
             self.infos = copy.copy(infos)
             self.rewards = copy.copy(rews)
             self._cumulative_rewards = copy.copy(rews)
@@ -283,7 +288,7 @@ class parallel_to_aec_wrapper(AECEnv):
                 self._agent_selector = agent_selector(self.env.agents)
                 self.agent_selection = self._agent_selector.reset()
 
-            self._dones_step_first()
+            self._deads_step_first()
         else:
             if self._agent_selector.is_first():
                 self._clear_rewards()
@@ -296,7 +301,8 @@ class parallel_to_aec_wrapper(AECEnv):
         return (
             observation,
             self._cumulative_rewards[agent],
-            self.dones[agent],
+            self.terminations[agent],
+            self.truncations[agent],
             self.infos[agent],
         )
 
@@ -369,7 +375,7 @@ class turn_based_aec_to_parallel_wrapper(ParallelEnv):
         observations = {
             agent: self.aec_env.observe(agent)
             for agent in self.aec_env.agents
-            if not self.aec_env.dones[agent]
+            if not (self.aec_env.terminations[agent] or self.aec_env.truncations[agent])
         }
 
         if not return_info:
@@ -383,14 +389,15 @@ class turn_based_aec_to_parallel_wrapper(ParallelEnv):
             return {}, {}, {}, {}
         self.aec_env.step(actions[self.aec_env.agent_selection])
         rewards = {**self.aec_env.rewards}
-        dones = {**self.aec_env.dones}
+        terminations = {**self.aec_env.terminations}
+        truncations = {**self.aec_env.truncations}
         infos = {**self.aec_env.infos}
         observations = {
             agent: self.aec_env.observe(agent) for agent in self.aec_env.agents
         }
 
         while self.aec_env.agents:
-            if self.aec_env.dones[self.aec_env.agent_selection]:
+            if (self.aec_env.terminations[self.aec_env.agent_selection] or self.aec_env.truncations[self.aec_env.agent_selection]):
                 self.aec_env.step(None)
             else:
                 break
@@ -399,7 +406,7 @@ class turn_based_aec_to_parallel_wrapper(ParallelEnv):
         for agent in self.aec_env.agents:
             infos[agent]["active_agent"] = self.aec_env.agent_selection
         self.agents = self.aec_env.agents
-        return observations, rewards, dones, infos
+        return observations, rewards, terminations, truncations, infos
 
     def render(self, mode="human"):
         return self.aec_env.render(mode)

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -140,7 +140,7 @@ class aec_to_parallel_wrapper(ParallelEnv):
         observations = {}
         for agent in self.aec_env.agents:
             if agent != self.aec_env.agent_selection:
-                if (self.aec_env.terminations[agent] or self.aec_env.truncations[agent]):
+                if self.aec_env.terminations[agent] or self.aec_env.truncations[agent]:
                     raise AssertionError(
                         f"expected agent {agent} got termination or truncation agent {self.aec_env.agent_selection}. Parallel environment wrapper expects all agent death (setting an agent's self.terminations or self.truncations entry to True) to happen only at the end of a cycle."
                     )
@@ -159,7 +159,10 @@ class aec_to_parallel_wrapper(ParallelEnv):
         observations = {
             agent: self.aec_env.observe(agent) for agent in self.aec_env.agents
         }
-        while self.aec_env.agents and (self.aec_env.terminations[self.aec_env.agent_selection] or self.aec_env.truncations[self.aec_env.agent_selection]):
+        while self.aec_env.agents and (
+            self.aec_env.terminations[self.aec_env.agent_selection]
+            or self.aec_env.truncations[self.aec_env.agent_selection]
+        ):
             self.aec_env.step(None)
 
         self.agents = self.aec_env.agents
@@ -262,7 +265,10 @@ class parallel_to_aec_wrapper(AECEnv):
         self._cumulative_rewards[new_agent] = 0
 
     def step(self, action):
-        if (self.terminations[self.agent_selection] or self.truncations[self.agent_selection]):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             del self._actions[self.agent_selection]
             return self._was_dead_step(action)
         self._actions[self.agent_selection] = action
@@ -397,7 +403,10 @@ class turn_based_aec_to_parallel_wrapper(ParallelEnv):
         }
 
         while self.aec_env.agents:
-            if (self.aec_env.terminations[self.aec_env.agent_selection] or self.aec_env.truncations[self.aec_env.agent_selection]):
+            if (
+                self.aec_env.terminations[self.aec_env.agent_selection]
+                or self.aec_env.truncations[self.aec_env.agent_selection]
+            ):
                 self.aec_env.step(None)
             else:
                 break

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -189,7 +189,7 @@ class AECEnv:
         self, observe: bool = True
     ) -> Tuple[ObsType, float, bool, bool, Dict[str, Any]]:
         """
-        Returns observation, cumulative reward, terminated, info   for the current agent (specified by self.agent_selection)
+        Returns observation, cumulative reward, terminated, truncated, info for the current agent (specified by self.agent_selection)
         """
         agent = self.agent_selection
         observation = self.observe(agent) if observe else None

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -149,7 +149,7 @@ class AECEnv:
     def max_num_agents(self) -> int:
         return len(self.possible_agents)
 
-    def _dead_step_first(self) -> AgentID:
+    def _deads_step_first(self) -> AgentID:
         """
         Makes .agent_selection point to first terminated agent. Stores old value of agent_selection
         so that _was_terminated_step can restore the variable after the terminated agent steps.

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -42,7 +42,8 @@ class AECEnv:
     action_spaces: Dict[AgentID, gym.spaces.Space]
 
     # Whether each agent has just reached a terminal state
-    dones: Dict[AgentID, bool]
+    terminations: Dict[AgentID, bool]
+    truncations: Dict[AgentID, bool]
     rewards: Dict[AgentID, float]  # Reward from the last step for each agent
     # Cumulative rewards for each agent
     _cumulative_rewards: Dict[AgentID, float]
@@ -148,15 +149,15 @@ class AECEnv:
     def max_num_agents(self) -> int:
         return len(self.possible_agents)
 
-    def _dones_step_first(self) -> AgentID:
+    def _dead_step_first(self) -> AgentID:
         """
-        Makes .agent_selection point to first done agent. Stores old value of agent_selection
-        so that _was_done_step can restore the variable after the done agent steps.
+        Makes .agent_selection point to first terminated agent. Stores old value of agent_selection
+        so that _was_terminated_step can restore the variable after the terminated agent steps.
         """
-        _dones_order = [agent for agent in self.agents if self.dones[agent]]
-        if _dones_order:
+        _deads_order = [agent for agent in self.agents if (self.terminations[agent] or self.truncations[agent])]
+        if _deads_order:
             self._skip_agent_selection = self.agent_selection
-            self.agent_selection = _dones_order[0]
+            self.agent_selection = _deads_order[0]
         return self.agent_selection
 
     def _clear_rewards(self) -> None:
@@ -180,57 +181,59 @@ class AECEnv:
         """
         return AECIterable(self, max_iter)
 
-    def last(self, observe: bool = True) -> Tuple[ObsType, float, bool, Dict[str, Any]]:
+    def last(self, observe: bool = True) -> Tuple[ObsType, float, bool, bool, Dict[str, Any]]:
         """
-        Returns observation, cumulative reward, done, info   for the current agent (specified by self.agent_selection)
+        Returns observation, cumulative reward, terminated, info   for the current agent (specified by self.agent_selection)
         """
         agent = self.agent_selection
         observation = self.observe(agent) if observe else None
         return (
             observation,
             self._cumulative_rewards[agent],
-            self.dones[agent],
+            self.terminations[agent],
+            self.truncations[agent],
             self.infos[agent],
         )
 
-    def _was_done_step(self, action: None) -> None:
+    def _was_dead_step(self, action: None) -> None:
         """
-        Helper function that performs step() for done agents.
+        Helper function that performs step() for terminated agents.
 
         Does the following:
 
-        1. Removes done agent from .agents, .dones, .rewards, ._cumulative_rewards, and .infos
-        2. Loads next agent into .agent_selection: if another agent is done, loads that one, otherwise load next live agent
+        1. Removes dead agent from .agents, .terminations, .truncations, .rewards, ._cumulative_rewards, and .infos
+        2. Loads next agent into .agent_selection: if another agent is dead, loads that one, otherwise load next live agent
         3. Clear the rewards dict
 
         Highly recommended to use at the beginning of step as follows:
 
         def step(self, action):
-            if self.dones[self.agent_selection]:
-                self._was_done_step()
+            if self.terminations[self.agent_selection]:
+                self._was_terminated_step()
                 return
             # main contents of step
         """
         if action is not None:
-            raise ValueError("when an agent is done, the only valid action is None")
+            raise ValueError("when an agent is dead, the only valid action is None")
 
-        # removes done agent
+        # removes terminated agent
         agent = self.agent_selection
-        assert self.dones[
+        assert self.terminations[
             agent
-        ], "an agent that was not done as attempted to be removed"
-        del self.dones[agent]
+        ] or self.truncations[agent], "an agent that was not dead as attempted to be removed"
+        del self.terminations[agent]
+        del self.truncations[agent]
         del self.rewards[agent]
         del self._cumulative_rewards[agent]
         del self.infos[agent]
         self.agents.remove(agent)
 
-        # finds next done agent or loads next live agent (Stored in _skip_agent_selection)
-        _dones_order = [agent for agent in self.agents if self.dones[agent]]
-        if _dones_order:
+        # finds next terminated agent or loads next live agent (Stored in _skip_agent_selection)
+        _deads_order = [agent for agent in self.agents if (self.terminations[agent] or self.truncations[agent])]
+        if _deads_order:
             if getattr(self, "_skip_agent_selection", None) is None:
                 self._skip_agent_selection = self.agent_selection
-            self.agent_selection = _dones_order[0]
+            self.agent_selection = _deads_order[0]
         else:
             if getattr(self, "_skip_agent_selection", None) is not None:
                 self.agent_selection = self._skip_agent_selection
@@ -308,10 +311,10 @@ class ParallelEnv:
 
     def step(
         self, actions: ActionDict
-    ) -> Tuple[ObsDict, Dict[str, float], Dict[str, bool], Dict[str, dict]]:
+    ) -> Tuple[ObsDict, Dict[str, float], Dict[str, bool], Dict[str, bool], Dict[str, dict]]:
         """
         receives a dictionary of actions keyed by the agent name.
-        Returns the observation dictionary, reward dictionary, done dictionary,
+        Returns the observation dictionary, reward dictionary, terminated dictionary, truncated dictionary
         and info dictionary, where each dictionary is keyed by the agent.
         """
         raise NotImplementedError

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -154,7 +154,11 @@ class AECEnv:
         Makes .agent_selection point to first terminated agent. Stores old value of agent_selection
         so that _was_terminated_step can restore the variable after the terminated agent steps.
         """
-        _deads_order = [agent for agent in self.agents if (self.terminations[agent] or self.truncations[agent])]
+        _deads_order = [
+            agent
+            for agent in self.agents
+            if (self.terminations[agent] or self.truncations[agent])
+        ]
         if _deads_order:
             self._skip_agent_selection = self.agent_selection
             self.agent_selection = _deads_order[0]
@@ -181,7 +185,9 @@ class AECEnv:
         """
         return AECIterable(self, max_iter)
 
-    def last(self, observe: bool = True) -> Tuple[ObsType, float, bool, bool, Dict[str, Any]]:
+    def last(
+        self, observe: bool = True
+    ) -> Tuple[ObsType, float, bool, bool, Dict[str, Any]]:
         """
         Returns observation, cumulative reward, terminated, info   for the current agent (specified by self.agent_selection)
         """
@@ -218,9 +224,9 @@ class AECEnv:
 
         # removes terminated agent
         agent = self.agent_selection
-        assert self.terminations[
-            agent
-        ] or self.truncations[agent], "an agent that was not dead as attempted to be removed"
+        assert (
+            self.terminations[agent] or self.truncations[agent]
+        ), "an agent that was not dead as attempted to be removed"
         del self.terminations[agent]
         del self.truncations[agent]
         del self.rewards[agent]
@@ -229,7 +235,11 @@ class AECEnv:
         self.agents.remove(agent)
 
         # finds next terminated agent or loads next live agent (Stored in _skip_agent_selection)
-        _deads_order = [agent for agent in self.agents if (self.terminations[agent] or self.truncations[agent])]
+        _deads_order = [
+            agent
+            for agent in self.agents
+            if (self.terminations[agent] or self.truncations[agent])
+        ]
         if _deads_order:
             if getattr(self, "_skip_agent_selection", None) is None:
                 self._skip_agent_selection = self.agent_selection
@@ -311,7 +321,9 @@ class ParallelEnv:
 
     def step(
         self, actions: ActionDict
-    ) -> Tuple[ObsDict, Dict[str, float], Dict[str, bool], Dict[str, bool], Dict[str, dict]]:
+    ) -> Tuple[
+        ObsDict, Dict[str, float], Dict[str, bool], Dict[str, bool], Dict[str, dict]
+    ]:
         """
         receives a dictionary of actions keyed by the agent name.
         Returns the observation dictionary, reward dictionary, terminated dictionary, truncated dictionary

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -222,7 +222,7 @@ class AECEnv:
         if action is not None:
             raise ValueError("when an agent is dead, the only valid action is None")
 
-        # removes terminated agent
+        # removes dead agent
         agent = self.agent_selection
         assert (
             self.terminations[agent] or self.truncations[agent]

--- a/pettingzoo/utils/wrappers/assert_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/assert_out_of_bounds.py
@@ -18,7 +18,7 @@ class AssertOutOfBoundsWrapper(BaseWrapper):
 
     def step(self, action):
         assert (
-            action is None and self.dones[self.agent_selection]
+            action is None and (self.terminations[self.agent_selection] or self.truncations[self.agent_selection])
         ) or self.action_space(self.agent_selection).contains(
             action
         ), "action is not in action space"

--- a/pettingzoo/utils/wrappers/assert_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/assert_out_of_bounds.py
@@ -18,7 +18,11 @@ class AssertOutOfBoundsWrapper(BaseWrapper):
 
     def step(self, action):
         assert (
-            action is None and (self.terminations[self.agent_selection] or self.truncations[self.agent_selection])
+            action is None
+            and (
+                self.terminations[self.agent_selection]
+                or self.truncations[self.agent_selection]
+            )
         ) or self.action_space(self.agent_selection).contains(
             action
         ), "action is not in action space"

--- a/pettingzoo/utils/wrappers/base.py
+++ b/pettingzoo/utils/wrappers/base.py
@@ -86,7 +86,8 @@ class BaseWrapper(AECEnv):
 
         self.agent_selection = self.env.agent_selection
         self.rewards = self.env.rewards
-        self.dones = self.env.dones
+        self.terminations = self.env.terminations
+        self.truncations = self.env.truncations
         self.infos = self.env.infos
         self.agents = self.env.agents
         self._cumulative_rewards = self.env._cumulative_rewards
@@ -102,7 +103,8 @@ class BaseWrapper(AECEnv):
 
         self.agent_selection = self.env.agent_selection
         self.rewards = self.env.rewards
-        self.dones = self.env.dones
+        self.terminations = self.env.terminations
+        self.truncations = self.env.truncations
         self.infos = self.env.infos
         self.agents = self.env.agents
         self._cumulative_rewards = self.env._cumulative_rewards

--- a/pettingzoo/utils/wrappers/clip_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/clip_out_of_bounds.py
@@ -20,7 +20,7 @@ class ClipOutOfBoundsWrapper(BaseWrapper):
     def step(self, action):
         space = self.action_space(self.agent_selection)
         if not (
-            action is None and self.dones[self.agent_selection]
+            action is None and (self.terminations[self.agent_selection] or self.truncations[self.agent_selection])
         ) and not space.contains(action):
             assert (
                 space.shape == action.shape

--- a/pettingzoo/utils/wrappers/clip_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/clip_out_of_bounds.py
@@ -20,7 +20,11 @@ class ClipOutOfBoundsWrapper(BaseWrapper):
     def step(self, action):
         space = self.action_space(self.agent_selection)
         if not (
-            action is None and (self.terminations[self.agent_selection] or self.truncations[self.agent_selection])
+            action is None
+            and (
+                self.terminations[self.agent_selection]
+                or self.truncations[self.agent_selection]
+            )
         ) and not space.contains(action):
             assert (
                 space.shape == action.shape

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -43,7 +43,8 @@ class OrderEnforcingWrapper(BaseWrapper):
             )
         elif value in {
             "rewards",
-            "dones",
+            "terminations",
+            "truncations",
             "infos",
             "agent_selection",
             "num_agents",

--- a/pettingzoo/utils/wrappers/terminate_illegal.py
+++ b/pettingzoo/utils/wrappers/terminate_illegal.py
@@ -46,7 +46,7 @@ class TerminateIllegalWrapper(BaseWrapper):
             self.rewards = {d: 0 for d in self.dones}
             self.rewards[current_agent] = float(self._illegal_value)
             self._accumulate_rewards()
-            self._dones_step_first()
+            self._deads_step_first()
             self._terminated = True
         else:
             super().step(action)


### PR DESCRIPTION
**Summary**
- All MPE envs are subclasses of AECEnvs (I'm aware there's a proposal to depreciate AECEnvs for ParallelEnvs)
- Hence AECEnvs and corresponding utils have to be refactored
- Once done with the above, a naive test ran without issue*
- Obviously the tests now failed, and I tried modified them to account for truncation
- The refactored tests pass for MPE envs.

------------------------------------------

**Changelist**

- `_dones_step_first()` -> `deads_change_first()` - "done" depreciated to avoid confusion with old versions of PZ/Gym, replaced with "dead"
- `dones` -> `terminations` & `truncations` - generally, the `done` boolean is taken to now be `termination or truncation`
- `done = True` -> `truncation = True` where timeout occurs
- outputs of `env.last()` changed to return `terminated` and `truncated` instead of `done`
- relevant docstring changes
- ~~! 2 tests removed ! (they were failing, idk why, hopefully other PRs will shed light on these)~~ (fixed as of 17/08)

------------------------------------------


This is quite a rough PR atm. ~~I'd like to sort out the two bugs and~~ maybe have more tests that verify that no truncated or terminated agent can be alive. But yes, it seems like refactoring MPE isn't isolated and affects all AECEnvs. Hence we should probably:

1. Decide whether we want to keep working with AECEnvs for now or just switch to ParallelEnvs already,
2. Agree on syntax for base environments before seriously working on our individual types of environment (butterfly, magent etc.)


(*) code:
```
import time

from pettingzoo.mpe import simple_v2, simple_adversary_v2, simple_crypto_v2, simple_push_v2, simple_reference_v2, \
    simple_speaker_listener_v3, simple_spread_v2, simple_tag_v2, simple_world_comm_v2

env_objects = [simple_v2, simple_adversary_v2, simple_crypto_v2, simple_push_v2, simple_reference_v2, simple_speaker_listener_v3, simple_spread_v2, simple_tag_v2, simple_world_comm_v2]

for env_object in env_objects:
    env = env_object.env()
    env.reset()
    for agent in env.agent_iter():
        env.render()
        env.step(env.action_space(agent).sample() if not (env.terminations[agent] or env.truncations[agent]) else None)
        #time.sleep(0.1)
    env.close()
```