### PR TITLE
Permit AgentIDs other than `str`

### DIFF
--- a/pettingzoo/test/api_test.py
+++ b/pettingzoo/test/api_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import warnings
 from collections import defaultdict

--- a/pettingzoo/test/api_test.py
+++ b/pettingzoo/test/api_test.py
@@ -249,7 +249,7 @@ def test_observation_action_spaces(env, agent_0):
             )
         if (not isinstance(agent, str)) and agent != "env":
             warnings.warn(
-                "Agent's are recommended to have numbered string names, like player_0"
+                "Agents are recommended to have numbered string names, like player_0"
             )
         if not isinstance(agent, str) or not re.match(
             "[a-z]+_[0-9]+", agent

--- a/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
@@ -1,0 +1,158 @@
+import gymnasium
+import numpy as np
+
+from pettingzoo import AECEnv
+from pettingzoo.utils import wrappers
+from pettingzoo.utils.agent_selector import agent_selector
+
+
+def env():
+    env = raw_env()
+    env = wrappers.AssertOutOfBoundsWrapper(env)
+    env = wrappers.OrderEnforcingWrapper(env)
+    return env
+
+
+def get_type(agent: tuple[str, int]):
+    return agent[0]
+
+class raw_env(AECEnv[tuple[str, int], np.ndarray, int | None]):
+    metadata = {"render_modes": ["human"], "name": "generated_agents_env_v0"}
+
+    def __init__(self, max_cycles=100, render_mode=None):
+        super().__init__()
+        self._obs_spaces = {}
+        self._act_spaces = {}
+
+        # dummy state space, not actually used
+        self.state_space = gymnasium.spaces.MultiDiscrete([10, 10])
+        self._state = self.state_space.sample()
+
+        self.types = []
+        self._agent_counters = {}
+        self.max_cycles = max_cycles
+        self._seed()
+        self.render_mode = render_mode
+        for i in range(3):
+            self.add_type()
+
+    def observation_space(self, agent):
+        return self._obs_spaces[get_type(agent)]
+
+    def action_space(self, agent):
+        return self._act_spaces[get_type(agent)]
+
+    def state(self) -> np.ndarray:
+        return self._state
+
+    def observe(self, agent):
+        return self.observation_space(agent).sample()
+
+    def add_type(self) -> str:
+        type_id = len(self.types)
+        num_actions = self.np_random.integers(3, 10)
+        obs_size = self.np_random.integers(10, 50)
+        obs_space = gymnasium.spaces.Box(low=0, high=1, shape=(obs_size,))
+        act_space = gymnasium.spaces.Discrete(num_actions)
+        new_type = f"type{type_id}"
+        self.types.append(new_type)
+        self._obs_spaces[new_type] = obs_space
+        self._act_spaces[new_type] = act_space
+        self._agent_counters[new_type] = 0
+        return new_type
+
+    def add_agent(self, type):
+        agent_id = self._agent_counters[type]
+        self._agent_counters[type] += 1
+        agent = (type, agent_id)
+        self.agents.append(agent)
+        self.terminations[agent] = False
+        self.truncations[agent] = False
+        self.rewards[agent] = 0
+        self._cumulative_rewards[agent] = 0
+        self.infos[agent] = {}
+        return agent
+
+    def reset(self, seed=None, options=None):
+        if seed is not None:
+            self._seed(seed=seed)
+        self.agents = []
+        self.rewards = {}
+        self._cumulative_rewards = {}
+        self.terminations = {}
+        self.truncations = {}
+        self.infos = {}
+        self.num_steps = 0
+
+        self._obs_spaces = {}
+        self._act_spaces = {}
+        self.state_space = gymnasium.spaces.MultiDiscrete([10, 10])
+        self._state = self.state_space.sample()
+
+        self.types = []
+        self._agent_counters = {}
+        for i in range(3):
+            self.add_type()
+        for i in range(5):
+            self.add_agent(self.np_random.choice(self.types))
+
+        self._agent_selector = agent_selector(self.agents)
+        self.agent_selection = self._agent_selector.reset()
+
+        # seed observation and action spaces
+        for i, agent in enumerate(self.agents):
+            self.observation_space(agent).seed(seed)
+        for i, agent in enumerate(self.agents):
+            self.action_space(agent).seed(seed)
+
+    def _seed(self, seed=None):
+        self.np_random, _ = gymnasium.utils.seeding.np_random(seed)
+
+    def step(self, action):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            return self._was_dead_step(action)
+
+        self._clear_rewards()
+        self._cumulative_rewards[self.agent_selection] = 0
+
+        if self._agent_selector.is_last():
+            for i in range(5):
+                if self.np_random.random() < 0.1:
+                    if self.np_random.random() < 0.1:
+                        type = self.add_type()
+                    else:
+                        type = self.np_random.choice(self.types)
+
+                    agent = self.add_agent(type)
+                    if len(self.agents) >= 20:
+                        self.terminations[self.np_random.choice(self.agents)] = True
+
+        if self._agent_selector.is_last():
+            self.num_steps += 1
+
+        if self.num_steps > self.max_cycles:
+            for agent in self.agents:
+                self.truncations[agent] = True
+
+        self.rewards[self.agents[self.np_random.choice(len(self.agents))]] = 1
+
+        self._state = self.state_space.sample()
+
+        self._accumulate_rewards()
+        self._deads_step_first()
+        if self.render_mode == "human":
+            self.render()
+
+    def render(self):
+        if self.render_mode is None:
+            gymnasium.logger.warn(
+                "You are calling render method without specifying any render mode."
+            )
+        else:
+            print(self.agents)
+
+    def close(self):
+        pass

--- a/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Tuple, Union
 
 import gymnasium
 import numpy as np
@@ -15,11 +15,11 @@ def env():
     return env
 
 
-def get_type(agent: tuple[str, int]):
+def get_type(agent: Tuple[str, int]):
     return agent[0]
 
 
-class raw_env(AECEnv[tuple[str, int], np.ndarray, Union[int, None]]):
+class raw_env(AECEnv[Tuple[str, int], np.ndarray, Union[int, None]]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_env_v0"}
 
     def __init__(self, max_cycles=100, render_mode=None):

--- a/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import gymnasium
 import numpy as np
 
@@ -17,7 +19,7 @@ def get_type(agent: tuple[str, int]):
     return agent[0]
 
 
-class raw_env(AECEnv[tuple[str, int], np.ndarray, int | None]):
+class raw_env(AECEnv[tuple[str, int], np.ndarray, Union[int, None]]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_env_v0"}
 
     def __init__(self, max_cycles=100, render_mode=None):

--- a/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
@@ -16,6 +16,7 @@ def env():
 def get_type(agent: tuple[str, int]):
     return agent[0]
 
+
 class raw_env(AECEnv[tuple[str, int], np.ndarray, int | None]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_env_v0"}
 

--- a/pettingzoo/test/example_envs/generated_agents_env_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_v0.py
@@ -17,7 +17,7 @@ def get_type(agent):
     return agent[: agent.rfind("_")]
 
 
-class raw_env(AECEnv):
+class raw_env(AECEnv[str, np.ndarray, int | None]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_env_v0"}
 
     def __init__(self, max_cycles=100, render_mode=None):
@@ -26,7 +26,7 @@ class raw_env(AECEnv):
         self._act_spaces = {}
 
         # dummy state space, not actually used
-        self.state_space = gymnasium.spaces.MultiDiscrete((10, 10))
+        self.state_space = gymnasium.spaces.MultiDiscrete([10, 10])
         self._state = self.state_space.sample()
 
         self.types = []
@@ -87,7 +87,7 @@ class raw_env(AECEnv):
 
         self._obs_spaces = {}
         self._act_spaces = {}
-        self.state_space = gymnasium.spaces.MultiDiscrete((10, 10))
+        self.state_space = gymnasium.spaces.MultiDiscrete([10, 10])
         self._state = self.state_space.sample()
 
         self.types = []

--- a/pettingzoo/test/example_envs/generated_agents_env_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_v0.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import gymnasium
 import numpy as np
 
@@ -17,7 +19,7 @@ def get_type(agent):
     return agent[: agent.rfind("_")]
 
 
-class raw_env(AECEnv[str, np.ndarray, int | None]):
+class raw_env(AECEnv[str, np.ndarray, Union[int, None]]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_env_v0"}
 
     def __init__(self, max_cycles=100, render_mode=None):

--- a/pettingzoo/test/example_envs/generated_agents_parallel_cust_agentid_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_parallel_cust_agentid_v0.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Tuple, Union
 
 import gymnasium
 import numpy as np
@@ -19,11 +19,11 @@ def raw_env(**kwargs):
     return conversions.parallel_to_aec(parallel_env(**kwargs))
 
 
-def get_type(agent: tuple[str, int]):
+def get_type(agent: Tuple[str, int]):
     return agent[0]
 
 
-class parallel_env(ParallelEnv[tuple[str, int], np.ndarray, Union[int, None]]):
+class parallel_env(ParallelEnv[Tuple[str, int], np.ndarray, Union[int, None]]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_parallel_v0"}
 
     def __init__(self, max_cycles=100, render_mode=None):

--- a/pettingzoo/test/example_envs/generated_agents_parallel_cust_agentid_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_parallel_cust_agentid_v0.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import gymnasium
 import numpy as np
 from gymnasium.utils import seeding
@@ -21,7 +23,7 @@ def get_type(agent: tuple[str, int]):
     return agent[0]
 
 
-class parallel_env(ParallelEnv[tuple[str, int], np.ndarray, int | None]):
+class parallel_env(ParallelEnv[tuple[str, int], np.ndarray, Union[int, None]]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_parallel_v0"}
 
     def __init__(self, max_cycles=100, render_mode=None):

--- a/pettingzoo/test/example_envs/generated_agents_parallel_cust_agentid_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_parallel_cust_agentid_v0.py
@@ -20,6 +20,7 @@ def raw_env(**kwargs):
 def get_type(agent: tuple[str, int]):
     return agent[0]
 
+
 class parallel_env(ParallelEnv[tuple[str, int], np.ndarray, int | None]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_parallel_v0"}
 
@@ -120,7 +121,9 @@ class parallel_env(ParallelEnv[tuple[str, int], np.ndarray, int | None]):
         if not truncated:
             for i in range(6):
                 if self.np_random.random() < 0.1 and len(self.agents) >= 10:
-                    all_terminations[self.agents[self.np_random.choice(len(self.agents))]] = True
+                    all_terminations[
+                        self.agents[self.np_random.choice(len(self.agents))]
+                    ] = True
 
             for i in range(3):
                 if self.np_random.random() < 0.1:

--- a/pettingzoo/test/example_envs/generated_agents_parallel_cust_agentid_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_parallel_cust_agentid_v0.py
@@ -1,0 +1,159 @@
+import gymnasium
+import numpy as np
+from gymnasium.utils import seeding
+
+from pettingzoo import ParallelEnv
+from pettingzoo.utils import conversions, wrappers
+
+
+def env(**kwargs):
+    env = raw_env(**kwargs)
+    env = wrappers.AssertOutOfBoundsWrapper(env)
+    env = wrappers.OrderEnforcingWrapper(env)
+    return env
+
+
+def raw_env(**kwargs):
+    return conversions.parallel_to_aec(parallel_env(**kwargs))
+
+
+def get_type(agent: tuple[str, int]):
+    return agent[0]
+
+class parallel_env(ParallelEnv[tuple[str, int], np.ndarray, int | None]):
+    metadata = {"render_modes": ["human"], "name": "generated_agents_parallel_v0"}
+
+    def __init__(self, max_cycles=100, render_mode=None):
+        super().__init__()
+        self._obs_spaces = {}
+        self._act_spaces = {}
+
+        # dummy state space, not actually used
+        self.state_space = gymnasium.spaces.MultiDiscrete([10, 10])
+        self._state = self.state_space.sample()
+
+        self.types = []
+        self._agent_counters = {}
+        self.max_cycles = max_cycles
+        self.rng_seed = None
+        self._seed()
+        self.render_mode = render_mode
+        for i in range(3):
+            self.add_type()
+
+    def observation_space(self, agent):
+        return self._obs_spaces[get_type(agent)]
+
+    def action_space(self, agent):
+        return self._act_spaces[get_type(agent)]
+
+    def state(self) -> np.ndarray:
+        return self._state
+
+    def observe(self, agent):
+        return self.observation_space(agent).sample()
+
+    def add_type(self) -> str:
+        type_id = len(self.types)
+        num_actions = self.np_random.integers(3, 10)
+        obs_size = self.np_random.integers(10, 50)
+        obs_space = gymnasium.spaces.Box(low=0, high=1, shape=(obs_size,))
+        act_space = gymnasium.spaces.Discrete(num_actions)
+        obs_space.seed(self.rng_seed)
+        act_space.seed(self.rng_seed)
+        new_type = f"type{type_id}"
+        self.types.append(new_type)
+        self._obs_spaces[new_type] = obs_space
+        self._act_spaces[new_type] = act_space
+        self._agent_counters[new_type] = 0
+        return new_type
+
+    def add_agent(self, type: str):
+        agent_id = self._agent_counters[type]
+        self._agent_counters[type] += 1
+        agent_name = (type, agent_id)
+        self.agents.append(agent_name)
+        return agent_name
+
+    def reset(self, seed=None, options=None):
+        self.rng_seed = seed
+
+        if seed is not None:
+            self._seed(seed=seed)
+        self.num_steps = 0
+
+        # Reset spaces and types
+        self._obs_spaces = {}
+        self._act_spaces = {}
+        self.state_space = gymnasium.spaces.MultiDiscrete([10, 10])
+        self._state = self.state_space.sample()
+
+        self.types = []
+        self._agent_counters = {}
+        for i in range(3):
+            self.add_type()
+
+        # Add agents
+        self.agents = []
+        for i in range(5):
+            self.add_agent(self.np_random.choice(self.types))
+
+        # seed observation and action spaces
+        for i, agent in enumerate(self.agents):
+            self.observation_space(agent).seed(seed)
+        for i, agent in enumerate(self.agents):
+            self.action_space(agent).seed(seed)
+
+        return {agent: self.observe(agent) for agent in self.agents}, {
+            agent: {} for agent in self.agents
+        }
+
+    def _seed(self, seed=None):
+        self.np_random, _ = seeding.np_random(seed)
+
+    def step(self, actions):
+        truncated = self.num_steps >= self.max_cycles
+        for agent in self.agents:
+            assert agent in actions
+        all_truncations = {agent: truncated for agent in self.agents}
+        all_terminations = {agent: False for agent in self.agents}
+        if not truncated:
+            for i in range(6):
+                if self.np_random.random() < 0.1 and len(self.agents) >= 10:
+                    all_terminations[self.agents[self.np_random.choice(len(self.agents))]] = True
+
+            for i in range(3):
+                if self.np_random.random() < 0.1:
+                    if self.np_random.random() < 0.1:
+                        type = self.add_type()
+                    else:
+                        type = self.np_random.choice(self.types)
+
+                    new_agent = self.add_agent(type)
+                    all_terminations[new_agent] = False
+                    all_truncations[new_agent] = False
+
+        all_infos = {agent: {} for agent in self.agents}
+        all_rewards = {agent: 0 for agent in self.agents}
+        all_rewards[self.agents[self.np_random.choice(len(self.agents))]] = 1
+        all_observes = {agent: self.observe(agent) for agent in self.agents}
+        self.agents = [
+            agent
+            for agent in self.agents
+            if not (all_truncations[agent] or all_terminations[agent])
+        ]
+
+        if self.render_mode == "human":
+            self.render()
+        return all_observes, all_rewards, all_terminations, all_truncations, all_infos
+
+    def render(self):
+        if self.render_mode is None:
+            gymnasium.logger.warn(
+                "You are calling render method without specifying any render mode."
+            )
+        else:
+            print(self.agents)
+
+    def close(self):
+        pass

--- a/pettingzoo/test/example_envs/generated_agents_parallel_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_parallel_v0.py
@@ -21,7 +21,7 @@ def get_type(agent):
     return agent[: agent.rfind("_")]
 
 
-class parallel_env(ParallelEnv):
+class parallel_env(ParallelEnv[str, np.ndarray, int | None]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_parallel_v0"}
 
     def __init__(self, max_cycles=100, render_mode=None):
@@ -30,7 +30,7 @@ class parallel_env(ParallelEnv):
         self._act_spaces = {}
 
         # dummy state space, not actually used
-        self.state_space = gymnasium.spaces.MultiDiscrete((10, 10))
+        self.state_space = gymnasium.spaces.MultiDiscrete([10, 10])
         self._state = self.state_space.sample()
 
         self.types = []
@@ -86,7 +86,7 @@ class parallel_env(ParallelEnv):
         # Reset spaces and types
         self._obs_spaces = {}
         self._act_spaces = {}
-        self.state_space = gymnasium.spaces.MultiDiscrete((10, 10))
+        self.state_space = gymnasium.spaces.MultiDiscrete([10, 10])
         self._state = self.state_space.sample()
 
         self.types = []

--- a/pettingzoo/test/example_envs/generated_agents_parallel_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_parallel_v0.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import gymnasium
 import numpy as np
 from gymnasium.utils import seeding
@@ -21,7 +23,7 @@ def get_type(agent):
     return agent[: agent.rfind("_")]
 
 
-class parallel_env(ParallelEnv[str, np.ndarray, int | None]):
+class parallel_env(ParallelEnv[str, np.ndarray, Union[int, None]]):
     metadata = {"render_modes": ["human"], "name": "generated_agents_parallel_v0"}
 
     def __init__(self, max_cycles=100, render_mode=None):

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -9,10 +9,15 @@ from pettingzoo.utils.conversions import (
     parallel_to_aec_wrapper,
     turn_based_aec_to_parallel_wrapper,
 )
+from pettingzoo.utils.env import ActionType, AgentID, ObsType, ParallelEnv
 from pettingzoo.utils.wrappers import BaseWrapper
 
 
-def sample_action(env, obs, agent):
+def sample_action(
+    env: ParallelEnv[AgentID, ObsType, ActionType],
+    obs: dict[AgentID, ObsType],
+    agent: AgentID,
+) -> ActionType:
     agent_obs = obs[agent]
     if isinstance(agent_obs, dict) and "action_mask" in agent_obs:
         legal_actions = np.flatnonzero(agent_obs["action_mask"])
@@ -22,7 +27,7 @@ def sample_action(env, obs, agent):
     return env.action_space(agent).sample()
 
 
-def parallel_api_test(par_env, num_cycles=1000):
+def parallel_api_test(par_env: ParallelEnv, num_cycles=1000):
     par_env.max_cycles = num_cycles
 
     if not hasattr(par_env, "possible_agents"):

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import warnings
 

--- a/pettingzoo/test/render_test.py
+++ b/pettingzoo/test/render_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 

--- a/pettingzoo/test/save_obs_test.py
+++ b/pettingzoo/test/save_obs_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gymnasium
 import numpy as np
 

--- a/pettingzoo/test/seed_test.py
+++ b/pettingzoo/test/seed_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gymnasium.utils.env_checker import data_equivalence
 
 

--- a/pettingzoo/test/state_test.py
+++ b/pettingzoo/test/state_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Tests that the environment's state() and state_space() methods work as expected."""
 import warnings
 

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -1,7 +1,7 @@
 import copy
 import warnings
 from collections import defaultdict
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional
 
 from pettingzoo.utils import agent_selector
 from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
@@ -296,7 +296,7 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
         self._observations, self.infos = self.env.reset(seed=seed, options=options)
         self.agents = self.env.agents[:]
         self._live_agents = self.agents[:]
-        self._actions: dict[AgentID, Optional[ActionType]] = {
+        self._actions: Dict[AgentID, Optional[ActionType]] = {
             agent: None for agent in self.agents
         }
         self._agent_selector = agent_selector(self._live_agents)
@@ -349,7 +349,7 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
 
             self.agents = self.env.agents + [
                 agent
-                for agent in sorted(self._observations.keys(), key=lambda x: hash(x))
+                for agent in sorted(self._observations.keys(), key=lambda x: str(x))
                 if agent not in env_agent_set
             ]
 

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -1,7 +1,7 @@
 import copy
 import warnings
 from collections import defaultdict
-from typing import Any, Callable, Generic, Optional, TypeVar
+from typing import Callable, Optional
 
 from pettingzoo.utils import agent_selector
 from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
@@ -236,8 +236,8 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
 
         try:
             self.render_mode = (
-                self.env.render_mode
-            )  # pyright: ignore[reportGeneralTypeIssues]
+                self.env.render_mode  # pyright: ignore[reportGeneralTypeIssues]
+            )
         except AttributeError:
             warnings.warn(
                 f"The base environment `{parallel_env}` does not have a `render_mode` defined."
@@ -251,8 +251,8 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
         # Not every environment has the .state_space attribute implemented
         try:
             self.state_space = (
-                self.env.state_space
-            )  # pyright: ignore[reportGeneralTypeIssues]
+                self.env.state_space  # pyright: ignore[reportGeneralTypeIssues]
+            )
         except AttributeError:
             pass
 
@@ -401,8 +401,8 @@ class turn_based_aec_to_parallel_wrapper(
         # Not every environment has the .state_space attribute implemented
         try:
             self.state_space = (
-                self.aec_env.state_space
-            )  # pyright: ignore[reportGeneralTypeIssues]
+                self.aec_env.state_space  # pyright: ignore[reportGeneralTypeIssues]
+            )
         except AttributeError:
             pass
 

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Iterable, Iterator, Generic, TypeVar
+from typing import Any, Generic, Iterable, Iterator, TypeVar
 
 import gymnasium.spaces
 import numpy as np
@@ -307,7 +307,7 @@ class ParallelEnv(Generic[AgentID, ObsType, ActionType]):
         dict[AgentID, float],
         dict[AgentID, bool],
         dict[AgentID, bool],
-        dict[AgentID, dict]
+        dict[AgentID, dict],
     ]:
         """Receives a dictionary of actions keyed by the agent name.
 

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -186,7 +186,7 @@ class AECEnv(Generic[AgentID, ObsType, ActionType]):
             self.infos[agent],
         )
 
-    def _was_dead_step(self, action: None) -> None:
+    def _was_dead_step(self, action: ActionType) -> None:
         """Helper function that performs step() for dead agents.
 
         Does the following:

--- a/pettingzoo/utils/save_observation.py
+++ b/pettingzoo/utils/save_observation.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Optional
+from typing import Any
 
 import gymnasium.spaces
 import numpy as np
 
-from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
+from pettingzoo.utils.env import AECEnv, AgentID, ParallelEnv
 
 
 def _check_observation_saveable(

--- a/pettingzoo/utils/save_observation.py
+++ b/pettingzoo/utils/save_observation.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import os
+from typing import Any, Optional
 
 import gymnasium.spaces
 import numpy as np
 
-from pettingzoo.utils.env import AECEnv, AgentID, ParallelEnv
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
 
 
-def _check_observation_saveable(env: AECEnv | ParallelEnv, agent: AgentID) -> None:
+def _check_observation_saveable(
+    env: AECEnv[AgentID, Any, Any] | ParallelEnv[AgentID, Any, Any], agent: AgentID
+) -> None:
     obs_space = env.observation_space(agent)
     assert isinstance(
         obs_space, gymnasium.spaces.Box
@@ -28,7 +31,7 @@ def _check_observation_saveable(env: AECEnv | ParallelEnv, agent: AgentID) -> No
 # save the observation of an agent. If agent not specified uses env selected agent. If all_agents
 # then all agents in environment observation recorded.
 def save_observation(
-    env: AECEnv,
+    env: AECEnv[AgentID, Any, Any],
     agent: AgentID | None = None,
     all_agents: bool = False,
     save_dir: str = os.getcwd(),

--- a/pettingzoo/utils/wrappers/assert_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/assert_out_of_bounds.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from pettingzoo.utils.env import ActionType, AECEnv
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType
 from pettingzoo.utils.wrappers.base import BaseWrapper
 
 
-class AssertOutOfBoundsWrapper(BaseWrapper):
+class AssertOutOfBoundsWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
     """Asserts if the action given to step is outside of the action space."""
 
-    def __init__(self, env: AECEnv):
+    def __init__(self, env: AECEnv[AgentID, ObsType, ActionType]):
         super().__init__(env)
 
     def step(self, action: ActionType) -> None:

--- a/pettingzoo/utils/wrappers/base.py
+++ b/pettingzoo/utils/wrappers/base.py
@@ -6,7 +6,7 @@ from typing import Any
 import gymnasium.spaces
 import numpy as np
 
-from pettingzoo.utils.env import ActionType, AgentID, AECEnv, ObsType
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType
 
 
 class BaseWrapper(AECEnv[AgentID, ObsType, ActionType]):

--- a/pettingzoo/utils/wrappers/base.py
+++ b/pettingzoo/utils/wrappers/base.py
@@ -6,16 +6,16 @@ from typing import Any
 import gymnasium.spaces
 import numpy as np
 
-from pettingzoo.utils.env import ActionType, AECEnv, ObsType
+from pettingzoo.utils.env import ActionType, AgentID, AECEnv, ObsType
 
 
-class BaseWrapper(AECEnv):
+class BaseWrapper(AECEnv[AgentID, ObsType, ActionType]):
     """Creates a wrapper around `env` parameter.
 
     All AECEnv wrappers should inherit from this base class
     """
 
-    def __init__(self, env: AECEnv):
+    def __init__(self, env: AECEnv[AgentID, ObsType, ActionType]):
         super().__init__()
         self.env = env
 
@@ -54,7 +54,7 @@ class BaseWrapper(AECEnv):
         return getattr(self.env, name)
 
     @property
-    def observation_spaces(self) -> dict[str, gymnasium.spaces.Space]:
+    def observation_spaces(self) -> dict[AgentID, gymnasium.spaces.Space]:
         warnings.warn(
             "The `observation_spaces` dictionary is deprecated. Use the `observation_space` function instead."
         )
@@ -68,7 +68,7 @@ class BaseWrapper(AECEnv):
             ) from e
 
     @property
-    def action_spaces(self) -> dict[str, gymnasium.spaces.Space]:
+    def action_spaces(self) -> dict[AgentID, gymnasium.spaces.Space]:
         warnings.warn(
             "The `action_spaces` dictionary is deprecated. Use the `action_space` function instead."
         )
@@ -79,10 +79,10 @@ class BaseWrapper(AECEnv):
                 "The base environment does not have an action_spaces dict attribute. Use the environment's `action_space` method instead"
             ) from e
 
-    def observation_space(self, agent: str) -> gymnasium.spaces.Space:
+    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space:
         return self.env.observation_space(agent)
 
-    def action_space(self, agent: str) -> gymnasium.spaces.Space:
+    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space:
         return self.env.action_space(agent)
 
     @property
@@ -106,7 +106,7 @@ class BaseWrapper(AECEnv):
         self.agents = self.env.agents
         self._cumulative_rewards = self.env._cumulative_rewards
 
-    def observe(self, agent: str) -> ObsType | None:
+    def observe(self, agent: AgentID) -> ObsType | None:
         return self.env.observe(agent)
 
     def state(self) -> np.ndarray:

--- a/pettingzoo/utils/wrappers/base_parallel.py
+++ b/pettingzoo/utils/wrappers/base_parallel.py
@@ -6,11 +6,10 @@ import gymnasium.spaces
 import numpy as np
 from gymnasium.utils import seeding
 
-from pettingzoo.utils.env import ActionType, ObsType, ParallelEnv
+from pettingzoo.utils.env import ParallelEnv, AgentID, ObsType, ActionType
 
-
-class BaseParallelWrapper(ParallelEnv):
-    def __init__(self, env: ParallelEnv):
+class BaseParallelWrapper(ParallelEnv[AgentID, ObsType, ActionType]):
+    def __init__(self, env: ParallelEnv[AgentID, ObsType, ActionType]):
         self.env = env
 
         self.metadata = env.metadata
@@ -29,7 +28,7 @@ class BaseParallelWrapper(ParallelEnv):
 
     def reset(
         self, seed: int | None = None, options: dict | None = None
-    ) -> tuple[dict[str, ObsType], dict[str, dict]]:
+    ) -> tuple[dict[AgentID, ObsType], dict[AgentID, dict]]:
         self.np_random, _ = seeding.np_random(seed)
 
         res, info = self.env.reset(seed=seed, options=options)
@@ -37,13 +36,13 @@ class BaseParallelWrapper(ParallelEnv):
         return res, info
 
     def step(
-        self, actions: dict[str, ActionType]
+        self, actions: dict[AgentID, ActionType]
     ) -> tuple[
-        dict[str, ObsType],
-        dict[str, float],
-        dict[str, bool],
-        dict[str, bool],
-        dict[str, dict],
+        dict[AgentID, ObsType],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict],
     ]:
         res = self.env.step(actions)
         self.agents = self.env.agents
@@ -63,7 +62,7 @@ class BaseParallelWrapper(ParallelEnv):
         return self.env.state()
 
     @property
-    def observation_spaces(self) -> dict[str, gymnasium.spaces.Space]:
+    def observation_spaces(self) -> dict[AgentID, gymnasium.spaces.Space]:
         warnings.warn(
             "The `observation_spaces` dictionary is deprecated. Use the `observation_space` function instead."
         )
@@ -77,7 +76,7 @@ class BaseParallelWrapper(ParallelEnv):
             ) from e
 
     @property
-    def action_spaces(self) -> dict[str, gymnasium.spaces.Space]:
+    def action_spaces(self) -> dict[AgentID, gymnasium.spaces.Space]:
         warnings.warn(
             "The `action_spaces` dictionary is deprecated. Use the `action_space` function instead."
         )
@@ -88,8 +87,8 @@ class BaseParallelWrapper(ParallelEnv):
                 "The base environment does not have an action_spaces dict attribute. Use the environments `action_space` method instead"
             ) from e
 
-    def observation_space(self, agent: str) -> gymnasium.spaces.Space:
+    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space:
         return self.env.observation_space(agent)
 
-    def action_space(self, agent: str) -> gymnasium.spaces.Space:
+    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space:
         return self.env.action_space(agent)

--- a/pettingzoo/utils/wrappers/base_parallel.py
+++ b/pettingzoo/utils/wrappers/base_parallel.py
@@ -6,7 +6,8 @@ import gymnasium.spaces
 import numpy as np
 from gymnasium.utils import seeding
 
-from pettingzoo.utils.env import ParallelEnv, AgentID, ObsType, ActionType
+from pettingzoo.utils.env import ActionType, AgentID, ObsType, ParallelEnv
+
 
 class BaseParallelWrapper(ParallelEnv[AgentID, ObsType, ActionType]):
     def __init__(self, env: ParallelEnv[AgentID, ObsType, ActionType]):

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -4,7 +4,14 @@ from typing import Any
 
 import numpy as np
 
-from pettingzoo.utils.env import ActionType, AECEnv, AECIterable, AECIterator, AgentID, ObsType
+from pettingzoo.utils.env import (
+    ActionType,
+    AECEnv,
+    AECIterable,
+    AECIterator,
+    AgentID,
+    ObsType,
+)
 from pettingzoo.utils.env_logger import EnvLogger
 from pettingzoo.utils.wrappers.base import BaseWrapper
 
@@ -90,7 +97,9 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
             EnvLogger.error_state_before_reset()
         return super().state()
 
-    def agent_iter(self, max_iter: int = 2**63) -> AECOrderEnforcingIterable[AgentID, ObsType, ActionType]:
+    def agent_iter(
+        self, max_iter: int = 2**63
+    ) -> AECOrderEnforcingIterable[AgentID, ObsType, ActionType]:
         if not self._has_reset:
             EnvLogger.error_agent_iter_before_reset()
         return AECOrderEnforcingIterable(self, max_iter)

--- a/pettingzoo/utils/wrappers/terminate_illegal.py
+++ b/pettingzoo/utils/wrappers/terminate_illegal.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
-from pettingzoo.utils.env import ActionType, AECEnv, ObsType
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType
 from pettingzoo.utils.env_logger import EnvLogger
 from pettingzoo.utils.wrappers.base import BaseWrapper
 
 
-class TerminateIllegalWrapper(BaseWrapper):
+class TerminateIllegalWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
     """This wrapper terminates the game with the current player losing in case of illegal values.
 
     Args:
         illegal_reward: number that is the value of the player making an illegal move.
     """
 
-    def __init__(self, env: AECEnv, illegal_reward: float):
+    def __init__(
+        self, env: AECEnv[AgentID, ObsType, ActionType], illegal_reward: float
+    ):
         super().__init__(env)
         self._illegal_value = illegal_reward
         self._prev_obs = None
@@ -22,7 +24,7 @@ class TerminateIllegalWrapper(BaseWrapper):
         self._prev_obs = None
         super().reset(seed=seed, options=options)
 
-    def observe(self, agent: str) -> ObsType | None:
+    def observe(self, agent: AgentID) -> ObsType | None:
         obs = super().observe(agent)
         if agent == self.agent_selection:
             self._prev_obs = obs
@@ -33,6 +35,7 @@ class TerminateIllegalWrapper(BaseWrapper):
         if self._prev_obs is None:
             self.observe(self.agent_selection)
         assert self._prev_obs
+        assert isinstance(self._prev_obs, dict)
         assert (
             "action_mask" in self._prev_obs
         ), "action_mask must always be part of environment observation as an element in a dictionary observation to use the TerminateIllegalWrapper"

--- a/test/all_parameter_combs_test.py
+++ b/test/all_parameter_combs_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pettingzoo.atari import (

--- a/test/doc_examples_test.py
+++ b/test/doc_examples_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from docs.code_examples import aec_rps, parallel_rps
 
 from pettingzoo.test import api_test, parallel_api_test

--- a/test/pickle_test.py
+++ b/test/pickle_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pickle
 
 import pytest

--- a/test/pytest_runner_test.py
+++ b/test/pytest_runner_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import pytest

--- a/test/unwrapped_test.py
+++ b/test/unwrapped_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from gymnasium import spaces
 

--- a/test/variable_env_test.py
+++ b/test/variable_env_test.py
@@ -1,9 +1,9 @@
 from pettingzoo.test import api_test, parallel_api_test, seed_test
 from pettingzoo.test.example_envs import (
-    generated_agents_env_v0,
-    generated_agents_parallel_v0,
     generated_agents_env_cust_agentid_v0,
-    generated_agents_parallel_cust_agentid_v0
+    generated_agents_env_v0,
+    generated_agents_parallel_cust_agentid_v0,
+    generated_agents_parallel_v0,
 )
 from pettingzoo.test.seed_test import (
     check_environment_deterministic_parallel,
@@ -37,7 +37,11 @@ def test_generated_agents_parallel_to_aec():
     seed_test(lambda: parallel_to_aec(generated_agents_parallel_v0.parallel_env()))
 
     api_test(parallel_to_aec(generated_agents_parallel_cust_agentid_v0.parallel_env()))
-    seed_test(lambda: parallel_to_aec(generated_agents_parallel_cust_agentid_v0.parallel_env()))
+    seed_test(
+        lambda: parallel_to_aec(
+            generated_agents_parallel_cust_agentid_v0.parallel_env()
+        )
+    )
 
 
 def test_double_conversion_equals():

--- a/test/variable_env_test.py
+++ b/test/variable_env_test.py
@@ -2,6 +2,8 @@ from pettingzoo.test import api_test, parallel_api_test, seed_test
 from pettingzoo.test.example_envs import (
     generated_agents_env_v0,
     generated_agents_parallel_v0,
+    generated_agents_env_cust_agentid_v0,
+    generated_agents_parallel_cust_agentid_v0
 )
 from pettingzoo.test.seed_test import (
     check_environment_deterministic_parallel,
@@ -11,15 +13,21 @@ from pettingzoo.utils.conversions import aec_to_parallel, parallel_to_aec
 
 
 def test_generated_agents_aec():
-    # check that that AEC env passes API test and produces deterministic behavior
+    # check that AEC env passes API test and produces deterministic behavior
     api_test(generated_agents_env_v0.env())
     seed_test(generated_agents_env_v0.env)
+    # check that AEC env using a non-string agentID passes API test and produces deterministic behavior
+    api_test(generated_agents_env_cust_agentid_v0.env())
+    seed_test(generated_agents_env_cust_agentid_v0.env)
 
 
 def test_generated_agents_parallel():
-    # check that that parallel env passes API test and produces deterministic behavior
+    # check that parallel env passes API test and produces deterministic behavior
     parallel_api_test(generated_agents_parallel_v0.parallel_env())
     parallel_seed_test(generated_agents_parallel_v0.parallel_env)
+    # check that parallel env using a non-string agentID passes API test and produces deterministic behavior
+    parallel_api_test(generated_agents_parallel_cust_agentid_v0.parallel_env())
+    parallel_seed_test(generated_agents_parallel_cust_agentid_v0.parallel_env)
 
 
 def test_generated_agents_parallel_to_aec():
@@ -27,6 +35,9 @@ def test_generated_agents_parallel_to_aec():
     # we don't do this test for aec_to_parallel because generated_agents_env_v0.env() is not parallelizable
     api_test(parallel_to_aec(generated_agents_parallel_v0.parallel_env()))
     seed_test(lambda: parallel_to_aec(generated_agents_parallel_v0.parallel_env()))
+
+    api_test(parallel_to_aec(generated_agents_parallel_cust_agentid_v0.parallel_env()))
+    seed_test(lambda: parallel_to_aec(generated_agents_parallel_cust_agentid_v0.parallel_env()))
 
 
 def test_double_conversion_equals():

--- a/test/variable_env_test.py
+++ b/test/variable_env_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pettingzoo.test import api_test, parallel_api_test, seed_test
 from pettingzoo.test.example_envs import (
     generated_agents_env_cust_agentid_v0,


### PR DESCRIPTION
# Description

Adds the feature described in https://github.com/Farama-Foundation/PettingZoo/issues/1070, by making ParallelEnv and AECEnv generic over AgentID.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
