### PR TITLE
Fixed: black screen rendering for MPE env in rgb_array mode

### DIFF
--- a/pettingzoo/mpe/_mpe_utils/simple_env.py
+++ b/pettingzoo/mpe/_mpe_utils/simple_env.py
@@ -280,9 +280,10 @@ class SimpleEnv(AECEnv):
         if self.render_mode == "rgb_array":
             observation = np.array(pygame.surfarray.pixels3d(self.screen))
             return np.transpose(observation, axes=(1, 0, 2))
-        if self.render_mode == "human":
+        elif self.render_mode == "human":
             pygame.display.flip()
-        return None
+            return
+        
 
     def draw(self):
         # clear screen

--- a/pettingzoo/mpe/_mpe_utils/simple_env.py
+++ b/pettingzoo/mpe/_mpe_utils/simple_env.py
@@ -276,15 +276,13 @@ class SimpleEnv(AECEnv):
 
         self.enable_render(self.render_mode)
 
-        observation = np.array(pygame.surfarray.pixels3d(self.screen))
+        self.draw()
+        if self.render_mode == "rgb_array":
+            observation = np.array(pygame.surfarray.pixels3d(self.screen))
+            return np.transpose(observation, axes=(1, 0, 2))
         if self.render_mode == "human":
-            self.draw()
             pygame.display.flip()
-        return (
-            np.transpose(observation, axes=(1, 0, 2))
-            if self.render_mode == "rgb_array"
-            else None
-        )
+        return None
 
     def draw(self):
         # clear screen


### PR DESCRIPTION
# Description

Fixes #864 by drawing on pygame screen before extracting the image for `rgb_array` mode. Only calls `pygame.surfarray.pixels3d` when needed.

Not sure if a new unit test is needed, can add if necessary !

## Type of change

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

> Please attach before and after screenshots of the change if applicable.

Before:
<img src="https://user-images.githubusercontent.com/33727915/210183057-43f513ed-67e4-42f7-a94a-2420d4b8c937.png" alt="drawing" width=500/>

After:
<img src="https://user-images.githubusercontent.com/33727915/210183058-7425b46e-9143-44a7-8d55-0895c4d22df1.png" alt="drawing" width=500/>

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
