### PR TITLE
Add info about aec and parallel APIs to homepage

### DIFF
--- a/docs/api/aec.md
+++ b/docs/api/aec.md
@@ -8,6 +8,10 @@ title: AEC
 
 By default, PettingZoo models games as [*Agent Environment Cycle*](https://arxiv.org/abs/2009.13051) (AEC) environments. This allows it to support any type of game multi-agent RL can consider.
 
+[PettingZoo Classic](https://pettingzoo.farama.org/environments/classic/) provides standard examples of AEC environments for turn-based games, many of which implement [Illegal Action Masking](#action-masking).
+
+We provide a [tutorial](https://pettingzoo.farama.org/content/environment_creation/#example-custom-environment) for creating a simple Rock-Paper-Scissors AEC environment, showing how games with simultaneous actions can also be represented with AEC environments.
+
 ## Usage
 
 AEC environments can be interacted with as follows:

--- a/docs/api/parallel.md
+++ b/docs/api/parallel.md
@@ -7,6 +7,10 @@ title: Parallel
 
 In addition to the main API, we have a secondary parallel API for environments where all agents have simultaneous actions and observations. An environment with parallel API support can be created via `<game>.parallel_env()`. This API is based around the paradigm of *Partially Observable Stochastic Games* (POSGs) and the details are similar to [RLLib's MultiAgent environment specification](https://docs.ray.io/en/latest/rllib-env.html#multi-agent-and-hierarchical), except we allow for different observation and action spaces between the agents.
 
+All parallel environments can be converted into AEC environments by splitting a simultaneous turn into sequential turns, with observations only from the previous cycle.
+
+We provide tutorials for creating two custom Parallel environments: [Rock-Paper-Scissors](https://pettingzoo.farama.org/content/environment_creation/#example-custom-parallel-environment), and a simple [gridworld environment](https://pettingzoo.farama.org/tutorials/environmentcreation/2-environment-logic/)
+
 ## Usage
 
 Parallel environments can be interacted with as follows:

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,8 @@ An API standard for multi-agent reinforcement learning.
 **PettingZoo is a simple, pythonic interface capable of representing general multi-agent reinforcement learning (MARL) problems.**
 PettingZoo includes a wide variety of reference environments, helpful utilities, and tools for creating your own custom environments.
 
+The [AEC API](https://pettingzoo.farama.org/api/aec/) supports sequential turn based environments, while the [Parallel API](https://pettingzoo.farama.org/api/parallel/) supports environments with simultaneous actions.
+
 Environments can be interacted with using a similar interface to [Gymnasium](https://gymnasium.farama.org):
 
 ```python


### PR DESCRIPTION
# Description

Minor PR based on feedback from Discord saying it was confusing figuring out which environments are turn based. May also edit the AEC and Parallel API pages to include info about example envs (e.g., mention that classic has board games, mention that butterfly has parallel pistonball and SISL has parallel multiwalker env for example) and explain them briefly

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
