### PR TITLE
Remove casting actions to int in the Parallel -> AEC conversion

### DIFF
--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -312,8 +312,6 @@ class parallel_to_aec_wrapper(AECEnv):
         self._cumulative_rewards[new_agent] = 0
 
     def step(self, action: ActionType):
-        if action is not None:
-            action = int(action)
         if (
             self.terminations[self.agent_selection]
             or self.truncations[self.agent_selection]


### PR DESCRIPTION
Addresses #939 

WIP, for now I just want to see what happens in the CI if we remove the offending conversion