### PR TITLE
Bug fixed related to a scalar np.array

### DIFF
--- a/pettingzoo/test/api_test.py
+++ b/pettingzoo/test/api_test.py
@@ -24,6 +24,8 @@ list and observation_spaces, action_spaces dictionaries."""
 
 def test_observation(observation, observation_0):
     if isinstance(observation, np.ndarray):
+        if observation.shape == ():
+            return # or check something.. TODO:
         if np.isinf(observation).any():
             warnings.warn(
                 "Observation contains infinity (np.inf) or negative infinity (-np.inf)"
@@ -297,11 +299,12 @@ def play_test(env, observation_0, num_cycles):
             assert env.observation_space(agent).dtype == prev_observe.dtype
         assert env.observation_space(agent).contains(
             prev_observe
-        ), "Out of bounds observation: " + str(prev_observe)
+        ) or env.observation_space(agent).contains(prev_observe[()]), "Out of bounds observation: " + str(prev_observe)
 
+        # Why the same assertion again???
         assert env.observation_space(agent).contains(
             prev_observe
-        ), "Agent's observation is outside of it's observation space"
+        ) or env.observation_space(agent).contains(prev_observe[()]), "Agent's observation is outside of it's observation space"
         test_observation(prev_observe, observation_0)
         if not isinstance(env.infos[env.agent_selection], dict):
             warnings.warn(


### PR DESCRIPTION
# Description

```
def test_evaluate():

  env = CollectCoinsEnv(pieces=['rock', 'rock'])

  action = None

  def another_action_taken(action_taken):
    nonlocal action
    action = action_taken

  # Wrapping the original environment as to make sure a valid action will be taken.
  env = EnsureValidAction(
      env,
      env.check_action_valid,
      env.provide_alternative_valid_action,
      another_action_taken
  )

  api_test(env, num_cycles=10, verbose_progress=False)

```

```
    obs_space = dict(
      board = gym.spaces.MultiBinary([8, 8]),
      player = gym.spaces.Tuple([gym.spaces.Discrete(8)] * 2),
      other_player = gym.spaces.Tuple([gym.spaces.Discrete(8)] * 2)
    )    
    self._observation_space = gym.spaces.Dict(spaces=obs_space)
    self._action_space = gym.spaces.Tuple([gym.spaces.Discrete(8)] * 2)

...

  # this cache ensures that same space object is returned for the same agent
  # allows action space seeding to work as expected
  @functools.lru_cache(maxsize=None)
  def observation_space(self, agent):
      # gymnasium spaces are defined and documented here: https://gymnasium.farama.org/api/spaces/
      return self._observation_space

  @functools.lru_cache(maxsize=None)
  def action_space(self, agent):
      return self._action_space
```

While I am aware of the concept of "action_mask", I still do it with the following wrapper.

```
from typing import TypeVar, Callable
import gymnasium as gym
from .action_wrapper_pz import ActionWrapper


Action = TypeVar("Action")


class EnsureValidAction(ActionWrapper):
  """
  A gym environment wrapper to help with the case that the agent wants to take invalid actions.
  For example consider a Chess game, where you let the action_space be any piece moving to any square on the board,
  but then when a wrong move is taken, instead of returing a big negative reward, you just take another action,
  this time a valid one. To make sure the learning algorithm is aware of the action taken, a callback should be provided.
  """
  def __init__(self, env: gym.Env,
    check_action_valid: Callable[[Action], bool],
    provide_alternative_valid_action: Callable[[Action], Action],
    alternative_action_cb: Callable[[Action], None]):

    super().__init__(env)
    self.check_action_valid = check_action_valid
    self.provide_alternative_valid_action = provide_alternative_valid_action
    self.alternative_action_cb = alternative_action_cb

  def action(self, action: Action) -> Action:
    if self.check_action_valid(action):
      return action
    alternative_action = self.provide_alternative_valid_action(action)
    self.alternative_action_cb(alternative_action)
    return alternative_action
```

```
from pettingzoo.utils.wrappers import BaseWrapper
import gymnasium as gym


class ActionWrapper(BaseWrapper):
  def __init__(self, env: gym.Env):
    super().__init__(env)

  def step(self, action):
    action = self.action(action)
    self.env.step(action)

  def action(self, action):
    pass

  def render(self, *args, **kwargs):
    self.env.render(*args, **kwargs)
```

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
