### PR TITLE
Add example usage to documentation, minor bugfixes to environments

### DIFF
--- a/docs/environments/atari.md
+++ b/docs/environments/atari.md
@@ -40,6 +40,30 @@ The Atari environments are based off the [Arcade Learning Environment](https://g
     :file: atari/list.html
 ```
 
+### Installation
+
+The unique dependencies for this set of environments can be installed via:
+
+````bash
+pip install pettingzoo[atari]
+````
+
+Install ROMs using [AutoROM](https://github.com/Farama-Foundation/AutoROM), or specify the path to your Atari rom using the `rom_path` argument (see [Common Parameters](#common-parameters)).
+
+### Usage
+
+To launch a [Space Invaders](https://pettingzoo.farama.org/environments/atari/space_invaders/) environment with agents taking random actions:
+``` python
+from pettingzoo.atari import space_invaders_v2
+env = space_invaders_v2.env(render_mode="human")
+
+env.reset()
+for agent in env.agent_iter():
+    observation, reward, termination, truncation, info = env.last()
+    action = None if termination or truncation else env.action_space(agent).sample()  # this is where you would insert your policy
+    env.step(action)
+```
+
 ### Games Overview
 
 Most games have two players, with the exception of Warlords and a couple of Pong variations which have four players.

--- a/docs/environments/butterfly.md
+++ b/docs/environments/butterfly.md
@@ -16,11 +16,14 @@ butterfly/pistonball
     :file: butterfly/list.html
 ```
 
-All butterfly environments were created by us using PyGame with visual Atari spaces. In Prison, all agents are completely independent (i.e. no coordination is possible, each agent is in it's own cell). It is intended as a debugging tool.
+Butterfly environments are challenging scenarios created by Farama, using Pygame with visual Atari spaces. 
 
-All other environments require a high degree of coordination and require learning of emergent behaviors to achieve an optimal policy. As such, these environments are currently very challenging to learn.
+All environments require a high degree of coordination and require learning of emergent behaviors to achieve an optimal policy. As such, these environments are currently very challenging to learn.
 
-All environments are highly configurable via arguments specified in each environment's documentation.
+Environments are highly configurable via arguments specified in their respective documentation:
+[Cooperative Pong](https://pettingzoo.farama.org/environments/butterfly/cooperative_pong/),
+[Knights Archers Zombies](https://pettingzoo.farama.org/environments/butterfly/knights_archers_zombies/),
+[Pistonball](https://pettingzoo.farama.org/environments/butterfly/pistonball/).
 
 ### Installation 
 The unique dependencies for this set of environments can be installed via:

--- a/docs/environments/butterfly.md
+++ b/docs/environments/butterfly.md
@@ -16,14 +16,53 @@ butterfly/pistonball
     :file: butterfly/list.html
 ```
 
+All butterfly environments were created by us using PyGame with visual Atari spaces. In Prison, all agents are completely independent (i.e. no coordination is possible, each agent is in it's own cell). It is intended as a debugging tool.
+
+All other environments require a high degree of coordination and require learning of emergent behaviors to achieve an optimal policy. As such, these environments are currently very challenging to learn.
+
+All environments are highly configurable via arguments specified in each environment's documentation.
+
+### Installation 
 The unique dependencies for this set of environments can be installed via:
 
 ````bash
 pip install pettingzoo[butterfly]
 ````
 
-All butterfly environments were created by us using PyGame with visual Atari spaces. In Prison, all agents are completely independent (i.e. no coordination is possible, each agent is in it's own cell). It is intended as a debugging tool.
+### Usage
 
-All other environments require a high degree of coordination and require learning of emergent behaviors to achieve an optimal policy. As such, these environments are currently very challenging to learn.
+To launch a [Pistonball](https://pettingzoo.farama.org/environments/butterfly/pistonball/) environment with agents taking random actions:
+``` python
+from pettingzoo.butterfly import pistonball_v6
+env = pistonball_v6.parallel_env(render_mode="human")
 
-All environments are highly configurable via arguments specified in each environment's documentation.
+env.reset()
+while env.agents:
+    actions = {agent: env.action_space(agent).sample() for agent in env.possible_agents}
+    observations, rewards, terminations, truncations, infos = env.step(actions)
+    env.step(actions)
+```
+
+To launch a [Knights Archers Zombies](https://pettingzoo.farama.org/environments/butterfly/knights_archers_zombies/) environment with interactive user input (see [manual_policy.py](https://github.com/Farama-Foundation/PettingZoo/blob/master/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py), controls are WASD and space):
+``` python
+import pygame
+from pettingzoo.butterfly import knights_archers_zombies_v10
+
+env = knights_archers_zombies_v10.env(render_mode="human")
+env.reset()
+
+clock = pygame.time.Clock()
+manual_policy = knights_archers_zombies_v10.ManualPolicy(env)
+
+for agent in env.agent_iter():
+    clock.tick(env.metadata["render_fps"])
+
+    observation, reward, termination, truncation, info = env.last()
+    if agent == manual_policy.agent:
+        action = manual_policy(observation, agent)
+    else:
+        action = env.action_space(agent).sample()
+
+    env.step(action)
+```
+

--- a/docs/environments/classic.md
+++ b/docs/environments/classic.md
@@ -23,13 +23,35 @@ classic/tictactoe
     :file: classic/list.html
 ```
 
+Classic environments represent implementations of popular turn-based human games and are mostly competitive. 
+
+
+### Installation
+
 The unique dependencies for this set of environments can be installed via:
 
 ````bash
 pip install pettingzoo[classic]
 ````
 
-Classic environments represent implementations of popular turn-based human games and are mostly competitive. The classic environments have a few differences from others in this library:
+### Usage
+
+To launch a [Texas Holdem](https://pettingzoo.farama.org/environments/classic/texas_holdem/) environment with agents taking random actions:
+``` python
+from pettingzoo.classic import texas_holdem_v4
+env = texas_holdem_v4.env(render_mode="human")
+
+env.reset()
+for agent in env.agent_iter():
+    observation, reward, termination, truncation, info = env.last()
+    if termination or truncation:
+        action = None
+    else:
+        action = env.action_space(agent).sample(observation["action_mask"])  # this is where you would insert your policy
+    env.step(action)
+```
+
+The classic environments have a few differences from others in this library:
 
 * No classic environments currently take any environment arguments.
 * All classic environments are rendered solely via printing to terminal.

--- a/docs/environments/mpe.md
+++ b/docs/environments/mpe.md
@@ -21,15 +21,34 @@ mpe/simple_world_comm
     :file: mpe/list.html
 ```
 
+Multi Particle Environments (MPE) are a set of communication oriented environment where particle agents can (sometimes) move, communicate, see each other, push each other around, and interact with fixed landmarks.
+
+These environments are from [OpenAI's MPE](https://github.com/openai/multiagent-particle-envs) codebase, with several minor fixes, mostly related to making the action space discrete by default, making the rewards consistent and cleaning up the observation space of certain environments.
+
+### Installation
+
 The unique dependencies for this set of environments can be installed via:
 
 ````bash
 pip install pettingzoo[mpe]
 ````
 
-Multi Particle Environments (MPE) are a set of communication oriented environment where particle agents can (sometimes) move, communicate, see each other, push each other around, and interact with fixed landmarks.
+### Usage
+To launch a [Simple Tag](https://pettingzoo.farama.org/environments/mpe/simple_tag/) environment with agents taking random actions:
 
-These environments are from [OpenAI's MPE](https://github.com/openai/multiagent-particle-envs) codebase, with several minor fixes, mostly related to making the action space discrete by default, making the rewards consistent and cleaning up the observation space of certain environments.
+``` python
+from pettingzoo.mpe import simple_tag_v2
+env = simple_tag_v2.env(render_mode='human')
+
+env.reset()
+for agent in env.agent_iter():
+    observation, reward, termination, truncation, info = env.last()
+    if termination or truncation:
+        action = None
+    else:
+        action = env.action_space(agent).sample()
+    env.step(action)
+```
 
 ### Types of Environments
 

--- a/docs/environments/sisl.md
+++ b/docs/environments/sisl.md
@@ -16,13 +16,32 @@ sisl/waterworld
     :file: sisl/list.html
 ```
 
+The SISL environments are a set of three cooperative multi-agent benchmark environments, created at SISL (Stanford Intelligent Systems Laboratory)) and released as part of "Cooperative multi-agent control using deep reinforcement learning." The code was originally released at: https://github.com/sisl/MADRL
+
+### Installation
+
 The unique dependencies for this set of environments can be installed via:
 
 ````bash
 pip install pettingzoo[sisl]
 ````
 
-The SISL environments are a set of three cooperative multi-agent benchmark environments, created at SISL (Stanford Intelligent Systems Laboratory)) and released as part of "Cooperative multi-agent control using deep reinforcement learning." The code was originally released at: https://github.com/sisl/MADRL
+### Usage
+To launch a [Waterworld](https://pettingzoo.farama.org/environments/sisl/waterworld/) environment with agents taking random actions:
+
+```python
+from pettingzoo.sisl import waterworld_v4
+env = waterworld_v4.env(render_mode='human')
+
+env.reset()
+for agent in env.agent_iter():
+    observation, reward, termination, truncation, info = env.last()
+    if termination or truncation:
+        action = None
+    else:
+        action = env.action_space(agent).sample()
+    env.step(action)
+```
 
 Please note that we've made major bug fixes to all environments included. As such, we discourage directly comparing results on these environments to those in the original paper.
 

--- a/pettingzoo/butterfly/cooperative_pong/manual_policy.py
+++ b/pettingzoo/butterfly/cooperative_pong/manual_policy.py
@@ -50,11 +50,10 @@ class ManualPolicy:
 if __name__ == "__main__":
     from pettingzoo.butterfly import cooperative_pong_v5
 
-    clock = pygame.time.Clock()
-
-    env = cooperative_pong_v5.env()
+    env = cooperative_pong_v5.env(render_mode="human")
     env.reset()
 
+    clock = pygame.time.Clock()
     manual_policy = cooperative_pong_v5.ManualPolicy(env)
 
     for agent in env.agent_iter():
@@ -68,8 +67,6 @@ if __name__ == "__main__":
             action = env.action_space(agent).sample()
 
         env.step(action)
-
-        env.render()
 
         if termination or truncation:
             env.reset()

--- a/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/manual_policy.py
@@ -53,11 +53,10 @@ class ManualPolicy:
 if __name__ == "__main__":
     from pettingzoo.butterfly import knights_archers_zombies_v10
 
-    clock = pygame.time.Clock()
-
-    env = knights_archers_zombies_v10.env()
+    env = knights_archers_zombies_v10.env(render_mode="human")
     env.reset()
 
+    clock = pygame.time.Clock()
     manual_policy = knights_archers_zombies_v10.ManualPolicy(env)
 
     for agent in env.agent_iter():
@@ -71,8 +70,6 @@ if __name__ == "__main__":
             action = env.action_space(agent).sample()
 
         env.step(action)
-
-        env.render()
 
         if termination or truncation:
             env.reset()

--- a/pettingzoo/butterfly/pistonball/manual_policy.py
+++ b/pettingzoo/butterfly/pistonball/manual_policy.py
@@ -51,11 +51,10 @@ class ManualPolicy:
 if __name__ == "__main__":
     from pettingzoo.butterfly import pistonball_v6
 
-    clock = pygame.time.Clock()
-
-    env = pistonball_v6.env()
+    env = pistonball_v6.env(render_mode="human")
     env.reset()
 
+    clock = pygame.time.Clock()
     manual_policy = pistonball_v6.ManualPolicy(env)
 
     for agent in env.agent_iter():
@@ -73,8 +72,6 @@ if __name__ == "__main__":
             1,
         )
         env.step(action)
-
-        env.render()
 
         if termination or truncation:
             env.reset()

--- a/pettingzoo/classic/rlcard_envs/gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/gin_rummy.py
@@ -197,6 +197,12 @@ class raw_env(RLCardBase, EzPickle):
 
         return {"observation": observation, "action_mask": action_mask}
 
+    def step(self, action):
+        super().step(action)
+
+        if self.render_mode == "human":
+            self.render()
+
     def render(self):
         if self.render_mode is None:
             gymnasium.logger.warn(

--- a/pettingzoo/classic/rlcard_envs/leduc_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/leduc_holdem.py
@@ -115,6 +115,12 @@ class raw_env(RLCardBase):
         super().__init__("leduc-holdem", num_players, (36,))
         self.render_mode = render_mode
 
+    def step(self, action):
+        super().step(action)
+
+        if self.render_mode == "human":
+            self.render()
+
     def render(self):
         if self.render_mode is None:
             gymnasium.logger.warn(

--- a/pettingzoo/classic/rlcard_envs/texas_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem.py
@@ -126,6 +126,12 @@ class raw_env(RLCardBase):
         super().__init__("limit-holdem", num_players, (72,))
         self.render_mode = render_mode
 
+    def step(self, action):
+        super().step(action)
+
+        if self.render_mode == "human":
+            self.render()
+
     def render(self):
         if self.render_mode is None:
             gymnasium.logger.warn(

--- a/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
@@ -164,6 +164,12 @@ class raw_env(RLCardBase):
 
         self.render_mode = render_mode
 
+    def step(self, action):
+        super().step(action)
+
+        if self.render_mode == "human":
+            self.render()
+
     def render(self):
         if self.render_mode is None:
             gymnasium.logger.warn(

--- a/pettingzoo/sisl/multiwalker/multiwalker.py
+++ b/pettingzoo/sisl/multiwalker/multiwalker.py
@@ -238,3 +238,6 @@ class raw_env(AECEnv, EzPickle):
         self._accumulate_rewards()
         self._deads_step_first()
         self.steps += 1
+
+        if self.render_mode == "human":
+            self.render()

--- a/pettingzoo/sisl/pursuit/pursuit.py
+++ b/pettingzoo/sisl/pursuit/pursuit.py
@@ -175,6 +175,9 @@ class raw_env(AECEnv, EzPickle):
         self.agent_selection = self._agent_selector.next()
         self._accumulate_rewards()
 
+        if self.render_mode == "human":
+            self.render()
+
     def observe(self, agent):
         o = self.env.safely_observe(self.agent_name_mapping[agent])
         return np.swapaxes(o, 2, 0)

--- a/pettingzoo/sisl/waterworld/waterworld.py
+++ b/pettingzoo/sisl/waterworld/waterworld.py
@@ -238,5 +238,8 @@ class raw_env(AECEnv):
         self.agent_selection = self._agent_selector.next()
         self._accumulate_rewards()
 
+        if self.render_mode == "human":
+            self.render()
+
     def observe(self, agent):
         return self.env.observe(self.agent_name_mapping[agent])


### PR DESCRIPTION
# Description

* Added sections Installation and Usage sections in each md file to make it more obvious how to use each of them (there have been a few questions on discord which this would help with)
* Updated RLcard envs step() functions to call render() if render_mode is set to "human" (consistent with other envs)
* Cleaned up Butterfly manual_policy examples:  supply render_mode (fixes warning when running code) and remove unnecessary render() call, and made env initialization be called first to be consistent with all other examples (group pygame and manual control code together as they are the distinct parts to the manual control examples as compared to any other example)
* Add documentation example on Butterfly for running manual_policy example (currently the only way to find this code is by digging through the files and finding the example script, also it's not clear that there even is manual control unless you click on the individual page)
* Cleaned up Butterfly documentation to remove prisoner example which no longer exists (was moved to tutorial)

## Type of change

Documentation update

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
