### PR TITLE
Update shimmy wrappers formatting, add Melting Pot

### DIFF
--- a/docs/api/shimmy_wrappers.md
+++ b/docs/api/shimmy_wrappers.md
@@ -23,7 +23,7 @@ The [Shimmy](https://shimmy.farama.org/) package (`pip install shimmy`) allows c
 
 ## Usage
 
-To load a DeepMind Control multi-agent soccer game:
+To load a DeepMind Control [multi-agent soccer game](https://github.com/deepmind/dm_control/blob/main/dm_control/locomotion/soccer/README.md):
 
 ```python
 from shimmy import DmControlMultiAgentCompatibilityV0
@@ -37,6 +37,9 @@ while env.agents:
     actions = {agent: env.action_space(agent).sample() for agent in env.agents}  # this is where you would insert your policy
     observations, rewards, terminations, truncations, infos = env.step(actions)
 ```
+For more information, see [Shimmy DM Control Multi-Agent documentation](https://shimmy.farama.org/contents/dm_multi/)
+
+---
 
 To load an OpenSpiel game of [backgammon](https://github.com/deepmind/open_spiel/blob/master/docs/games.md#backgammon):
 ```python
@@ -56,6 +59,24 @@ for agent in env.agent_iter():
     env.step(action)
     env.render()
 ```
+For more information, see [Shimmy OpenSpiel documentation](https://shimmy.farama.org/contents/open_spiel/)
+
+---
+
+To load a Melting Pot [prisoner's dilemma in the matrix](https://github.com/deepmind/meltingpot/blob/main/docs/substrate_scenario_details.md#prisoners-dilemma-in-the-matrix) substrate:
+
+```python
+from shimmy import MeltingPotCompatibilityV0
+env = MeltingPotCompatibilityV0(substrate_name="prisoners_dilemma_in_the_matrix__arena", render_mode="human")
+observations = env.reset()
+while env.agents:
+    actions = {agent: env.action_space(agent).sample() for agent in env.agents}
+    observations, rewards, terminations, truncations, infos = env.step(actions)
+    env.step(actions)
+env.close()
+```
+
+For more information, see [Shimmy Melting Pot documentation](https://shimmy.farama.org/contents/meltingpot/)
 
 ## Citation
 


### PR DESCRIPTION
# Description

This is a minor patch that updates some of the links in the shimmy wrappers md page, and adds melting pot to the documentation as that will be included in the next Shimmy update.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
