### PR TITLE
Update simple_spread agent reward

### DIFF
--- a/pettingzoo/mpe/simple_spread/simple_spread.py
+++ b/pettingzoo/mpe/simple_spread/simple_spread.py
@@ -164,6 +164,8 @@ class Scenario(BaseScenario):
         rew = 0
         if agent.collide:
             for a in world.agents:
+                if(agent == a):
+                    continue
                 if self.is_collision(a, agent):
                     rew -= 1
         return rew

--- a/pettingzoo/mpe/simple_spread/simple_spread.py
+++ b/pettingzoo/mpe/simple_spread/simple_spread.py
@@ -164,10 +164,7 @@ class Scenario(BaseScenario):
         rew = 0
         if agent.collide:
             for a in world.agents:
-                if(agent == a):
-                    continue
-                if self.is_collision(a, agent):
-                    rew -= 1
+                rew -= 1.0 * (self.is_collision(a, agent) and a != agent)
         return rew
 
     def global_reward(self, world):


### PR DESCRIPTION
# Description
The non-global reward function for individual agents is -1 for each agent it collides with. The agent would always get a reward of -1 for colliding with itself which does not make sense. I've added a check to not consider an agent colliding with itself.

## Type of change
- Bug fix 

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
