### PR TITLE
Fix: set render_mode in tianshou tutorials (#853)

### DIFF
--- a/tutorials/Tianshou/1_basic_api_usage.py
+++ b/tutorials/Tianshou/1_basic_api_usage.py
@@ -17,10 +17,10 @@ from pettingzoo.classic import rps_v2
 
 if __name__ == "__main__":
     # Step 1: Load the PettingZoo environment
-    env = rps_v2.env()
+    env = rps_v2.env(render_mode="human")
 
     # Step 2: Wrap the environment for Tianshou interfacing
-    env = PettingZooEnv(rps_v2.env())
+    env = PettingZooEnv(env)
 
     # Step 3: Define policies for each agent
     policies = MultiAgentPolicyManager([RandomPolicy(), RandomPolicy()], env)

--- a/tutorials/Tianshou/3_cli_and_logging.py
+++ b/tutorials/Tianshou/3_cli_and_logging.py
@@ -147,8 +147,8 @@ def get_agents(
     return policy, optim, env.agents
 
 
-def get_env():
-    return PettingZooEnv(tictactoe_v3.env())
+def get_env(render_mode=None):
+    return PettingZooEnv(tictactoe_v3.env(render_mode=render_mode))
 
 
 def train_agent(
@@ -241,7 +241,7 @@ def watch(
     agent_learn: Optional[BasePolicy] = None,
     agent_opponent: Optional[BasePolicy] = None,
 ) -> None:
-    env = get_env()
+    env = DummyVectorEnv([lambda: get_env(render_mode="human")])
     policy, optim, agents = get_agents(
         args, agent_learn=agent_learn, agent_opponent=agent_opponent
     )
@@ -257,4 +257,4 @@ if __name__ == "__main__":
     # train the agent and watch its performance in a match!
     args = get_args()
     result, agent = train_agent(args)
-    # watch(args, agent)
+    watch(args, agent)


### PR DESCRIPTION
# Description

Set render_mode in tianshou tutorials when environment initialization is performed, which otherwise would cause the following error:
```
pettingzoo/classic/rps/rps.py", line 228, in render
   gymnasium.logger.WARN(
TypeError: 'int' object is not callable.
```
Fixes #853 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
