### PR TITLE
Docs update

### DIFF
--- a/docs/api/aec.md
+++ b/docs/api/aec.md
@@ -1,4 +1,4 @@
-# Core API
+# AEC Env API
 
 ```{eval-rst}
 .. currentmodule:: pettingzoo.utils.env

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ tutorials/rllib/pistonball
 :hidden:
 :caption: API
 
-api/core
+api/aec
 api/parallel
 api/pz_wrappers
 api/supersuit_wrappers


### PR DESCRIPTION
- [x] * Rename "Core API" to "AEC Env API"
- [ ] * AEC Env attribute should have the type hints with the variables https://gymnasium.farama.org/api/core/#gymnasium.Env.action_space
- [ ] * AEC Env split attributes and functions on the content table to the right. See gymnasium core
- [ ] * Parallel content table Example usage is greater than ParallelEnv
- [ ] * PettingZoo wrappers should have the __init__ of the wrappers I think
- [ ] * Supersuit wrappers should have content table with all of the wrappers
- [ ] *  https://pettingzoo.farama.org/content/basic_usage/#additional-environment-api should this not be in Core API
- [ ] * Should Environment creation be in the tutorial section
- [x] * Tutorials need comments to explain the decisions made