### PR TITLE
Env creation tutorial 2 : grid size inconsistent

### DIFF
--- a/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
+++ b/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
@@ -104,7 +104,7 @@ class CustomEnvironment(ParallelEnv):
         return observations, rewards, terminations, truncations, infos
 
     def render(self):
-        grid = np.zeros((7, 7))
+        grid = np.full((8,8), ' ', dtype='U1')
         grid[self.prisoner_y, self.prisoner_x] = "P"
         grid[self.guard_y, self.guard_x] = "G"
         grid[self.escape_y, self.escape_x] = "E"

--- a/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
+++ b/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
@@ -104,7 +104,7 @@ class CustomEnvironment(ParallelEnv):
         return observations, rewards, terminations, truncations, infos
 
     def render(self):
-        grid = np.full((7,7), ' ', dtype='U1')
+        grid = np.full((7,7), ' ')
         grid[self.prisoner_y, self.prisoner_x] = "P"
         grid[self.guard_y, self.guard_x] = "G"
         grid[self.escape_y, self.escape_x] = "E"

--- a/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
+++ b/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
@@ -30,8 +30,8 @@ class CustomEnvironment(ParallelEnv):
         self.prisoner_x = 0
         self.prisoner_y = 0
 
-        self.guard_x = 7
-        self.guard_y = 7
+        self.guard_x = 6
+        self.guard_y = 6
 
         self.escape_x = random.randint(2, 5)
         self.escape_y = random.randint(2, 5)
@@ -104,7 +104,7 @@ class CustomEnvironment(ParallelEnv):
         return observations, rewards, terminations, truncations, infos
 
     def render(self):
-        grid = np.full((8,8), ' ', dtype='U1')
+        grid = np.full((7,7), ' ', dtype='U1')
         grid[self.prisoner_y, self.prisoner_x] = "P"
         grid[self.guard_y, self.guard_x] = "G"
         grid[self.escape_y, self.escape_x] = "E"

--- a/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
+++ b/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
@@ -104,7 +104,7 @@ class CustomEnvironment(ParallelEnv):
         return observations, rewards, terminations, truncations, infos
 
     def render(self):
-        grid = np.full((7,7), ' ')
+        grid = np.full((7, 7), " ")
         grid[self.prisoner_y, self.prisoner_x] = "P"
         grid[self.guard_y, self.guard_x] = "G"
         grid[self.escape_y, self.escape_x] = "E"


### PR DESCRIPTION
There were two mistakes
 - The grid is 7x7 but the guard starts at position (7,7) which is out of bounds
 - The type of the grid used in `render() `was integers and it conflicts with the characters we assign in the function

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Most of those at not relevant, it's a doc change