### PR TITLE
Allow AssertOutOfBoundsWrapper to be applied to any environment

### DIFF
--- a/pettingzoo/utils/wrappers/assert_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/assert_out_of_bounds.py
@@ -1,24 +1,14 @@
 from __future__ import annotations
 
-from gymnasium.spaces import Discrete, MultiDiscrete
-
 from pettingzoo.utils.env import ActionType, AECEnv
 from pettingzoo.utils.wrappers.base import BaseWrapper
 
 
 class AssertOutOfBoundsWrapper(BaseWrapper):
-    """Asserts if the action given to step is outside of the action space. Applied in PettingZoo environments with discrete or multidiscrete action spaces."""
+    """Asserts if the action given to step is outside of the action space."""
 
     def __init__(self, env: AECEnv):
         super().__init__(env)
-        assert all(
-            isinstance(self.action_space(agent), Discrete)
-            or isinstance(
-                self.action_space(agent),
-                MultiDiscrete,
-            )
-            for agent in getattr(self, "possible_agents", [])
-        ), "should only use AssertOutOfBoundsWrapper for Discrete or MultiDiscrete spaces"
 
     def step(self, action: ActionType) -> None:
         assert (

--- a/pettingzoo/utils/wrappers/assert_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/assert_out_of_bounds.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
-from gymnasium.spaces import Discrete
+from gymnasium.spaces import Discrete, MultiDiscrete
 
 from pettingzoo.utils.env import ActionType, AECEnv
 from pettingzoo.utils.wrappers.base import BaseWrapper
 
 
 class AssertOutOfBoundsWrapper(BaseWrapper):
-    """Asserts if the action given to step is outside of the action space. Applied in PettingZoo environments with discrete action spaces."""
+    """Asserts if the action given to step is outside of the action space. Applied in PettingZoo environments with discrete or multidiscrete action spaces."""
 
     def __init__(self, env: AECEnv):
         super().__init__(env)
         assert all(
             isinstance(self.action_space(agent), Discrete)
+            or isinstance(
+                self.action_space(agent),
+                MultiDiscrete,
+            )
             for agent in getattr(self, "possible_agents", [])
-        ), "should only use AssertOutOfBoundsWrapper for Discrete spaces"
+        ), "should only use AssertOutOfBoundsWrapper for Discrete or MultiDiscrete spaces"
 
     def step(self, action: ActionType) -> None:
         assert (

--- a/test/unwrapped_test.py
+++ b/test/unwrapped_test.py
@@ -20,15 +20,6 @@ def box_observation(env, agents):
     return boxable
 
 
-def discrete_observation(env, agents):
-    is_discrete = True
-    for agent in agents:
-        is_discrete = is_discrete and (
-            isinstance(env.observation_space(agent), spaces.Discrete)
-        )
-    return is_discrete
-
-
 @pytest.mark.parametrize(("name", "env_module"), list(all_environments.items()))
 def test_unwrapped(name, env_module):
     env = env_module.env(render_mode="human")
@@ -37,8 +28,7 @@ def test_unwrapped(name, env_module):
     env.reset()
     agents = env.agents
 
-    if discrete_observation(env, agents):
-        env = wrappers.AssertOutOfBoundsWrapper(env)
+    env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.BaseWrapper(env)
     env = wrappers.CaptureStdoutWrapper(env)
     if box_observation(env, agents) and box_action(env, agents):


### PR DESCRIPTION
# Description

Allows `AssertOutOfBoundsWrapper` to be applied to environments with any action space type, resolving https://github.com/Farama-Foundation/PettingZoo/issues/866.

## Type of change

- New feature (non-breaking change which adds functionality)

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
