### PR TITLE
Env creation tutorial 2 fix observation space

### DIFF
--- a/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
+++ b/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
@@ -112,7 +112,7 @@ class CustomEnvironment(ParallelEnv):
 
     @functools.lru_cache(maxsize=None)
     def observation_space(self, agent):
-        return MultiDiscrete([7 * 7 - 1] * 3)
+        return MultiDiscrete([7 * 7] * 3)
 
     @functools.lru_cache(maxsize=None)
     def action_space(self, agent):


### PR DESCRIPTION
# Description

The observation space was too small. For example, for the observation returned after a `reset()`, the guard is at the extreme corner, which is indexed 48. However, the current observation space can only go up to 47

Related question : should the tests like `parallel_api_test()` check that the observations are consistent with the observation spaces? This could have been easily caught (cf tutorial 4)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update



# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

It's just a doc change
