### PR TITLE
fix wrapper unwrapped thing

### DIFF
--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -190,7 +190,12 @@ class parallel_to_aec_wrapper(AECEnv):
         self.metadata = {**parallel_env.metadata}
         self.metadata["is_parallelizable"] = True
 
-        self.render_mode = self.env.render_mode
+        try:
+            self.render_mode = self.env.render_mode
+        except:
+            warnings.warn(
+                f"The base environment `{parallel_env}` does not have a `render_mode` defined."
+            )
 
         try:
             self.possible_agents = parallel_env.possible_agents


### PR DESCRIPTION
This fixes supersuit failing because some envs don't have render_mode that we're not enforcing, currently it's just implemented as a warning.