### PR TITLE
Update parallel wrappers documentation

### DIFF
--- a/docs/api/pz_wrappers.md
+++ b/docs/api/pz_wrappers.md
@@ -4,7 +4,7 @@
 
 ### AEC to Parallel
 
-An environment can be converted from an AEC environment to a parallel environment with the `to_parallel` wrapper shown below. Note that this wrapper makes the following assumptions about the underlying environment:
+An environment can be converted from an AEC environment to a parallel environment with the `aec_to_parallel` wrapper shown below. Note that this wrapper makes the following assumptions about the underlying environment:
 
 1. The environment steps in a cycle, i.e. it steps through every live agent in order.
 2. The environment does not update the observations of the agents except at the end of a cycle.
@@ -15,18 +15,18 @@ Most parallel environments in PettingZoo only allocate rewards at the end of a c
 from pettingzoo.utils.conversions import to_parallel
 from pettingzoo.butterfly import pistonball_v6
 env = pistonball_v6.env()
-env = to_parallel(env)
+env = aec_to_parallel(env)
 ```
 
 ### Parallel to AEC
 
-Any parallel environment can be efficiently converted to an AEC environment with the `from_parallel` wrapper.
+Any parallel environment can be efficiently converted to an AEC environment with the `parallel_to_aec` wrapper.
 
 ``` python
 from pettingzoo.utils import from_parallel
 from pettingzoo.butterfly import pistonball_v6
 env = pistonball_v6.parallel_env()
-env = from_parallel(env)
+env = parallel_to_aec(env)
 ```
 
 ## Utility Wrappers


### PR DESCRIPTION
# Description

Updates the documentation for PettingZoo Wrappers to use the appropriate parallel wrapper functions. The old ones are now deprecated.

Fixes #937.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

