### PR TITLE
Added Carla gym to third_party_envs.md

### DIFF
--- a/docs/environments/third_party_envs.md
+++ b/docs/environments/third_party_envs.md
@@ -91,6 +91,13 @@ Interactive PettingZoo implementation of the [Gobblet](https://en.wikipedia.org/
 
 Interactive PettingZoo implementation of the [Cathedral](https://en.wikipedia.org/wiki/Cathedral_(board_game)) board game.
 
+### [Carla Gym](https://github.com/johnMinelli/carla-gym/)
+
+[![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.23.0-blue)]()
+[![GitHub stars](https://img.shields.io/github/stars/johnMinelli/carla-gym)]()
+
+PettingZoo interface for CARLA Autonomous Driving simulator.
+
 
 ___
 


### PR DESCRIPTION
# Description

I have included the Carla gym in the documentation listing the third-party environments. The added env provides the PettingZoo API to CARLA autonomous driving simulator with easy configuration capabilities of the environment. It is also possible to use/share preset scenarios to train single/multi-agents in controlled situations and test them with reproducibility in mind.

### [Carla Gym](https://github.com/johnMinelli/carla-gym/)

The environment uses a previous work, which is no longer supported, as a starting point.
