### PR TITLE
Add parallel_seed_test import to test init

### DIFF
--- a/pettingzoo/test/__init__.py
+++ b/pettingzoo/test/__init__.py
@@ -6,5 +6,5 @@ from .parallel_test import parallel_api_test
 from .performance_benchmark import performance_benchmark
 from .render_test import collect_render_results, render_test
 from .save_obs_test import test_save_obs
-from .seed_test import seed_test
+from .seed_test import parallel_seed_test, seed_test
 from .state_test import state_test


### PR DESCRIPTION
# Description

Minor bug, can import directly: `from pettingzoo.test.seed_test import parallel_seed_test, seed_test` but from init you can only import seed test, not parallel: `from pettingzoo.test import seed_test, parallel_seed_test` throws an error.

The documentation uses the latter code (importing from test rather than the file itself): https://pettingzoo.farama.org/content/environment_tests/

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
