### PR TITLE
Fix docs build fail, include methods in env API documentation

### DIFF
--- a/docs/_scripts/gen_envs_mds.py
+++ b/docs/_scripts/gen_envs_mds.py
@@ -91,6 +91,7 @@ if __name__ == "__main__":
 
 .. autoclass:: env
 .. autoclass:: raw_env
+   :members:
 ```
 """
             elif env_type in ["mpe", "atari"]:
@@ -99,6 +100,8 @@ if __name__ == "__main__":
 .. currentmodule:: pettingzoo.{env_type}.{env_name}.{env_name}
 
 .. autoclass:: raw_env
+   :members:
+   :undoc-members:
 ```
 """
             else:
@@ -108,6 +111,7 @@ if __name__ == "__main__":
 
 .. autoclass:: env
 .. autoclass:: raw_env
+   :members:
 ```
 """
             docs_env_path = os.path.join(

--- a/docs/api/aec.md
+++ b/docs/api/aec.md
@@ -151,7 +151,6 @@ For more information on action masking, see [A Closer Look at Invalid Action Mas
 .. automethod:: AECEnv.reset
 .. automethod:: AECEnv.observe
 .. automethod:: AECEnv.render
-.. automethod:: AECEnv.seed
 .. automethod:: AECEnv.close
 
 ```


### PR DESCRIPTION
# Description

Minor change to expand the API documentation to include methods (screenshot below)

Also fixes a reference to AECEnv.seed() in the AEC.md file, which was causing a build failure as that was removed in #930 

![firefox_J3vYSehpVv](https://github.com/Farama-Foundation/PettingZoo/assets/32176771/a95b2fa7-95ff-4ccb-8a40-425228b0e10a)



Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
