### PR TITLE
Update environment creation tutorial with accurate obs/action space usage

### DIFF
--- a/docs/code_examples/aec_rps.py
+++ b/docs/code_examples/aec_rps.py
@@ -62,8 +62,9 @@ class raw_env(AECEnv):
         - possible_agents
         - render_mode
 
-        Note: the action_spaces and observation_spaces attributes are deprecated.
-        Spaces must be defined in the action_space() and observation_space() methods.
+        Note: as of v1.18.1, the action_spaces and observation_spaces attributes are deprecated.
+        Spaces should be defined in the action_space() and observation_space() methods.
+        If these methods are not overridden, spaces will be inferred from self.observation_spaces/action_spaces, raising a warning.
 
         These attributes should not be changed after initialization.
         """
@@ -74,22 +75,23 @@ class raw_env(AECEnv):
             zip(self.possible_agents, list(range(len(self.possible_agents))))
         )
 
-        # optional: explicitly define spaces as dicts (deprecated)
+        # optional: we can define the observation and action spaces here as attributes to be used in their corresponding methods
         self._action_spaces = {agent: Discrete(3) for agent in self.possible_agents}
         self._observation_spaces = {
             agent: Discrete(4) for agent in self.possible_agents
         }
         self.render_mode = render_mode
 
-    # observation space must be defined here
-    # this cache ensures that same space object is returned for the same agent
-    # allows observation and action space seeding to work as expected
+    # Observation space should be defined here.
+    # lru_cache allows observation and action spaces to be memoized, reducing clock cycles required to get each agent's space.
+    # If your spaces change over time, remove this line (disable caching).
     @functools.lru_cache(maxsize=None)
     def observation_space(self, agent):
         # gymnasium spaces are defined and documented here: https://gymnasium.farama.org/api/spaces/
         return Discrete(4)
 
-    # action space must be defined here
+    # Action space should be defined here.
+    # If your spaces change over time, remove this line (disable caching).
     @functools.lru_cache(maxsize=None)
     def action_space(self, agent):
         return Discrete(3)

--- a/docs/code_examples/aec_rps.py
+++ b/docs/code_examples/aec_rps.py
@@ -74,21 +74,22 @@ class raw_env(AECEnv):
             zip(self.possible_agents, list(range(len(self.possible_agents))))
         )
         
-        # optional: helper attributes for action and observation spaces (not used 
+        # optional: explicitly define spaces as dicts (deprecated)
         self._action_spaces = {agent: Discrete(3) for agent in self.possible_agents}
         self._observation_spaces = {
             agent: Discrete(4) for agent in self.possible_agents
         }
         self.render_mode = render_mode
 
-    # action and observation spaces must be defined 
+    # observation space must be defined here
     # this cache ensures that same space object is returned for the same agent
-    # allows action space seeding to work as expected
+    # allows observation and action space seeding to work as expected
     @functools.lru_cache(maxsize=None)
     def observation_space(self, agent):
         # gymnasium spaces are defined and documented here: https://gymnasium.farama.org/api/spaces/
         return Discrete(4)
 
+    # action space must be defined here
     @functools.lru_cache(maxsize=None)
     def action_space(self, agent):
         return Discrete(3)

--- a/docs/code_examples/aec_rps.py
+++ b/docs/code_examples/aec_rps.py
@@ -60,7 +60,7 @@ class raw_env(AECEnv):
         The init method takes in environment arguments and
          should define the following attributes:
         - possible_agents
-        - arender_mode
+        - render_mode
         
         Note: the action_spaces and observation_spaces attributes are deprecated.
         Spaces must be defined in the action_space() and observation_space() methods.

--- a/docs/code_examples/aec_rps.py
+++ b/docs/code_examples/aec_rps.py
@@ -61,19 +61,19 @@ class raw_env(AECEnv):
          should define the following attributes:
         - possible_agents
         - render_mode
-        
+
         Note: the action_spaces and observation_spaces attributes are deprecated.
         Spaces must be defined in the action_space() and observation_space() methods.
-        
+
         These attributes should not be changed after initialization.
         """
         self.possible_agents = ["player_" + str(r) for r in range(2)]
-        
+
         # optional: a mapping between agent name and ID
         self.agent_name_mapping = dict(
             zip(self.possible_agents, list(range(len(self.possible_agents))))
         )
-        
+
         # optional: explicitly define spaces as dicts (deprecated)
         self._action_spaces = {agent: Discrete(3) for agent in self.possible_agents}
         self._observation_spaces = {

--- a/docs/code_examples/aec_rps.py
+++ b/docs/code_examples/aec_rps.py
@@ -60,22 +60,28 @@ class raw_env(AECEnv):
         The init method takes in environment arguments and
          should define the following attributes:
         - possible_agents
-        - action_spaces
-        - observation_spaces
+        - arender_mode
+        
+        Note: the action_spaces and observation_spaces attributes are deprecated.
+        Spaces must be defined in the action_space() and observation_space() methods.
+        
         These attributes should not be changed after initialization.
         """
         self.possible_agents = ["player_" + str(r) for r in range(2)]
+        
+        # optional: a mapping between agent name and ID
         self.agent_name_mapping = dict(
             zip(self.possible_agents, list(range(len(self.possible_agents))))
         )
-
-        # gymnasium spaces are defined and documented here: https://gymnasium.farama.org/api/spaces/
+        
+        # optional: helper attributes for action and observation spaces (not used 
         self._action_spaces = {agent: Discrete(3) for agent in self.possible_agents}
         self._observation_spaces = {
             agent: Discrete(4) for agent in self.possible_agents
         }
         self.render_mode = render_mode
 
+    # action and observation spaces must be defined 
     # this cache ensures that same space object is returned for the same agent
     # allows action space seeding to work as expected
     @functools.lru_cache(maxsize=None)

--- a/docs/code_examples/parallel_rps.py
+++ b/docs/code_examples/parallel_rps.py
@@ -61,11 +61,16 @@ class parallel_env(ParallelEnv):
         """
         The init method takes in environment arguments and should define the following attributes:
         - possible_agents
-        - action_spaces
-        - observation_spaces
+        - render_mode
+        
+        Note: the action_spaces and observation_spaces attributes are deprecated.
+        Spaces must be defined in the action_space() and observation_space() methods.
+        
         These attributes should not be changed after initialization.
         """
         self.possible_agents = ["player_" + str(r) for r in range(2)]
+        
+        # optional: a mapping between agent name and ID
         self.agent_name_mapping = dict(
             zip(self.possible_agents, list(range(len(self.possible_agents))))
         )

--- a/docs/code_examples/parallel_rps.py
+++ b/docs/code_examples/parallel_rps.py
@@ -62,14 +62,14 @@ class parallel_env(ParallelEnv):
         The init method takes in environment arguments and should define the following attributes:
         - possible_agents
         - render_mode
-        
+
         Note: the action_spaces and observation_spaces attributes are deprecated.
         Spaces must be defined in the action_space() and observation_space() methods.
-        
+
         These attributes should not be changed after initialization.
         """
         self.possible_agents = ["player_" + str(r) for r in range(2)]
-        
+
         # optional: a mapping between agent name and ID
         self.agent_name_mapping = dict(
             zip(self.possible_agents, list(range(len(self.possible_agents))))
@@ -83,7 +83,7 @@ class parallel_env(ParallelEnv):
     def observation_space(self, agent):
         # gymnasium spaces are defined and documented here: https://gymnasium.farama.org/api/spaces/
         return Discrete(4)
-    
+
     # action space must be defined here
     @functools.lru_cache(maxsize=None)
     def action_space(self, agent):

--- a/docs/code_examples/parallel_rps.py
+++ b/docs/code_examples/parallel_rps.py
@@ -76,13 +76,15 @@ class parallel_env(ParallelEnv):
         )
         self.render_mode = render_mode
 
+    # observation space must be defined here
     # this cache ensures that same space object is returned for the same agent
-    # allows action space seeding to work as expected
+    # allows observation and action space seeding to work as expected
     @functools.lru_cache(maxsize=None)
     def observation_space(self, agent):
         # gymnasium spaces are defined and documented here: https://gymnasium.farama.org/api/spaces/
         return Discrete(4)
-
+    
+    # action space must be defined here
     @functools.lru_cache(maxsize=None)
     def action_space(self, agent):
         return Discrete(3)

--- a/docs/code_examples/parallel_rps.py
+++ b/docs/code_examples/parallel_rps.py
@@ -63,8 +63,9 @@ class parallel_env(ParallelEnv):
         - possible_agents
         - render_mode
 
-        Note: the action_spaces and observation_spaces attributes are deprecated.
-        Spaces must be defined in the action_space() and observation_space() methods.
+        Note: as of v1.18.1, the action_spaces and observation_spaces attributes are deprecated.
+        Spaces should be defined in the action_space() and observation_space() methods.
+        If these methods are not overridden, spaces will be inferred from self.observation_spaces/action_spaces, raising a warning.
 
         These attributes should not be changed after initialization.
         """
@@ -76,15 +77,16 @@ class parallel_env(ParallelEnv):
         )
         self.render_mode = render_mode
 
-    # observation space must be defined here
-    # this cache ensures that same space object is returned for the same agent
-    # allows observation and action space seeding to work as expected
+    # Observation space should be defined here.
+    # lru_cache allows observation and action spaces to be memoized, reducing clock cycles required to get each agent's space.
+    # If your spaces change over time, remove this line (disable caching).
     @functools.lru_cache(maxsize=None)
     def observation_space(self, agent):
         # gymnasium spaces are defined and documented here: https://gymnasium.farama.org/api/spaces/
         return Discrete(4)
 
-    # action space must be defined here
+    # Action space should be defined here.
+    # If your spaces change over time, remove this line (disable caching).
     @functools.lru_cache(maxsize=None)
     def action_space(self, agent):
         return Discrete(3)


### PR DESCRIPTION
# Description

Minor update addressing a question in discord about the usage of env.action_spaces (which is deprecated in favor of the env.action_space(agent) method).

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
