### PR TITLE
Add information about MAgent2 standalone package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: codespell
         args:
           - --skip=*.css,*.js,*.map,*.scss,*svg
+          - --ignore-words-list=magent
   - repo: https://gitlab.com/PyCQA/flake8
     rev: 5.0.4
     hooks:

--- a/pettingzoo/magent/README.md
+++ b/pettingzoo/magent/README.md
@@ -1,0 +1,1 @@
+MAgent has been moved into its own package: MAgent2. Install with `pip install magent2`. For more information on the MAgent2 package, see https://magent2.farama.org/.

--- a/pettingzoo/magent/__init__.py
+++ b/pettingzoo/magent/__init__.py
@@ -1,0 +1,3 @@
+raise ImportError(
+    "MAgent has been moved into its own package: MAgent2. Install with `pip install magent2`. For more information on the MAgent2 package, see https://magent2.farama.org/."
+)


### PR DESCRIPTION
Communicates to users trying to import magent that it has been moved to a new location.

Note that the website https://magent2.farama.org/ isn't up yet. It should be in the next day or so.