### PR TITLE
change paradigm of parallel api loops

### DIFF
--- a/docs/api/parallel.md
+++ b/docs/api/parallel.md
@@ -9,8 +9,8 @@ Environments can be interacted with as follows:
 ``` python
 parallel_env = pistonball_v6.parallel_env()
 observations = parallel_env.reset()
-max_cycles = 500
-for step in range(max_cycles):
+
+while env.agents:
     actions = {agent: parallel_env.action_space(agent).sample() for agent in parallel_env.agents}  # this is where you would insert your policy
     observations, rewards, terminations, truncations, infos = parallel_env.step(actions)
 ```


### PR DESCRIPTION
I didn't like how we used `for step in range(max_cycles)` before, now that we have `truncation`.
