### PR TITLE
Fix tutorial reset returns

### DIFF
--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -46,8 +46,11 @@ def parallel_api_test(par_env: ParallelEnv, num_cycles=1000):
     MAX_RESETS = 2
     for _ in range(MAX_RESETS):
         obs, infos = par_env.reset()
+
         assert isinstance(obs, dict)
+        assert isinstance(infos, dict)
         assert set(obs.keys()) == (set(par_env.agents))
+        assert set(infos.keys()) == (set(par_env.agents))
         terminated = {agent: False for agent in par_env.agents}
         truncated = {agent: False for agent in par_env.agents}
         live_agents = set(par_env.agents[:])

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -294,11 +294,6 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
 
     def reset(self, seed=None, options=None):
         self._observations, self.infos = self.env.reset(seed=seed, options=options)
-
-        # Every environment needs to return infos that contain the same keys as the observations
-        if bool(self.infos) == False:
-            self.infos = {agent: {} for agent in self._observations.keys()}
-
         self.agents = self.env.agents[:]
         self._live_agents = self.agents[:]
         self._actions: Dict[AgentID, Optional[ActionType]] = {
@@ -309,6 +304,12 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
         self.terminations = {agent: False for agent in self.agents}
         self.truncations = {agent: False for agent in self.agents}
         self.rewards = {agent: 0 for agent in self.agents}
+
+        # Every environment needs to return infos that contain the same keys as the observations
+        if bool(self.infos) == False:
+            warnings.warn("The `infos` dictionary returned by `env.reset` was empty. Agent IDs as keys will be used")
+            self.infos = {agent: {} for agent in self.agents}
+
         self._cumulative_rewards = {agent: 0 for agent in self.agents}
         self.new_agents = []
         self.new_values = {}

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -294,6 +294,11 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
 
     def reset(self, seed=None, options=None):
         self._observations, self.infos = self.env.reset(seed=seed, options=options)
+
+        # Every environment needs to return infos that contain the same keys as the observations
+        if bool(self.infos) == False:
+            self.infos = {agent: {} for agent in self._observations.keys()}
+
         self.agents = self.env.agents[:]
         self._live_agents = self.agents[:]
         self._actions: Dict[AgentID, Optional[ActionType]] = {

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -305,11 +305,14 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
         self.truncations = {agent: False for agent in self.agents}
         self.rewards = {agent: 0 for agent in self.agents}
 
-        # Every environment needs to return infos that contain the same keys as the observations
-        if bool(self.infos) == False:
+        # Every environment needs to return infos that contain self.agents as their keys
+        if not self.infos:
             warnings.warn("The `infos` dictionary returned by `env.reset` was empty. Agent IDs as keys will be used")
             self.infos = {agent: {} for agent in self.agents}
-
+        elif set(self.infos.keys()) != set(self.agents):
+            warnings.warn("The `infos` dictionary keys returned by `env.reset` is not equal to the agent IDs listed in `self.agents`. Overwriting with just agent IDs as keys")
+            self.infos = {agent: {} for agent in self.agents}
+            
         self._cumulative_rewards = {agent: 0 for agent in self.agents}
         self.new_agents = []
         self.new_values = {}

--- a/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
+++ b/tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
@@ -44,7 +44,11 @@ class CustomEnvironment(ParallelEnv):
             )
             for a in self.agents
         }
-        return observations, {}
+
+        # Get dummy infos. Necessary for proper parallel_to_aec conversion
+        infos = {a: {} for a in self.agents}
+
+        return observations, infos
 
     def step(self, actions):
         # Execute actions

--- a/tutorials/EnvironmentCreation/tutorial3_action_masking.py
+++ b/tutorials/EnvironmentCreation/tutorial3_action_masking.py
@@ -45,7 +45,11 @@ class CustomEnvironment(ParallelEnv):
             "prisoner": {"observation": observation, "action_mask": [0, 1, 1, 0]},
             "guard": {"observation": observation, "action_mask": [1, 0, 0, 1]},
         }
-        return observations, {}
+
+        # Get dummy infos. Necessary for proper parallel_to_aec conversion
+        infos = {a: {} for a in self.agents}
+
+        return observations, infos
 
     def step(self, actions):
         # Execute actions


### PR DESCRIPTION
# Description

Environments that inherit from `ParallelEnv` and are converted to  `AECEnv` via `parallel_to_aec` require named agent keys in their `env.reset() `infos` returns. This is because the generated `env.last` function uses the info IDs from the `env.reset` return.

The tutorial for custom environment creation had an empty object returned for `infos`, which would pass the current `parallel_api_test` however cause failures if a user for example wanted to train their agents in Tianshou and needed to covert `ParallelEnv` as an `AECEnv` before necessary Tianshou wrappers..

This fix looks to update the documentation while also updating the `parallel_api_test` to catch this oversight in current and future projects.

Fixes # (issue), Depends on # (pull request)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Screenshots
The CustomEnvironment is copied over verbatim, and we are trying to wrap it in a compatible Tianshou PettingZooEnv 

![image](https://github.com/Farama-Foundation/PettingZoo/assets/98220445/884a1d1b-e25f-49ea-a900-add05586736e)


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
