### PR TITLE
Fix broken tinyscaler version in cleanrl tutorial

### DIFF
--- a/tutorials/CleanRL/requirements.txt
+++ b/tutorials/CleanRL/requirements.txt
@@ -2,4 +2,4 @@ SuperSuit==3.7.2
 torch==1.13.1
 pettingzoo[butterfly]==1.22.4
 # remove this line when SuperSuit has been updated to 3.7.3
-tinyscaler==1.2.5
+tinyscaler==1.2.4


### PR DESCRIPTION
# Description

Installing locally I got an error that there was no such module tinyscaler 1.2.5. This PR is just changing this so that the requirements.txt can at least be installed locally. Currently the tutorial doesn't work due to supersuit not returning info

Edit: Looks like there actually is this version, I'm not sure what was going on with my pip, but clearly it exists https://pypi.org/project/tinyscaler/

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
