### PR TITLE
Update enity.state.p_pos with state.p_vel of previous timestep

### DIFF
--- a/pettingzoo/mpe/_mpe_utils/core.py
+++ b/pettingzoo/mpe/_mpe_utils/core.py
@@ -168,6 +168,7 @@ class World:  # multi-agent world
         for i, entity in enumerate(self.entities):
             if not entity.movable:
                 continue
+            entity.state.p_pos += entity.state.p_vel * self.dt
             entity.state.p_vel = entity.state.p_vel * (1 - self.damping)
             if p_force[i] is not None:
                 entity.state.p_vel += (p_force[i] / entity.mass) * self.dt
@@ -184,7 +185,6 @@ class World:  # multi-agent world
                         )
                         * entity.max_speed
                     )
-            entity.state.p_pos += entity.state.p_vel * self.dt
 
     def update_agent_state(self, agent):
         # set communication state (directly for now)


### PR DESCRIPTION
# Description

This PR updates the dynamics of the agents to be coherent with the original paper [Emergence of Grounded Compositional Language in Multi-Agent Populations](https://arxiv.org/abs/1703.04908) (Appendix: Physical State and Dynamics).
In particular, the line `entity.state.p_pos += entity.state.p_vel * self.dt ` is moved to before `entity.state.p_vel ` is updated making  `p_pos` at time $t$ dependent on `p_vel` at time $t-1$ as specified in the paper.


Fixes #962

## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [X] New and existing unit tests pass locally with my changes
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
