### PR TITLE
Classic Envs Update

### DIFF
--- a/pettingzoo/classic/backgammon/backgammon.py
+++ b/pettingzoo/classic/backgammon/backgammon.py
@@ -74,7 +74,10 @@ class raw_env(AECEnv):
         self.np_random = np.random.RandomState(seed)
 
     def step(self, action):
-        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             return self._was_dead_step(action)
 
         if action != 26**2 * 2:
@@ -90,7 +93,9 @@ class raw_env(AECEnv):
             else:
                 self.rewards[self.agent_selection] = -1
                 self.rewards[opp_agent] = 1
-            self.terminations = {i: True for i in self.agents}  # only update terminations, the game is over with winner
+            self.terminations = {
+                i: True for i in self.agents
+            }  # only update terminations, the game is over with winner
         else:
             self._clear_rewards()
 

--- a/pettingzoo/classic/backgammon/backgammon.py
+++ b/pettingzoo/classic/backgammon/backgammon.py
@@ -74,8 +74,8 @@ class raw_env(AECEnv):
         self.np_random = np.random.RandomState(seed)
 
     def step(self, action):
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+            return self._was_dead_step(action)
 
         if action != 26**2 * 2:
             action = bg_utils.to_bg_format(action, self.roll)
@@ -90,7 +90,7 @@ class raw_env(AECEnv):
             else:
                 self.rewards[self.agent_selection] = -1
                 self.rewards[opp_agent] = 1
-            self.dones = {i: True for i in self.agents}
+            self.terminations = {i: True for i in self.agents}  # only update terminations, the game is over with winner
         else:
             self._clear_rewards()
 
@@ -137,13 +137,14 @@ class raw_env(AECEnv):
         if seed is not None:
             self.seed(seed=seed)
         self.agents = self.possible_agents[:]
-        self.dones = {i: False for i in self.agents}
         self.infos = {i: {"legal_moves": []} for i in self.agents}
         self._agent_order = list(self.agents)
         self._agent_selector.reinit(self._agent_order)
         self.agent_selection = self._agent_selector.reset()
         self.rewards = {i: 0 for i in self.agents}
         self._cumulative_rewards = {i: 0 for i in self.agents}
+        self.terminations = {i: False for i in self.agents}
+        self.truncations = {i: False for i in self.agents}
         self.colors = {}
         self.double_roll = 0
         self.game = Game()

--- a/pettingzoo/classic/checkers/checkers.py
+++ b/pettingzoo/classic/checkers/checkers.py
@@ -222,7 +222,10 @@ class raw_env(AECEnv):
         return legal_moves
 
     def step(self, action):
-        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             return self._was_dead_step(action)
         if action not in self.legal_moves():
             warnings.warn(
@@ -249,7 +252,6 @@ class raw_env(AECEnv):
 
         self.terminations[self.agent_order[0]] = winner is not None
         self.terminations[self.agent_order[1]] = winner is not None
-
 
         self._accumulate_rewards()
 

--- a/pettingzoo/classic/checkers/checkers.py
+++ b/pettingzoo/classic/checkers/checkers.py
@@ -130,7 +130,8 @@ class raw_env(AECEnv):
         self.last_turn = "black"
         self.rewards = {name: 0 for name in self.agents}
         self._cumulative_rewards = {name: 0 for name in self.agents}
-        self.dones = {name: False for name in self.agents}
+        self.truncations = {name: False for name in self.agents}
+        self.terminations = {name: False for name in self.agents}
         self.winner = -1
 
     # Parse action from (256) action space into (32)x(32) action space
@@ -221,8 +222,8 @@ class raw_env(AECEnv):
         return legal_moves
 
     def step(self, action):
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+            return self._was_dead_step(action)
         if action not in self.legal_moves():
             warnings.warn(
                 "Bad checkers move made, game terminating with current player losing. \n env.infos[player]['legal_moves'] contains a list of all legal moves that can be chosen."
@@ -246,8 +247,9 @@ class raw_env(AECEnv):
             self.rewards[self.agents[0]] = -1
             self.rewards[self.agents[1]] = 1
 
-        self.dones[self.agent_order[0]] = winner is not None
-        self.dones[self.agent_order[1]] = winner is not None
+        self.terminations[self.agent_order[0]] = winner is not None
+        self.terminations[self.agent_order[1]] = winner is not None
+
 
         self._accumulate_rewards()
 

--- a/pettingzoo/classic/chess/chess.py
+++ b/pettingzoo/classic/chess/chess.py
@@ -54,6 +54,8 @@ class raw_env(AECEnv):
 
         self.rewards = None
         self.infos = {name: {} for name in self.agents}
+        self.truncations = {name: False for name in self.agents}
+        self.terminations = {name: False for name in self.agents}
 
         self.agent_selection = None
 
@@ -101,7 +103,6 @@ class raw_env(AECEnv):
     def set_game_result(self, result_val):
         for i, name in enumerate(self.agents):
             self.terminations[name] = True
-            self.truncations[name] = True
             result_coef = 1 if i == 0 else -1
             self.rewards[name] = result_val * result_coef
             self.infos[name] = {"legal_moves": []}

--- a/pettingzoo/classic/chess/chess.py
+++ b/pettingzoo/classic/chess/chess.py
@@ -108,7 +108,10 @@ class raw_env(AECEnv):
             self.infos[name] = {"legal_moves": []}
 
     def step(self, action):
-        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             return self._was_dead_step(action)
         current_agent = self.agent_selection
         current_index = self.agents.index(current_agent)

--- a/pettingzoo/classic/chess/chess.py
+++ b/pettingzoo/classic/chess/chess.py
@@ -53,7 +53,6 @@ class raw_env(AECEnv):
         }
 
         self.rewards = None
-        self.dones = None
         self.infos = {name: {} for name in self.agents}
 
         self.agent_selection = None
@@ -93,21 +92,23 @@ class raw_env(AECEnv):
 
         self.rewards = {name: 0 for name in self.agents}
         self._cumulative_rewards = {name: 0 for name in self.agents}
-        self.dones = {name: False for name in self.agents}
+        self.terminations = {name: False for name in self.agents}
+        self.truncations = {name: False for name in self.agents}
         self.infos = {name: {} for name in self.agents}
 
         self.board_history = np.zeros((8, 8, 104), dtype=bool)
 
     def set_game_result(self, result_val):
         for i, name in enumerate(self.agents):
-            self.dones[name] = True
+            self.terminations[name] = True
+            self.truncations[name] = True
             result_coef = 1 if i == 0 else -1
             self.rewards[name] = result_val * result_coef
             self.infos[name] = {"legal_moves": []}
 
     def step(self, action):
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+            return self._was_dead_step(action)
         current_agent = self.agent_selection
         current_index = self.agents.index(current_agent)
 

--- a/pettingzoo/classic/connect_four/connect_four.py
+++ b/pettingzoo/classic/connect_four/connect_four.py
@@ -105,8 +105,8 @@ class raw_env(AECEnv):
 
     # action in this case is a value from 0 to 6 indicating position to move on the flat representation of the connect4 board
     def step(self, action):
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if self.truncations[self.agent_selection] or self.terminations[self.agent_selection]:
+            return self._was_dead_step(action)
         # assert valid move
         assert self.board[0:7][action] == 0, "played illegal move."
 
@@ -124,11 +124,11 @@ class raw_env(AECEnv):
         if winner:
             self.rewards[self.agent_selection] += 1
             self.rewards[next_agent] -= 1
-            self.dones = {i: True for i in self.agents}
+            self.terminations = {i: True for i in self.agents}
         # check if there is a tie
         elif all(x in [1, 2] for x in self.board):
             # once either play wins or there is a draw, game over, both players are done
-            self.dones = {i: True for i in self.agents}
+            self.terminations = {i: True for i in self.agents}
         else:
             # no winner yet
             self.agent_selection = next_agent
@@ -142,7 +142,8 @@ class raw_env(AECEnv):
         self.agents = self.possible_agents[:]
         self.rewards = {i: 0 for i in self.agents}
         self._cumulative_rewards = {name: 0 for name in self.agents}
-        self.dones = {i: False for i in self.agents}
+        self.terminations = {i: False for i in self.agents}
+        self.truncations = {i: False for i in self.agents}
         self.infos = {i: {} for i in self.agents}
 
         self._agent_selector = agent_selector(self.agents)

--- a/pettingzoo/classic/connect_four/connect_four.py
+++ b/pettingzoo/classic/connect_four/connect_four.py
@@ -105,7 +105,10 @@ class raw_env(AECEnv):
 
     # action in this case is a value from 0 to 6 indicating position to move on the flat representation of the connect4 board
     def step(self, action):
-        if self.truncations[self.agent_selection] or self.terminations[self.agent_selection]:
+        if (
+            self.truncations[self.agent_selection]
+            or self.terminations[self.agent_selection]
+        ):
             return self._was_dead_step(action)
         # assert valid move
         assert self.board[0:7][action] == 0, "played illegal move."

--- a/pettingzoo/classic/go/go.py
+++ b/pettingzoo/classic/go/go.py
@@ -161,7 +161,10 @@ class raw_env(AECEnv):
         return {"observation": observation, "action_mask": action_mask}
 
     def step(self, action):
-        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             return self._was_dead_step(action)
         self._go = self._go.play_move(coords.from_flat(action))
         self._last_obs = self.observe(self.agent_selection)
@@ -173,7 +176,9 @@ class raw_env(AECEnv):
         )
         next_player = self._agent_selector.next()
         if self._go.is_game_over():
-            self.terminations = self._convert_to_dict([True for _ in range(self.num_agents)])
+            self.terminations = self._convert_to_dict(
+                [True for _ in range(self.num_agents)]
+            )
             self.rewards = self._convert_to_dict(
                 self._encode_rewards(self._go.result())
             )
@@ -196,8 +201,12 @@ class raw_env(AECEnv):
         self.agent_selection = self._agent_selector.reset()
         self._cumulative_rewards = self._convert_to_dict(np.array([0.0, 0.0]))
         self.rewards = self._convert_to_dict(np.array([0.0, 0.0]))
-        self.terminations = self._convert_to_dict([False for _ in range(self.num_agents)])
-        self.truncations = self._convert_to_dict([False for _ in range(self.num_agents)])
+        self.terminations = self._convert_to_dict(
+            [False for _ in range(self.num_agents)]
+        )
+        self.truncations = self._convert_to_dict(
+            [False for _ in range(self.num_agents)]
+        )
         self.infos = self._convert_to_dict([{} for _ in range(self.num_agents)])
         self.next_legal_moves = self._encode_legal_actions(self._go.all_legal_moves())
         self._last_obs = self.observe(self.agents[0])

--- a/pettingzoo/classic/go/go.py
+++ b/pettingzoo/classic/go/go.py
@@ -161,8 +161,8 @@ class raw_env(AECEnv):
         return {"observation": observation, "action_mask": action_mask}
 
     def step(self, action):
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+            return self._was_dead_step(action)
         self._go = self._go.play_move(coords.from_flat(action))
         self._last_obs = self.observe(self.agent_selection)
         current_agent_plane, opponent_agent_plane = self._encode_board_planes(
@@ -173,7 +173,7 @@ class raw_env(AECEnv):
         )
         next_player = self._agent_selector.next()
         if self._go.is_game_over():
-            self.dones = self._convert_to_dict([True for _ in range(self.num_agents)])
+            self.terminations = self._convert_to_dict([True for _ in range(self.num_agents)])
             self.rewards = self._convert_to_dict(
                 self._encode_rewards(self._go.result())
             )
@@ -196,7 +196,8 @@ class raw_env(AECEnv):
         self.agent_selection = self._agent_selector.reset()
         self._cumulative_rewards = self._convert_to_dict(np.array([0.0, 0.0]))
         self.rewards = self._convert_to_dict(np.array([0.0, 0.0]))
-        self.dones = self._convert_to_dict([False for _ in range(self.num_agents)])
+        self.terminations = self._convert_to_dict([False for _ in range(self.num_agents)])
+        self.truncations = self._convert_to_dict([False for _ in range(self.num_agents)])
         self.infos = self._convert_to_dict([{} for _ in range(self.num_agents)])
         self.next_legal_moves = self._encode_legal_actions(self._go.all_legal_moves())
         self._last_obs = self.observe(self.agents[0])

--- a/pettingzoo/classic/hanabi/hanabi.py
+++ b/pettingzoo/classic/hanabi/hanabi.py
@@ -314,8 +314,8 @@ class raw_env(AECEnv, EzPickle):
             By default a list of integers, describing the logic state of the game from the view of the agent.
             Can be a returned as a descriptive dictionary, if as_vector=False.
         """
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+            return self._was_dead_step(action)
         action = int(action)
 
         agent_on_turn = self.agent_selection
@@ -362,7 +362,8 @@ class raw_env(AECEnv, EzPickle):
 
         self.latest_observations = obs
         self.rewards = {a: reward for a in self.agents}
-        self.dones = {player_name: done for player_name in self.agents}
+        self.terminations = {player_name: done for player_name in self.agents}
+        self.truncations = {player_name: done for player_name in self.agents}
 
         # Here we have to deal with the player index with offset = 1
         self.infos = {

--- a/pettingzoo/classic/hanabi/hanabi.py
+++ b/pettingzoo/classic/hanabi/hanabi.py
@@ -314,7 +314,10 @@ class raw_env(AECEnv, EzPickle):
             By default a list of integers, describing the logic state of the game from the view of the agent.
             Can be a returned as a descriptive dictionary, if as_vector=False.
         """
-        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             return self._was_dead_step(action)
         action = int(action)
 

--- a/pettingzoo/classic/rps/rps.py
+++ b/pettingzoo/classic/rps/rps.py
@@ -92,7 +92,8 @@ class raw_env(AECEnv):
         self.agent_selection = self._agent_selector.next()
         self.rewards = {agent: 0 for agent in self.agents}
         self._cumulative_rewards = {agent: 0 for agent in self.agents}
-        self.dones = {agent: False for agent in self.agents}
+        self.terminations = {agent: False for agent in self.agents}
+        self.truncations = {agent: False for agent in self.agents}
         self.infos = {agent: {} for agent in self.agents}
 
         self.state = {agent: self._none for agent in self.agents}
@@ -316,8 +317,8 @@ class raw_env(AECEnv):
         self.reinit()
 
     def step(self, action):
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+            return self._was_dead_step(action)
         agent = self.agent_selection
 
         self.state[self.agent_selection] = action
@@ -345,7 +346,7 @@ class raw_env(AECEnv):
 
             self.num_moves += 1
 
-            self.dones = {
+            self.truncations = {
                 agent: self.num_moves >= self.max_cycles for agent in self.agents
             }
 

--- a/pettingzoo/classic/rps/rps.py
+++ b/pettingzoo/classic/rps/rps.py
@@ -317,7 +317,10 @@ class raw_env(AECEnv):
         self.reinit()
 
     def step(self, action):
-        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             return self._was_dead_step(action)
         agent = self.agent_selection
 

--- a/pettingzoo/classic/tictactoe/tictactoe.py
+++ b/pettingzoo/classic/tictactoe/tictactoe.py
@@ -90,7 +90,10 @@ class raw_env(AECEnv):
 
     # action in this case is a value from 0 to 8 indicating position to move on tictactoe board
     def step(self, action):
-        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             return self._was_dead_step(action)
         # check if input action is a valid move (0 == empty spot)
         assert self.board.squares[action] == 0, "played illegal move"

--- a/pettingzoo/classic/tictactoe/tictactoe.py
+++ b/pettingzoo/classic/tictactoe/tictactoe.py
@@ -45,7 +45,8 @@ class raw_env(AECEnv):
         }
 
         self.rewards = {i: 0 for i in self.agents}
-        self.dones = {i: False for i in self.agents}
+        self.terminations = {i: False for i in self.agents}
+        self.truncations = {i: False for i in self.agents}
         self.infos = {i: {"legal_moves": list(range(0, 9))} for i in self.agents}
 
         self._agent_selector = agent_selector(self.agents)
@@ -89,8 +90,8 @@ class raw_env(AECEnv):
 
     # action in this case is a value from 0 to 8 indicating position to move on tictactoe board
     def step(self, action):
-        if self.dones[self.agent_selection]:
-            return self._was_done_step(action)
+        if self.terminations[self.agent_selection] or self.truncations[self.agent_selection]:
+            return self._was_dead_step(action)
         # check if input action is a valid move (0 == empty spot)
         assert self.board.squares[action] == 0, "played illegal move"
         # play turn
@@ -117,7 +118,7 @@ class raw_env(AECEnv):
                 self.rewards[self.agents[0]] -= 1
 
             # once either play wins or there is a draw, game over, both players are done
-            self.dones = {i: True for i in self.agents}
+            self.terminations = {i: True for i in self.agents}
 
         # Switch selection to next agents
         self._cumulative_rewards[self.agent_selection] = 0
@@ -132,7 +133,8 @@ class raw_env(AECEnv):
         self.agents = self.possible_agents[:]
         self.rewards = {i: 0 for i in self.agents}
         self._cumulative_rewards = {i: 0 for i in self.agents}
-        self.dones = {i: False for i in self.agents}
+        self.terminations = {i: False for i in self.agents}
+        self.truncations = {i: False for i in self.agents}
         self.infos = {i: {} for i in self.agents}
         # selects the first agent
         self._agent_selector.reinit(self.agents)

--- a/pettingzoo/utils/wrappers/terminate_illegal.py
+++ b/pettingzoo/utils/wrappers/terminate_illegal.py
@@ -36,11 +36,16 @@ class TerminateIllegalWrapper(BaseWrapper):
         ), "action_mask must always be part of environment observation as an element in a dictionary observation to use the TerminateIllegalWrapper"
         _prev_action_mask = self._prev_obs["action_mask"]
         self._prev_obs = None
-        if self._terminated and (self.terminations[self.agent_selection] or self.truncations[self.agent_selection]):
+        if self._terminated and (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
             self._was_dead_step(action)
-        elif (not self.terminations[self.agent_selection] and
-            not self.truncations[self.agent_selection] and
-            not _prev_action_mask[action]):
+        elif (
+            not self.terminations[self.agent_selection]
+            and not self.truncations[self.agent_selection]
+            and not _prev_action_mask[action]
+        ):
             EnvLogger.warn_on_illegal_move()
             self._cumulative_rewards[self.agent_selection] = 0
             self.terminations = {d: True for d in self.agents}

--- a/pettingzoo/utils/wrappers/terminate_illegal.py
+++ b/pettingzoo/utils/wrappers/terminate_illegal.py
@@ -36,14 +36,17 @@ class TerminateIllegalWrapper(BaseWrapper):
         ), "action_mask must always be part of environment observation as an element in a dictionary observation to use the TerminateIllegalWrapper"
         _prev_action_mask = self._prev_obs["action_mask"]
         self._prev_obs = None
-        if self._terminated and self.dones[self.agent_selection]:
-            self._was_done_step(action)
-        elif not self.dones[self.agent_selection] and not _prev_action_mask[action]:
+        if self._terminated and (self.terminations[self.agent_selection] or self.truncations[self.agent_selection]):
+            self._was_dead_step(action)
+        elif (not self.terminations[self.agent_selection] and
+            not self.truncations[self.agent_selection] and
+            not _prev_action_mask[action]):
             EnvLogger.warn_on_illegal_move()
             self._cumulative_rewards[self.agent_selection] = 0
-            self.dones = {d: True for d in self.dones}
+            self.terminations = {d: True for d in self.agents}
+            self.truncations = {d: True for d in self.agents}
             self._prev_obs = None
-            self.rewards = {d: 0 for d in self.dones}
+            self.rewards = {d: 0 for d in self.truncations}
             self.rewards[current_agent] = float(self._illegal_value)
             self._accumulate_rewards()
             self._deads_step_first()


### PR DESCRIPTION
This update removes the use of self.dones in the Classic envs, replaces self.dones with self.terminations and self.truncations, and changes references from __was_done_step to _was_dead_step. There is also an update to pettingzoo/utils/wrappers/terminate_illegal.py that removes self.dones and uses self.terminations and self.truncations