### PR TITLE
Check `parallel_seed_test` for all envs, fix `seed_test` to actually use `num_cycles` arg

### DIFF
--- a/pettingzoo/test/seed_test.py
+++ b/pettingzoo/test/seed_test.py
@@ -116,15 +116,15 @@ def check_environment_deterministic_parallel(env1, env2, num_cycles):
     env2.close()
 
 
-def seed_test(env_constructor, num_cycles=10):
+def seed_test(env_constructor, num_cycles=500):
     env1 = env_constructor()
     env2 = env_constructor()
 
-    check_environment_deterministic(env1, env2, 500)
+    check_environment_deterministic(env1, env2, num_cycles)
 
 
-def parallel_seed_test(parallel_env_fn):
+def parallel_seed_test(parallel_env_fn, num_cycles=500):
     env1 = parallel_env_fn()
     env2 = parallel_env_fn()
 
-    check_environment_deterministic_parallel(env1, env2, 500)
+    check_environment_deterministic_parallel(env1, env2, num_cycles)

--- a/test/all_parameter_combs_test.py
+++ b/test/all_parameter_combs_test.py
@@ -60,7 +60,7 @@ from pettingzoo.sisl import multiwalker_v9, pursuit_v4, waterworld_v4
 from pettingzoo.test import max_cycles_test, parallel_api_test
 from pettingzoo.test.api_test import api_test
 from pettingzoo.test.render_test import render_test
-from pettingzoo.test.seed_test import seed_test
+from pettingzoo.test.seed_test import parallel_seed_test, seed_test
 from pettingzoo.test.state_test import state_test
 
 parameterized_envs = [
@@ -367,10 +367,11 @@ def test_module(name, env_module, kwargs):
     if "classic/" not in name:
         parallel_api_test(env_module.parallel_env())
         max_cycles_test(env_module)
+        parallel_seed_test(lambda: env_module.parallel_env(**kwargs), 500)
 
-    # some atari environments fail this test, waterworld fails for certain seeds
+    # some atari environments fail this test
     if "atari/" not in name:
-        seed_test(lambda: env_module.env(**kwargs), 50)
+        seed_test(lambda: env_module.env(**kwargs), 500)
 
     render_test(lambda render_mode: env_module.env(render_mode=render_mode, **kwargs))
 


### PR DESCRIPTION
Minor testing updates, just to check that parallel envs work with the seed test as well. The seed test has an argument which was unused so I made it actually work and mirrored it to the parallel seed test as well. Non-breaking changes, just quality of life improvements.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
