### PR TITLE
Fix typo in chess documentation

### DIFF
--- a/pettingzoo/classic/chess/chess.py
+++ b/pettingzoo/classic/chess/chess.py
@@ -73,7 +73,7 @@ You can get back the original (x,y,c) coordinates from the integer action `a` wi
 > a = x*(8*73) + y*73 + c
 > print(a // (8*73), a % (8*73) // 73, a % (8*73) % 73)  # -> 6 0 12
 
-Note: the coordinates (6, 0, 12) correspond to row 6, column 0, plane 12. In chess notation, this would signify square G1:
+Note: the coordinates (6, 0, 12) correspond to column 6, row 0, plane 12. In chess notation, this would signify square G1:
 
 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
 | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: |


### PR DESCRIPTION
# Description

Mistakenly wrote the wrong order of coordinates in the previous PR, my mistake. 

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
