### PR TITLE
Add parallel_seed_test to pettingzoo/test/__init__.py

### DIFF
--- a/pettingzoo/test/__init__.py
+++ b/pettingzoo/test/__init__.py
@@ -7,4 +7,5 @@ from .performance_benchmark import performance_benchmark
 from .render_test import collect_render_results, render_test
 from .save_obs_test import test_save_obs
 from .seed_test import seed_test
+from .seed_test import parallel_seed_test
 from .state_test import state_test


### PR DESCRIPTION
# Description

`parallel_seed_test` was added in response to #529 but wasn't included in the `__init__.py`. This lets users use it with `from pettingzoo.test import parallel_seed_test`, as per the tutorial.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

