### PR TITLE
Fix incorrect arguments in waterworld docstring example

### DIFF
--- a/pettingzoo/sisl/waterworld/waterworld.py
+++ b/pettingzoo/sisl/waterworld/waterworld.py
@@ -83,7 +83,7 @@ averaged over the number of agents (global rewards) are scaled by `(1 - local_ra
 ``` python
 waterworld_v4.env(n_pursuers=5, n_evaders=5, n_poisons=10, n_coop=2, n_sensors=20,
 sensor_range=0.2,radius=0.015, obstacle_radius=0.2,
-obstacle_coord=(0.5, 0.5), pursuer_max_accel=0.01, evader_speed=0.01,
+obstacle_coord=[(0.5, 0.5)], pursuer_max_accel=0.01, evader_speed=0.01,
 poison_speed=0.01, poison_reward=-1.0, food_reward=10.0, encounter_reward=0.01,
 thrust_penalty=-0.5, local_ratio=1.0, speed_features=True, max_cycles=500)
 ```


### PR DESCRIPTION
# Description

Hopefully we can get docstring tests soon so things like this will be found. Fixes https://github.com/Farama-Foundation/PettingZoo/issues/1052

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
