### PR TITLE
Remove `ParrellEnv.seed()`

### DIFF
--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -304,12 +304,6 @@ class ParallelEnv:
         """
         raise NotImplementedError
 
-    def seed(self, seed=None):
-        """Reseeds the environment (making it deterministic)."""
-        raise NotImplementedError(
-            "Calling seed externally is deprecated; call reset(seed=seed) instead"
-        )
-
     def step(
         self, actions: ActionDict
     ) -> tuple[


### PR DESCRIPTION
# Description

removes `ParrellEnv.seed()`, was deprecated

@RedTachyon Is there a reason this was kept

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
