### PR TITLE
Update RLlib tutorials (Ray now supports Gymnasium v28)

### DIFF
--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        tutorial: ['Tianshou', 'EnvironmentCreation', 'CleanRL', 'SB3/kaz', 'SB3/waterworld', 'SB3/connect_four', 'SB3/test'] # TODO: add back RLlib once it is fixed
+        tutorial: ['Tianshou', 'EnvironmentCreation', 'CleanRL', 'RLlib', 'SB3/kaz', 'SB3/waterworld', 'SB3/connect_four', 'SB3/test'] # TODO: add back RLlib once it is fixed
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        tutorial: ['Tianshou', 'EnvironmentCreation', 'CleanRL', 'Ray', 'SB3/kaz', 'SB3/waterworld', 'SB3/connect_four', 'SB3/test']
+        tutorial: ['Tianshou', 'EnvironmentCreation', 'CleanRL', 'SB3/kaz', 'SB3/waterworld', 'SB3/connect_four', 'SB3/test'] # TODO: add back Ray once next release after 2.6.2
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        tutorial: ['Tianshou', 'EnvironmentCreation', 'CleanRL', 'RLlib', 'SB3/kaz', 'SB3/waterworld', 'SB3/connect_four', 'SB3/test'] # TODO: add back RLlib once it is fixed
+        tutorial: ['Tianshou', 'EnvironmentCreation', 'CleanRL', 'Ray', 'SB3/kaz', 'SB3/waterworld', 'SB3/connect_four', 'SB3/test'] # TODO: add back RLlib once it is fixed
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/tutorials/Ray/requirements.txt
+++ b/tutorials/Ray/requirements.txt
@@ -1,10 +1,10 @@
 PettingZoo[classic, butterfly]==1.23.1
 Pillow>=9.4.0
 # TODO: replace with ray[rllib] >= 2.6.2 once the next release is out
-ray[rllib] @ git+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-manylinux2014_x86_64.whl; python_version=='3.11' and sys_platform == "linux"
-ray[rllib] @ git+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl; python_version=='3.10' and sys_platform == "linux"
-ray[rllib] @ git+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl; python_version=='3.9' and sys_platform == "linux"
-ray[rllib] @ git+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl; python_version=='3.8' and sys_platform == "linux"
+ray[rllib] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-manylinux2014_x86_64.whl; python_version=='3.11' and sys_platform == "linux"
+ray[rllib] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl; python_version=='3.10' and sys_platform == "linux"
+ray[rllib] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl; python_version=='3.9' and sys_platform == "linux"
+ray[rllib] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl; python_version=='3.8' and sys_platform == "linux"
 SuperSuit==3.8.0
 torch>=1.13.1
 tensorflow-probability>=0.19.0

--- a/tutorials/Ray/requirements.txt
+++ b/tutorials/Ray/requirements.txt
@@ -1,6 +1,6 @@
-PettingZoo[classic, butterfly]>=1.23.1
+PettingZoo[classic, butterfly]==1.23.1
 Pillow>=9.4.0
-ray[rllib]>=2.5.1 # Note: RLlib's PettingZoo wrapper is currently broken, but will be fixed with https://github.com/ray-project/ray/pull/34696
-SuperSuit>=3.9.0
+ray[rllib]>=2.6.2
+SuperSuit==3.8.0
 torch>=1.13.1
 tensorflow-probability>=0.19.0

--- a/tutorials/Ray/requirements.txt
+++ b/tutorials/Ray/requirements.txt
@@ -1,6 +1,6 @@
 PettingZoo[classic, butterfly]==1.23.1
 Pillow>=9.4.0
-ray[rllib]>=2.6.2
+ray[rllib] @ git+https://github.com/ray-project/ray.git
 SuperSuit==3.8.0
 torch>=1.13.1
 tensorflow-probability>=0.19.0

--- a/tutorials/Ray/requirements.txt
+++ b/tutorials/Ray/requirements.txt
@@ -1,10 +1,6 @@
 PettingZoo[classic, butterfly]==1.23.1
 Pillow>=9.4.0
-# TODO: replace with ray[rllib] >= 2.6.2 once the next release is out
-ray[rllib] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-manylinux2014_x86_64.whl; python_version=='3.11' and sys_platform == "linux"
-ray[rllib] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl; python_version=='3.10' and sys_platform == "linux"
-ray[rllib] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl; python_version=='3.9' and sys_platform == "linux"
-ray[rllib] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl; python_version=='3.8' and sys_platform == "linux"
+ray[rllib]>2.6.2
 SuperSuit==3.8.0
 torch>=1.13.1
 tensorflow-probability>=0.19.0

--- a/tutorials/Ray/requirements.txt
+++ b/tutorials/Ray/requirements.txt
@@ -1,6 +1,10 @@
 PettingZoo[classic, butterfly]==1.23.1
 Pillow>=9.4.0
-ray[rllib]>2.6.2
+# TODO: replace with ray[rllib] >= 2.6.2 once the next release is out
+ray[rllib] @ git+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-manylinux2014_x86_64.whl; python_version=='3.11' and sys_platform == "linux"
+ray[rllib] @ git+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl; python_version=='3.10' and sys_platform == "linux"
+ray[rllib] @ git+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl; python_version=='3.9' and sys_platform == "linux"
+ray[rllib] @ git+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl; python_version=='3.8' and sys_platform == "linux"
 SuperSuit==3.8.0
 torch>=1.13.1
 tensorflow-probability>=0.19.0

--- a/tutorials/Ray/requirements.txt
+++ b/tutorials/Ray/requirements.txt
@@ -1,6 +1,6 @@
 PettingZoo[classic, butterfly]==1.23.1
 Pillow>=9.4.0
-ray[rllib] @ git+https://github.com/ray-project/ray.git
+ray[rllib]>2.6.2
 SuperSuit==3.8.0
 torch>=1.13.1
 tensorflow-probability>=0.19.0


### PR DESCRIPTION
# Description

This will have to wait until the next release after ray 2.6.2, as that does not include the changes. There's no easy way to install the latest ray master besides specifying the python/linux version in nightlies for ray, so simplest to just wait

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
