### PR TITLE
Fix typo: `BaseParallelWraper` renamed to `BaseParallelWrapper`

### DIFF
--- a/pettingzoo/utils/__init__.py
+++ b/pettingzoo/utils/__init__.py
@@ -6,7 +6,7 @@ from .random_demo import random_demo
 from .save_observation import save_observation
 from .wrappers import (
     AssertOutOfBoundsWrapper,
-    BaseParallelWraper,
+    BaseParallelWrapper,
     BaseWrapper,
     CaptureStdoutWrapper,
     ClipOutOfBoundsWrapper,

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -1,6 +1,6 @@
 from .assert_out_of_bounds import AssertOutOfBoundsWrapper
 from .base import BaseWrapper
-from .base_parallel import BaseParallelWraper
+from .base_parallel import BaseParallelWrapper
 from .capture_stdout import CaptureStdoutWrapper
 from .clip_out_of_bounds import ClipOutOfBoundsWrapper
 from .order_enforcing import OrderEnforcingWrapper

--- a/pettingzoo/utils/wrappers/base_parallel.py
+++ b/pettingzoo/utils/wrappers/base_parallel.py
@@ -5,7 +5,7 @@ from gymnasium.utils import seeding
 from ..env import ParallelEnv
 
 
-class BaseParallelWraper(ParallelEnv):
+class BaseParallelWrapper(ParallelEnv):
     def __init__(self, env):
         self.env = env
 


### PR DESCRIPTION
# Description
As title, fix typo of `BaseParallelWrapper` (previously `BaseParallelWraper`). Linked to its SuperSuit counterpart https://github.com/Farama-Foundation/SuperSuit/pull/204.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
