### PR TITLE
Fix chess documentation coordinates error

### DIFF
--- a/pettingzoo/classic/chess/chess.py
+++ b/pettingzoo/classic/chess/chess.py
@@ -65,7 +65,19 @@ queen.
 
 We instead flatten this into 8×8×73 = 4672 discrete action space.
 
-You can get back the original (x,y,c) coordinates from the integer action `a` with the following expression: `(a/(8*73), (a/73)%8, a%(8*8))`
+You can get back the original (x,y,c) coordinates from the integer action `a` with the following expression: `(a // (8*73), (a // 73) % 8, a % (8*73) % 73)`
+
+> x = 6
+> y = 0
+> c = 12
+> a = x*(8*73) + y*73 + c
+> print(a // (8*73), a % (8*73) // 73, a % (8*73) % 73)  # -> 6 0 12
+
+Note: the coordinates (6, 0, 12) correspond to row 6, column 0, plane 12. In chess notation, this would signify square G1:
+
+| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
+| :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: |
+| A | B | C | D | E | F | G | H |
 
 ### Rewards
 


### PR DESCRIPTION
# Description

This addressed a problem brought up in our discord, about how there was a typo in the equation to get the original coordinates from the flattened representation.

The markdown table I added is as follows (just showing chess notation for people unfamiliar, tested that it works using an online viewer)
![firefox_f5oJYSL04u](https://github.com/Farama-Foundation/PettingZoo/assets/32176771/4d1bc9f2-af06-4d09-a920-11a8a94f60de)


Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
