### PR TITLE
Update parallel docs, fix all usages of `obs = env.reset` to `obs, info = env.reset`

### DIFF
--- a/docs/api/parallel.md
+++ b/docs/api/parallel.md
@@ -7,6 +7,8 @@ title: Parallel
 
 In addition to the main API, we have a secondary parallel API for environments where all agents have simultaneous actions and observations. An environment with parallel API support can be created via `<game>.parallel_env()`. This API is based around the paradigm of *Partially Observable Stochastic Games* (POSGs) and the details are similar to [RLlib's MultiAgent environment specification](https://docs.ray.io/en/latest/rllib-env.html#multi-agent-and-hierarchical), except we allow for different observation and action spaces between the agents.
 
+For a comparison with the AEC API, see [About AEC](https://pettingzoo.farama.org/api/aec/#about-aec). For more information, see [*PettingZoo: A Standard API for Multi-Agent Reinforcement Learning*](https://arxiv.org/pdf/2009.14471.pdf).
+
 [PettingZoo Wrappers](/api/wrappers/pz_wrappers/) can be used to convert between Parallel and AEC environments, with some restrictions (e.g., an AEC env must only update once at the end of each cycle).
 
 We provide tutorials for creating two custom Parallel environments: [Rock-Paper-Scissors](https://pettingzoo.farama.org/content/environment_creation/#example-custom-parallel-environment), and a simple [gridworld environment](https://pettingzoo.farama.org/tutorials/environmentcreation/2-environment-logic/)
@@ -18,7 +20,7 @@ Parallel environments can be interacted with as follows:
 ``` python
 from pettingzoo.butterfly import pistonball_v6
 parallel_env = pistonball_v6.parallel_env(render_mode="human")
-observations = parallel_env.reset(seed=42)
+observations, infos = parallel_env.reset(seed=42)
 
 while env.agents:
     # this is where you would insert your policy

--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -69,7 +69,7 @@ from pettingzoo.butterfly import pistonball_v6
 parallel_env = pistonball_v6.env()
 parallel_env = CaptureStdoutWrapper(parallel_env)
 
-observations = parallel_env.reset()
+observations, infos = parallel_env.reset()
 
 while parallel_env.agents:
     actions = {agent: parallel_env.action_space(agent).sample() for agent in parallel_env.agents}  # this is where you would insert your policy

--- a/docs/api/wrappers/shimmy_wrappers.md
+++ b/docs/api/wrappers/shimmy_wrappers.md
@@ -32,7 +32,7 @@ from dm_control.locomotion import soccer as dm_soccer
 env = dm_soccer.load(team_size=2)
 env = DmControlMultiAgentCompatibilityV0(env, render_mode="human")
 
-observations = env.reset()
+observations, infos = env.reset()
 while env.agents:
     actions = {agent: env.action_space(agent).sample() for agent in env.agents}  # this is where you would insert your policy
     observations, rewards, terminations, truncations, infos = env.step(actions)
@@ -64,7 +64,7 @@ To load a Melting Pot [prisoner's dilemma in the matrix](https://github.com/deep
 ```python
 from shimmy import MeltingPotCompatibilityV0
 env = MeltingPotCompatibilityV0(substrate_name="prisoners_dilemma_in_the_matrix__arena", render_mode="human")
-observations = env.reset()
+observations, infos = env.reset()
 while env.agents:
     actions = {agent: env.action_space(agent).sample() for agent in env.agents}
     observations, rewards, terminations, truncations, infos = env.step(actions)

--- a/docs/environments/butterfly.md
+++ b/docs/environments/butterfly.md
@@ -39,7 +39,7 @@ To launch a [Pistonball](https://pettingzoo.farama.org/environments/butterfly/pi
 from pettingzoo.butterfly import pistonball_v6
 
 env = pistonball_v6.parallel_env(render_mode="human")
-observations = env.reset()
+observations, infos = env.reset()
 
 while env.agents:
     # this is where you would insert your policy

--- a/pettingzoo/test/max_cycles_test.py
+++ b/pettingzoo/test/max_cycles_test.py
@@ -5,7 +5,7 @@ def max_cycles_test(mod):
     max_cycles = 4
     parallel_env = mod.parallel_env(max_cycles=max_cycles)
 
-    observations = parallel_env.reset()
+    observations, infos = parallel_env.reset()
     terminations = {agent: False for agent in parallel_env.agents}
     truncations = {agent: False for agent in parallel_env.agents}
     test_cycles = (


### PR DESCRIPTION
Docs were written prior to return info change, have to update them. Also added link to the PettingZoo paper in the parallel docs and a link to the about AEC section I wrote (just for maximum information for new users to understand it)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
