### PR TITLE
Rename seed to _seed

### DIFF
--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -161,9 +161,9 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
         }
 
         self._screen = None
-        self.seed(seed)
+        self._seed(seed)
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         if seed is None:
             _, seed = seeding.np_random()
         self.ale.setInt(b"random_seed", seed)
@@ -172,7 +172,7 @@ class ParallelAtariEnv(ParallelEnv, EzPickle):
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self._seed(seed=seed)
         self.ale.reset_game()
         self.agents = self.possible_agents[:]
         self.terminations = {agent: False for agent in self.possible_agents}

--- a/pettingzoo/butterfly/cooperative_pong/cooperative_pong.py
+++ b/pettingzoo/butterfly/cooperative_pong/cooperative_pong.py
@@ -362,7 +362,7 @@ class raw_env(AECEnv, EzPickle):
         EzPickle.__init__(self, **kwargs)
         self._kwargs = kwargs
 
-        self.seed()
+        self._seed()
 
         self.render_mode = self.env.render_mode
         self.agents = self.env.agents[:]
@@ -391,13 +391,13 @@ class raw_env(AECEnv, EzPickle):
     # def convert_to_dict(self, list_of_list):
     #     return dict(zip(self.agents, list_of_list))
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         self.randomizer, seed = seeding.np_random(seed)
         self.env = CooperativePong(self.randomizer, **self._kwargs)
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self._seed(seed=seed)
         self.env.reset()
         self.agents = self.possible_agents[:]
         self.agent_selection = self._agent_selector.reset()

--- a/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
@@ -280,7 +280,7 @@ class raw_env(AECEnv, EzPickle):
         self.render_on = False
 
         # Game Constants
-        self.seed()
+        self._seed()
         self.spawn_rate = spawn_rate
         self.max_cycles = max_cycles
         self.pad_observation = pad_observation
@@ -380,7 +380,7 @@ class raw_env(AECEnv, EzPickle):
     def action_space(self, agent):
         return self.action_spaces[agent]
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)
 
     # Spawn Zombies at Random Location at every 100 iterations
@@ -900,7 +900,7 @@ class raw_env(AECEnv, EzPickle):
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self._seed(seed=seed)
         self.has_reset = True
         self.agents = self.possible_agents
         self._agent_selector.reinit(self.agents)

--- a/pettingzoo/butterfly/pistonball/pistonball.py
+++ b/pettingzoo/butterfly/pistonball/pistonball.py
@@ -272,7 +272,7 @@ class raw_env(AECEnv, EzPickle):
 
         self.has_reset = False
         self.closed = False
-        self.seed()
+        self._seed()
 
     def observation_space(self, agent):
         return self.observation_spaces[agent]
@@ -280,7 +280,7 @@ class raw_env(AECEnv, EzPickle):
     def action_space(self, agent):
         return self.action_spaces[agent]
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)
 
     def observe(self, agent):
@@ -393,7 +393,7 @@ class raw_env(AECEnv, EzPickle):
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed)
+            self._seed(seed)
         self.space = pymunk.Space(threaded=False)
         self.add_walls()
         # self.space.threads = 2

--- a/pettingzoo/classic/hanabi/hanabi.py
+++ b/pettingzoo/classic/hanabi/hanabi.py
@@ -364,7 +364,7 @@ class raw_env(AECEnv, EzPickle):
     def action_space(self, agent):
         return self.action_spaces[agent]
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         config = dict(seed=seed, **self._config)
         self.hanabi_env = HanabiEnv(config=config)
 
@@ -440,7 +440,7 @@ class raw_env(AECEnv, EzPickle):
             current agent (agent_selection).
         """
         if seed is not None:
-            self.seed(seed=seed)
+            self._seed(seed=seed)
 
         self.agents = self.possible_agents[:]
         # Reset underlying hanabi reinforcement learning environment

--- a/pettingzoo/classic/rlcard_envs/rlcard_base.py
+++ b/pettingzoo/classic/rlcard_envs/rlcard_base.py
@@ -55,7 +55,7 @@ class RLCardBase(AECEnv):
     def action_space(self, agent):
         return self.action_spaces[agent]
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         config = {
             "allow_step_back": False,
             "seed": seed,
@@ -115,7 +115,7 @@ class RLCardBase(AECEnv):
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self._seed(seed=seed)
         obs, player_id = self.env.reset()
         self.agents = self.possible_agents[:]
         self.agent_selection = self._int_to_name(player_id)

--- a/pettingzoo/mpe/_mpe_utils/simple_env.py
+++ b/pettingzoo/mpe/_mpe_utils/simple_env.py
@@ -59,7 +59,7 @@ class SimpleEnv(AECEnv):
         # Set up the drawing window
 
         self.renderOn = False
-        self.seed()
+        self._seed()
 
         self.max_cycles = max_cycles
         self.scenario = scenario
@@ -126,7 +126,7 @@ class SimpleEnv(AECEnv):
     def action_space(self, agent):
         return self.action_spaces[agent]
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)
 
     def observe(self, agent):
@@ -145,7 +145,7 @@ class SimpleEnv(AECEnv):
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self._seed(seed=seed)
         self.scenario.reset_world(self.world, self.np_random)
 
         self.agents = self.possible_agents[:]

--- a/pettingzoo/sisl/multiwalker/multiwalker.py
+++ b/pettingzoo/sisl/multiwalker/multiwalker.py
@@ -167,15 +167,12 @@ class raw_env(AECEnv, EzPickle):
     def action_space(self, agent):
         return self.action_spaces[agent]
 
-    def seed(self, seed=None):
-        self.env.seed(seed)
-
     def convert_to_dict(self, list_of_list):
         return dict(zip(self.agents, list_of_list))
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self.env._seed(seed=seed)
         self.env.reset()
         self.steps = 0
         self.agents = self.possible_agents[:]

--- a/pettingzoo/sisl/multiwalker/multiwalker_base.py
+++ b/pettingzoo/sisl/multiwalker/multiwalker_base.py
@@ -330,7 +330,7 @@ class MultiWalkerEnv:
         self.remove_on_fall = remove_on_fall
         self.terrain_length = terrain_length
         self.seed_val = None
-        self.seed()
+        self._seed()
         self.setup()
         self.screen = None
         self.isopen = True
@@ -376,7 +376,7 @@ class MultiWalkerEnv:
     def agents(self):
         return self.walkers
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         self.np_random, seed_ = seeding.np_random(seed)
         self.seed_val = seed_
         for walker in getattr(self, "walkers", []):

--- a/pettingzoo/sisl/pursuit/pursuit.py
+++ b/pettingzoo/sisl/pursuit/pursuit.py
@@ -125,12 +125,9 @@ class raw_env(AECEnv, EzPickle):
         self.steps = 0
         self.closed = False
 
-    def seed(self, seed=None):
-        self.env.seed(seed)
-
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self.env._seed(seed=seed)
         self.steps = 0
         self.agents = self.possible_agents[:]
         self.rewards = dict(zip(self.agents, [(0) for _ in self.agents]))

--- a/pettingzoo/sisl/pursuit/pursuit_base.py
+++ b/pettingzoo/sisl/pursuit/pursuit_base.py
@@ -59,7 +59,7 @@ class Pursuit:
         self.y_size = y_size
         self.map_matrix = two_d_maps.rectangle_map(self.x_size, self.y_size)
         self.max_cycles = max_cycles
-        self.seed()
+        self._seed()
 
         self.shared_reward = shared_reward
         self.local_ratio = 1.0 - float(self.shared_reward)
@@ -177,7 +177,7 @@ class Pursuit:
     def agents(self):
         return self.pursuers
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         self.np_random, seed_ = seeding.np_random(seed)
         try:
             policies = [self.evader_controller, self.pursuer_controller]

--- a/pettingzoo/sisl/waterworld/waterworld.py
+++ b/pettingzoo/sisl/waterworld/waterworld.py
@@ -184,15 +184,12 @@ class raw_env(AECEnv):
     def action_space(self, agent):
         return self.action_spaces[agent]
 
-    def seed(self, seed=None):
-        self.env.seed(seed)
-
     def convert_to_dict(self, list_of_list):
         return dict(zip(self.agents, list_of_list))
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self.env._seed(seed=seed)
         self.has_reset = True
         self.env.reset()
         self.agents = self.possible_agents[:]

--- a/pettingzoo/sisl/waterworld/waterworld_base.py
+++ b/pettingzoo/sisl/waterworld/waterworld_base.py
@@ -113,7 +113,7 @@ class WaterworldBase:
         self.frames = 0
         self.num_agents = self.n_pursuers
         self.get_spaces()
-        self.seed()
+        self._seed()
 
     def get_spaces(self):
         """Define the action and observation spaces for all of the agents."""
@@ -139,7 +139,7 @@ class WaterworldBase:
         self.observation_space = [obs_space for i in range(self.n_pursuers)]
         self.action_space = [act_space for i in range(self.n_pursuers)]
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)
         return [seed]
 

--- a/pettingzoo/test/example_envs/generated_agents_env_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_v0.py
@@ -26,7 +26,7 @@ class raw_env(AECEnv):
         self.types = []
         self._agent_counters = {}
         self.max_cycles = max_cycles
-        self.seed()
+        self._seed()
         self.render_mode = render_mode
         for i in range(3):
             self.add_type()
@@ -67,7 +67,7 @@ class raw_env(AECEnv):
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self._seed(seed=seed)
         self.agents = []
         self.rewards = {}
         self._cumulative_rewards = {}
@@ -81,7 +81,7 @@ class raw_env(AECEnv):
         self._agent_selector = agent_selector(self.agents)
         self.agent_selection = self._agent_selector.reset()
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         self.np_random, _ = gymnasium.utils.seeding.np_random(seed)
 
     def step(self, action):

--- a/pettingzoo/test/example_envs/generated_agents_parallel_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_parallel_v0.py
@@ -30,7 +30,7 @@ class parallel_env(ParallelEnv):
         self.types = []
         self._agent_counters = {}
         self.max_cycles = max_cycles
-        self.seed()
+        self._seed()
         self.render_mode = render_mode
         for i in range(3):
             self.add_type()
@@ -66,14 +66,14 @@ class parallel_env(ParallelEnv):
 
     def reset(self, seed=None, options=None):
         if seed is not None:
-            self.seed(seed=seed)
+            self._seed(seed=seed)
         self.agents = []
         self.num_steps = 0
         for i in range(5):
             self.add_agent(self.np_random.choice(self.types))
         return {a: self.observe(a) for a in self.agents}, {a: {} for a in self.agents}
 
-    def seed(self, seed=None):
+    def _seed(self, seed=None):
         self.np_random, _ = seeding.np_random(seed)
 
     def step(self, actions):

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -310,12 +310,6 @@ class ParallelEnv:
         """
         raise NotImplementedError
 
-    def seed(self, seed=None):
-        """Reseeds the environment (making it deterministic)."""
-        raise NotImplementedError(
-            "Calling seed externally is deprecated; call reset(seed=seed) instead"
-        )
-
     def step(
         self, actions: ActionDict
     ) -> Tuple[

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -303,7 +303,7 @@ class ParallelEnv:
         self,
         seed: Optional[int] = None,
         options: Optional[dict] = None,
-    ) -> ObsDict:
+    ) -> Tuple[ObsDict, Dict[str, dict]]:
         """Resets the environment.
 
         And returns a dictionary of observations (keyed by the agent name)

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -71,12 +71,6 @@ class AECEnv:
         """Resets the environment to a starting state."""
         raise NotImplementedError
 
-    def seed(self, seed: Optional[int] = None) -> None:
-        """Reseeds the environment (making the resulting environment deterministic)."""
-        raise NotImplementedError(
-            "Calling seed externally is deprecated; call reset(seed=seed) instead"
-        )
-
     # TODO: Remove `Optional` type below
     def observe(self, agent: str) -> Optional[ObsType]:
         """Returns the observation an agent currently can make.

--- a/tutorials/CleanRL/cleanrl.py
+++ b/tutorials/CleanRL/cleanrl.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
         # collect an episode
         with torch.no_grad():
             # collect observations and convert to batch of torch tensors
-            next_obs = env.reset(seed=None)
+            next_obs, info = env.reset(seed=None)
             # reset the episodic return
             total_episodic_return = 0
 

--- a/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
+++ b/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
@@ -44,7 +44,7 @@ class CustomEnvironment(ParallelEnv):
             )
             for a in self.agents
         }
-        return observations
+        return observations, {}
 
     def step(self, actions):
         # Execute actions

--- a/tutorials/EnvironmentCreation/tutorial3_action_masking.py
+++ b/tutorials/EnvironmentCreation/tutorial3_action_masking.py
@@ -45,7 +45,7 @@ class CustomEnvironment(ParallelEnv):
             "prisoner": {"observation": observation, "action_mask": [0, 1, 1, 0]},
             "guard": {"observation": observation, "action_mask": [1, 0, 0, 1]},
         }
-        return observations
+        return observations, {}
 
     def step(self, actions):
         # Execute actions


### PR DESCRIPTION
This PR removes the `env.seed` method in favor of `env._seed` in some environments.

Neither should be used by end-users, and instead they should use `env.reset(seed=seed)`