### PR TITLE
Env creation tutorial 3: Change action mask type to int8

### DIFF
--- a/tutorials/EnvironmentCreation/tutorial3_action_masking.py
+++ b/tutorials/EnvironmentCreation/tutorial3_action_masking.py
@@ -71,7 +71,7 @@ class CustomEnvironment(ParallelEnv):
             self.guard_y += 1
 
         # Generate action masks
-        prisoner_action_mask = np.ones(4)
+        prisoner_action_mask = np.ones(4, dtype=np.int8)
         if self.prisoner_x == 0:
             prisoner_action_mask[0] = 0  # Block left movement
         elif self.prisoner_x == 6:
@@ -81,7 +81,7 @@ class CustomEnvironment(ParallelEnv):
         elif self.prisoner_y == 6:
             prisoner_action_mask[3] = 0  # Block up movement
 
-        guard_action_mask = np.ones(4)
+        guard_action_mask = np.ones(4, dtype=np.int8)
         if self.guard_x == 0:
             guard_action_mask[0] = 0
         elif self.guard_x == 6:


### PR DESCRIPTION
# Description

The expected type of an action mask in gymnasium is int8 (cf https://github.com/Farama-Foundation/Gymnasium/blob/40822a9e8fabb5b064597aaf1982f997162bd369/gymnasium/spaces/discrete.py#L58)

```
assert (
                mask.dtype == np.int8
            ), f"The expected dtype of the mask is np.int8, actual dtype: {mask.dtype}"
```
This PR just changes the type of the mask to the right type

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

It's just a doc change
