### PR TITLE
Add API section to every environment with links to source code

### DIFF
--- a/docs/_scripts/gen_envs_mds.py
+++ b/docs/_scripts/gen_envs_mds.py
@@ -84,19 +84,27 @@ if __name__ == "__main__":
                 if "rlcard_envs" not in env_dir_path
                 else env_dir_path + ".py"
             )
-            if "rlcard_envs" not in env_dir_path:
+            if "rlcard_envs" in env_dir_path:
+                docs_text += f"""## API
+```{{eval-rst}}
+.. currentmodule:: pettingzoo.{env_type}.rlcard_envs.{env_name}
+
+.. autoclass:: env
+.. autoclass:: raw_env
+```
+"""
+            elif env_type in ["mpe", "atari"]:
                 docs_text += f"""## API
 ```{{eval-rst}}
 .. currentmodule:: pettingzoo.{env_type}.{env_name}.{env_name}
 
-.. autoclass:: env
 .. autoclass:: raw_env
 ```
 """
             else:
                 docs_text += f"""## API
 ```{{eval-rst}}
-.. currentmodule:: pettingzoo.{env_type}.rlcard_envs.{env_name}
+.. currentmodule:: pettingzoo.{env_type}.{env_name}.{env_name}
 
 .. autoclass:: env
 .. autoclass:: raw_env

--- a/docs/_scripts/gen_envs_mds.py
+++ b/docs/_scripts/gen_envs_mds.py
@@ -84,6 +84,24 @@ if __name__ == "__main__":
                 if "rlcard_envs" not in env_dir_path
                 else env_dir_path + ".py"
             )
+            if "rlcard_envs" not in env_dir_path:
+                docs_text += f"""## API
+```{{eval-rst}}
+.. currentmodule:: pettingzoo.{env_type}.{env_name}.{env_name}
+
+.. autoclass:: env
+.. autoclass:: raw_env
+```
+"""
+            else:
+                docs_text += f"""## API
+```{{eval-rst}}
+.. currentmodule:: pettingzoo.{env_type}.rlcard_envs.{env_name}
+
+.. autoclass:: env
+.. autoclass:: raw_env
+```
+"""
             docs_env_path = os.path.join(
                 os.path.dirname(__file__),
                 "..",


### PR DESCRIPTION
I have always found it annoying that there was no direct way to view the full source code from being on an environment page, so I added this. Thanks to the previous PR that gives links to source code for API documentation, this now allows there to be links to source code at the bottom of the file.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
