### PR TITLE
Waterworld_v4: Fixed incorrect pursuer being selected when adding rewards

### DIFF
--- a/pettingzoo/sisl/waterworld/waterworld_base.py
+++ b/pettingzoo/sisl/waterworld/waterworld_base.py
@@ -450,7 +450,7 @@ class WaterworldBase:
             self.last_obs = obs_list
 
             for id in range(self.n_pursuers):
-                p = self.pursuers[agent_id]
+                p = self.pursuers[id]
 
                 # reward for food caught, encountered and poison
                 self.behavior_rewards[id] = (


### PR DESCRIPTION
# Description

Fixed the same pursuer always being selected when calculating `behavior_rewards`, leading to one agent always getting all the reward.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have run `pytest -v` and no errors are present.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
