### PR TITLE
Fix chess to white perspective, fix observation bug, add documentation

### DIFF
--- a/pettingzoo/classic/chess/chess.py
+++ b/pettingzoo/classic/chess/chess.py
@@ -205,12 +205,12 @@ class raw_env(AECEnv, EzPickle):
         return self.action_spaces[agent]
 
     def observe(self, agent):
-        agent_index = self.possible_agents.index(agent)
+        current_index = self.possible_agents.index(agent)
 
-        observation = chess_utils.get_observation(self.board, agent_index)
+        observation = chess_utils.get_observation(self.board, current_index)
         observation = np.dstack((observation[:, :, :7], self.board_history))
         # We need to swap the white 6 channels with black 6 channels
-        if agent_index == 1:
+        if current_index == 1:
             # 1. Mirror the board
             observation = np.flip(observation, axis=0)
             # 2. Swap the white 6 channels with the black 6 channels
@@ -286,7 +286,8 @@ class raw_env(AECEnv, EzPickle):
         self._accumulate_rewards()
 
         # Update board after applying action
-        next_board = chess_utils.get_observation(self.board, 0)
+        # We always take the perspective of the white agent
+        next_board = chess_utils.get_observation(self.board, player=0)
         self.board_history = np.dstack(
             (next_board[:, :, 7:], self.board_history[:, :, :-13])
         )

--- a/pettingzoo/classic/chess/chess.py
+++ b/pettingzoo/classic/chess/chess.py
@@ -38,10 +38,11 @@ Like AlphaZero, the main observation space is an 8x8 image representing the boar
 * Channel 4: Is black or white
 * Channel 5: A move clock counting up to the 50 move rule. Represented by a single channel where the *n* th element in the flattened channel is set if there has been *n* moves
 * Channel 6: All ones to help neural networks find board edges in padded convolutions
-* Channel 7 - 18: One channel for each piece type and player color combination. For example, there is a specific channel that represents black knights. An index of this channel is set to 1 if a black knight is in the corresponding spot on the game board, otherwise, it is set to 0. En passant
-possibilities are represented by displaying the vulnerable pawn on the 8th row instead of the 5th.
+* Channel 7 - 18: One channel for each piece type and player color combination. For example, there is a specific channel that represents black knights. An index of this channel is set to 1 if a black knight is in the corresponding spot on the game board, otherwise, it is set to 0.
+Similar to LeelaChessZero, en passant possibilities are represented by displaying the vulnerable pawn on the 8th row instead of the 5th.
 * Channel 19: represents whether a position has been seen before (whether a position is a 2-fold repetition)
 * Channel 20 - 111 represents the previous 7 boards, with each board represented by 13 channels. The latest board occupies the first 13 channels, followed by the second latest board, and so on. These 13 channels correspond to channels 7 - 20.
+
 
 Similar to AlphaZero, our observation space follows a stacking approach, where it accumulates the previous 8 board observations.
 

--- a/pettingzoo/classic/chess/chess_utils.py
+++ b/pettingzoo/classic/chess/chess_utils.py
@@ -326,6 +326,7 @@ def get_observation(orig_board: chess.Board, player: int):
 
     # from 0-63
     """
+    The LeelaChessZero-style en passant flag.
     Adjust the row number for the white pawn to the 1st if the en passant flag is set, and vice versa for black pawns.
     E.g. A white pawn(e2) just made an initial two-square advance, `e2e4`.
          A black pawn(f4) next to that white pawn(e4) can play en passant capture on it.
@@ -346,7 +347,9 @@ def get_observation(orig_board: chess.Board, player: int):
     1  · · · · ♔ · · ·    1  · · · · 1 · · ·
        a b c d e f g h       a b c d e f g h
 
-    More details: pettingzoo/classic/chess/chess.py Line 41
+    More details:
+    https://github.com/Farama-Foundation/PettingZoo/blob/master/pettingzoo/classic/chess/chess.py#L42
+    https://github.com/LeelaChessZero/lc0/blob/master/src/chess/board.cc#L1114
     """
 
     # square where the en passant happened (int)

--- a/pettingzoo/classic/chess/chess_utils.py
+++ b/pettingzoo/classic/chess/chess_utils.py
@@ -336,18 +336,14 @@ def get_observation(orig_board: chess.Board, player: int):
         dest_col_add = 0 if ours else 8 * 7
         dest_square = dest_col_add + row
         if ours:
-            result[base + 0].remove(
-                square + 8
-            )  # Set the `square + 8` position in channel `base` to 0
-            result[base + 0].add(
-                dest_square
-            )  # Set the `dest_square` position in channel `base` to 1
+            # Set the `square + 8` position in channel `base` to False
+            result[base + 0].remove(square + 8)
+            # Set the `dest_square` position in channel `base` to True
+            result[base + 0].add(dest_square)
         else:
-            result[base + 6].remove(
-                square - 8
-            )  # Set the `square + 8` position in channel `base` to 0
-            result[base + 6].add(
-                dest_square
-            )  # Set the `dest_square` position in channel `base` to 1
+            # Set the `square + 8` position in channel `base` to False
+            result[base + 6].remove(square - 8)
+            # Set the `dest_square` position in channel `base` to True
+            result[base + 6].add(dest_square)
 
     return boards_to_ndarray(result)

--- a/pettingzoo/classic/chess/chess_utils.py
+++ b/pettingzoo/classic/chess/chess_utils.py
@@ -324,10 +324,11 @@ def get_observation(orig_board: chess.Board, player: int):
       }
     """
 
-    # from 0-63
     """
     The LeelaChessZero-style en passant flag.
-    Adjust the row number for the white pawn to the 1st if the en passant flag is set, and vice versa for black pawns.
+    In FEN, the en passant flag is represented by the square that can be a possible target of an en passant, e.g. the `e3` in `4k3/8/8/8/4Pp2/8/8/4K3 b - e3 99 50`.
+    However, for a neural network, it is not easy to train the network to recognize sparse and unstructured data.
+    Therefore, we adhere to LeelaChessZero's convention, which adjusts the row number to the 1st for white pawns if the en passant flag is set, and vice versa for black pawns.
     E.g. A white pawn(e2) just made an initial two-square advance, `e2e4`.
          A black pawn(f4) next to that white pawn(e4) can play en passant capture on it.
          To show this chance, we denote the white pawn at `e1` instead of `e4` once that white pawn play two-square advance.
@@ -335,7 +336,6 @@ def get_observation(orig_board: chess.Board, player: int):
          Note that the en passant flag has nothing to do with the opponent's pawn.
          i.e. an en passant flag always set after an initial two-square advance.
 
-    FEN: 4k3/8/8/8/4Pp2/8/8/4K3 b - e3 99 50
        The board             The observation of the 7th channel(white pawn)
     8  · · · · ♚ · · ·    8  · · · · · · · ·
     7  · · · · · · · ·    7  · · · · · · · ·
@@ -346,13 +346,14 @@ def get_observation(orig_board: chess.Board, player: int):
     2  · · · · · · · ·    2  · · · · · · · ·
     1  · · · · ♔ · · ·    1  · · · · 1 · · ·
        a b c d e f g h       a b c d e f g h
+    FEN: 4k3/8/8/8/4Pp2/8/8/4K3 b - e3 99 50
 
     More details:
     https://github.com/Farama-Foundation/PettingZoo/blob/master/pettingzoo/classic/chess/chess.py#L42
     https://github.com/LeelaChessZero/lc0/blob/master/src/chess/board.cc#L1114
     """
 
-    # square where the en passant happened (int)
+    # square where the en passant happened, ranging from 0 to 63 (int)
     square = board.ep_square
     if square:
         # Less than 32 is a white square, otherwise it's a black square

--- a/pettingzoo/classic/chess/chess_utils.py
+++ b/pettingzoo/classic/chess/chess_utils.py
@@ -329,9 +329,8 @@ def get_observation(orig_board: chess.Board, player: int):
     # To show this, we denote the pawn at (row, col) = (1, `dest_square`) instead of (5, `dest_square`).
     square = board.ep_square  # square where the en passant happened (int)
     if square:
-        ours = (
-            square < 32
-        )  # Less than 32 is a white square, otherwise it's a black square
+        # Less than 32 is a white square, otherwise it's a black square
+        ours = square < 32
         row = square % 8
         dest_col_add = 0 if ours else 8 * 7
         dest_square = dest_col_add + row


### PR DESCRIPTION
# Description

Fix the issue # 992. In this pull request, the observations in `env.board_history` is now always toward the white player. However, users can still get observations orientated toward the black player by  `env.observe('player_1")`.

Fix the issue where the env.observe("player_x")["observation"] is left-side right mirroring compare to `env.render()`.
This issue is contributed by two bugs. Firstly, in the `pettingzoo/classic/chess/chess_utils.py#L286`, It should be `OURS=1` but `OURS=0` in the last version. Vice versa for`THEIRS`. Secondly, the function `boards_to_ndarray` in `pettingzoo/classic/chess/chess_utils.py#L5` output an array `boardimage` but incorrectly with a 180 degree rotation. We use np.flip to fix it.

Corresponding updates on `pettingzoo/classic/chess/chess_utils.py#L330-#L344` to keep the en passant flag working.

Add a few type hints for functions in `pettingzoo/classic/chess/chess_utils.py` and `pettingzoo/classic/chess/chess.py`

Revise comments in `pettingzoo/classic/chess/chess.py` to match the current situation, especially on the board orientation and env.observe().

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [x ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x ] I have run `pytest -v` and no errors are present.
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
