### PR TITLE
Fix bug in API test test_action_flexibility()

### DIFF
--- a/pettingzoo/test/api_test.py
+++ b/pettingzoo/test/api_test.py
@@ -434,7 +434,8 @@ def play_test(env, observation_0, num_cycles):
 
 
 def test_action_flexibility(env):
-    env.reset()
+    """Tests that a given action is valid given a seeded environment reset"""
+    env.reset(seed=0)
     agent = env.agent_selection
     action_space = env.action_space(agent)
     if isinstance(action_space, gymnasium.spaces.Discrete):
@@ -448,11 +449,11 @@ def test_action_flexibility(env):
         else:
             action = 0
         env.step(action)
-        env.reset()
+        env.reset(seed=0)
         env.step(np.int32(action))
     elif isinstance(action_space, gymnasium.spaces.Box):
         env.step(np.zeros_like(action_space.low))
-        env.reset()
+        env.reset(seed=0)
         env.step(np.zeros_like(action_space.low))
 
 


### PR DESCRIPTION
# Description

This code was made before environment seeding was done in the reset() function, so the reset() calls do not seed the environment. This results in false negatives where environments should pass, but sometimes do not because a given action can be valid or invalid in an environment after it is reset, if it is not seeded. 

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
