### PR TITLE
Fix typo in EnvironmentCreation tutorial

### DIFF
--- a/tutorials/EnvironmentCreation/2-AddingGameLogic.py
+++ b/tutorials/EnvironmentCreation/2-AddingGameLogic.py
@@ -81,6 +81,7 @@ class CustomEnvironment(ParallelEnv):
         if self.timestep > 100:
             rewards = {"prisoner": 0, "guard": 0}
             truncations = {"prisoner": True, "guard": True}
+            self.agents = []
         self.timestep += 1
 
         # Get observations


### PR DESCRIPTION
# Description

Very minor fix, just updating the tutorial as mentioned in https://github.com/Farama-Foundation/PettingZoo/issues/881, to remove the agents from the environment when the game has terminated (otherwise it leads to issues with API tests, and it led them astray copying this incomplete example code). 

Fixes #881 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
