### PR TITLE
Fix CI after gymnasium 28.1 reelase

### DIFF
--- a/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
@@ -329,7 +329,7 @@ class raw_env(AECEnv, EzPickle):
             )
         else:
             box_space = Box(low=low, high=high, shape=[shape[-1]], dtype=dtype)
-            obs_space = Sequence(space=box_space)
+            obs_space = Sequence(space=box_space, stack=True)
             self.observation_spaces = dict(
                 zip(
                     self.agents,


### PR DESCRIPTION
# Description

Fix KAZ Sequence space with stack=True (new gymnasium changes to how Sequence spaces work)

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
