### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/api/parallel.md
+++ b/docs/api/parallel.md
@@ -79,7 +79,6 @@ parallel_env.close()
 
     .. automethod:: step
     .. automethod:: reset
-    .. automethod:: seed
     .. automethod:: render
     .. automethod:: close
     .. automethod:: state

--- a/docs/tutorials/langchain/langchain.md
+++ b/docs/tutorials/langchain/langchain.md
@@ -20,7 +20,7 @@ To follow this tutorial, you will need to install the dependencies shown below. 
 
 ## Environment Loop
 ```{eval-rst}
-.. literalinclude:: ../../../tutorials/LangChain/langchain.py
+.. literalinclude:: ../../../tutorials/LangChain/langchain_example.py
    :pyobject: main
    :language: python
 ```
@@ -46,7 +46,7 @@ The `PettingZooAgent` extends the `GymnasiumAgent` to the multi-agent setting. T
 We can now run a simulation of a multi-agent rock, paper, scissors game using the `PettingZooAgent`.
 
 ```{eval-rst}
-.. literalinclude:: ../../../tutorials/LangChain/langchain.py
+.. literalinclude:: ../../../tutorials/LangChain/langchain_example.py
    :pyobject: rock_paper_scissors
    :language: python
 ```
@@ -128,7 +128,7 @@ Some `PettingZoo` environments provide an `action_mask` to tell the agent which 
 ### Tic-Tac-Toe
 Here is an example of a Tic-Tac-Toe game that uses the `ActionMaskAgent`.
 ```{eval-rst}
-.. literalinclude:: ../../../tutorials/LangChain/langchain.py
+.. literalinclude:: ../../../tutorials/LangChain/langchain_example.py
    :pyobject: tic_tac_toe
    :language: python
 ```
@@ -363,7 +363,7 @@ Action: None
 ### Texas Holdem' No Limit
 Here is an example of a Texas Hold'em No Limit game that uses the `ActionMaskAgent`.
 ```{eval-rst}
-.. literalinclude:: ../../../tutorials/LangChain/langchain.py
+.. literalinclude:: ../../../tutorials/LangChain/langchain_example.py
    :pyobject: texas_holdem_no_limit
    :language: python
 ```

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -45,9 +45,9 @@ def aec_wrapper_fn(par_env_fn: Callable) -> Callable:
 
 
 def aec_to_parallel(aec_env: AECEnv) -> ParallelEnv:
-    """Converts an aec environment to a parallel environment.
+    """Converts an AEC environment to a Parallel environment.
 
-    In the case of an existing parallel environment wrapped using a `parallel_to_aec_wrapper`, this function will return the original parallel environment.
+    In the case of an existing Parallel environment wrapped using a `parallel_to_aec_wrapper`, this function will return the original Parallel environment.
     Otherwise, it will apply the `aec_to_parallel_wrapper` to convert the environment.
     """
     if isinstance(aec_env, OrderEnforcingWrapper) and isinstance(
@@ -60,9 +60,9 @@ def aec_to_parallel(aec_env: AECEnv) -> ParallelEnv:
 
 
 def parallel_to_aec(par_env: ParallelEnv) -> AECEnv:
-    """Converts an aec environment to a parallel environment.
+    """Converts a Parallel environment to an AEC environment.
 
-    In the case of an existing aec environment wrapped using a `aec_to_prallel_wrapper`, this function will return the original AEC environment.
+    In the case of an existing AEC environment wrapped using a `aec_to_parallel_wrapper`, this function will return the original AEC environment.
     Otherwise, it will apply the `parallel_to_aec_wrapper` to convert the environment.
     """
     if isinstance(par_env, aec_to_parallel_wrapper):
@@ -100,7 +100,7 @@ class aec_to_parallel_wrapper(ParallelEnv):
 
     def __init__(self, aec_env):
         assert aec_env.metadata.get("is_parallelizable", False), (
-            "Converting from an AEC environment to a parallel environment "
+            "Converting from an AEC environment to a Parallel environment "
             "with the to_parallel wrapper is not generally safe "
             "(the AEC environment should only update once at the end "
             "of each cycle). If you have confirmed that your AEC environment "
@@ -218,7 +218,7 @@ class aec_to_parallel_wrapper(ParallelEnv):
 
 
 class parallel_to_aec_wrapper(AECEnv):
-    """Converts a parallel environment into an AEC environment."""
+    """Converts a Parallel environment into an AEC environment."""
 
     def __init__(self, parallel_env):
         self.env = parallel_env


### PR DESCRIPTION
# Description

Minor typos in the langchain tutorial and there's a warning in the parallel API docs where it is still searching for the `seed` method which has been removed (in favor of env.reset(seed))

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
