### PR TITLE
Remove 3.11 tests

### DIFF
--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
       # - uses: openrndr/setup-opengl@v1.1


### PR DESCRIPTION
AutoROM broken with 3.11, test up to 3.10 (current version of python shipped w ubuntu)