### PR TITLE
fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We support Python 3.8, 3.9, 3.10 and 3.11 on Linux and macOS. We will accept PRs
 
 ## Getting started
 
-For an introduction to PettingZoo, see [Basic Usage](https://pettingzoo.farama.org/content/basic_usage/). To create a new environment, see our [Environment Creation Tutorial](https://pettingzoo.farama.org/tutorials/environmentcreation/1-project-structure/) and [Custom Environment Examples](https://pettingzoo.farama.org/content/environment_creation/).
+For an introduction to PettingZoo, see [Basic Usage](https://pettingzoo.farama.org/content/basic_usage/). To create a new environment, see our [Environment Creation Tutorial](https://pettingzoo.farama.org/tutorials/custom_environment/1-project-structure/) and [Custom Environment Examples](https://pettingzoo.farama.org/content/environment_creation/).
 For examples of training RL models using PettingZoo see our tutorials:
 * [CleanRL: Implementing PPO](https://pettingzoo.farama.org/tutorials/cleanrl/implementing_PPO/):train multiple PPO agents in the [Pistonball](https://pettingzoo.farama.org/environments/butterfly/pistonball/) environment.
 * [Tianshou: Training Agents](https://pettingzoo.farama.org/tutorials/tianshou/intermediate/): train DQN agents in the [Tic-Tac-Toe](https://pettingzoo.farama.org/environments/classic/tictactoe/) environment.

--- a/docs/api/aec.md
+++ b/docs/api/aec.md
@@ -77,7 +77,7 @@ Note: action masking is optional, and can be implemented using either `observati
 * [Shimmy](https://shimmy.farama.org/)'s [OpenSpiel environments](https://shimmy.farama.org/environments/open_spiel/) stores action masks in the `info` dict:
   * `mask = info["action_mask"]`
 
-To implement action masking in a custom environment, see [Environment Creation: Action Masking](/tutorials/environmentcreation/3-action-masking/)
+To implement action masking in a custom environment, see [Custom Environment: Action Masking](/tutorials/custom_environment/3-action-masking/)
 
 For more information on action masking, see [A Closer Look at Invalid Action Masking in Policy Gradient Algorithms](https://arxiv.org/abs/2006.14171) (Huang, 2022)
 

--- a/docs/api/parallel.md
+++ b/docs/api/parallel.md
@@ -15,7 +15,7 @@ For a comparison with the AEC API, see [About AEC](https://pettingzoo.farama.org
 
 [PettingZoo Butterfly](/environments/butterfly/) provides standard examples of Parallel environments, such as [Pistonball](/environments/butterfly/pistonball).
 
-We provide tutorials for creating two custom Parallel environments: [Rock-Paper-Scissors (Parallel)](https://pettingzoo.farama.org/content/environment_creation/#example-custom-parallel-environment), and a simple [gridworld environment](/tutorials/environmentcreation/2-environment-logic/)
+We provide tutorials for creating two custom Parallel environments: [Rock-Paper-Scissors (Parallel)](https://pettingzoo.farama.org/content/environment_creation/#example-custom-parallel-environment), and a simple [gridworld environment](/tutorials/custom_environment/2-environment-logic/)
 
 ## Usage
 

--- a/docs/tutorials/custom_environment/1-project-structure.md
+++ b/docs/tutorials/custom_environment/1-project-structure.md
@@ -41,7 +41,7 @@ Implementing these are outside the scope of this tutorial.
 The entirety of your environment logic is stored within `/custom-environment/env`
 
 ```{eval-rst}
-.. literalinclude:: ../../../tutorials/EnvironmentCreation/tutorial1_skeleton_creation.py
+.. literalinclude:: ../../../tutorials/CustomEnvironment/tutorial1_skeleton_creation.py
    :language: python
    :caption: /custom-environment/env/custom_environment.py
 ```

--- a/docs/tutorials/custom_environment/2-environment-logic.md
+++ b/docs/tutorials/custom_environment/2-environment-logic.md
@@ -17,7 +17,7 @@ For this tutorial, we will be creating a two-player game consisting of a prisone
 ## Code
 
 ```{eval-rst}
-.. literalinclude:: ../../../tutorials/EnvironmentCreation/tutorial2_adding_game_logic.py
+.. literalinclude:: ../../../tutorials/CustomEnvironment/tutorial2_adding_game_logic.py
    :language: python
    :caption: /custom-environment/env/custom_environment.py
 ```

--- a/docs/tutorials/custom_environment/3-action-masking.md
+++ b/docs/tutorials/custom_environment/3-action-masking.md
@@ -13,7 +13,7 @@ Action masking is a more natural way of handling invalid actions than having an 
 ## Code
 
 ```{eval-rst}
-.. literalinclude:: ../../../tutorials/EnvironmentCreation/tutorial3_action_masking.py
+.. literalinclude:: ../../../tutorials/CustomEnvironment/tutorial3_action_masking.py
    :language: python
    :caption: /custom-environment/env/custom_environment.py
 ```

--- a/docs/tutorials/custom_environment/4-testing-your-environment.md
+++ b/docs/tutorials/custom_environment/4-testing-your-environment.md
@@ -15,7 +15,7 @@ Note: This code can be added to the bottom of the same file, without using any i
 Relative importing is used for simplicity, and assumes your custom environment is in the same directory. If your test is in another location (e.g., a root-level `/test/` directory), it is recommended to import using absolute path.
 
 ```{eval-rst}
-.. literalinclude:: ../../../tutorials/EnvironmentCreation/tutorial4_testing_the_environment.py
+.. literalinclude:: ../../../tutorials/CustomEnvironment/tutorial4_testing_the_environment.py
    :language: python
    :caption: /custom-environment/env/custom_environment.py
 ```

--- a/docs/tutorials/custom_environment/index.md
+++ b/docs/tutorials/custom_environment/index.md
@@ -6,13 +6,13 @@ title: "Custom Environment Tutorial"
 
 These tutorials walk you though the full process of creating a custom environment from scratch, and are recommended as a starting point for anyone new to PettingZoo.
 
-1. [Project Structure](/tutorials/environmentcreation/1-project-structure.md)
+1. [Project Structure](/tutorials/custom_environment/1-project-structure.md)
 
-2. [Environment Logic](/tutorials/environmentcreation/2-environment-logic.md)
+2. [Environment Logic](/tutorials/custom_environment/2-environment-logic.md)
 
-3. [Action Masking](/tutorials/environmentcreation/3-action-masking.md)
+3. [Action Masking](/tutorials/custom_environment/3-action-masking.md)
 
-4. [Testing Your Environment](/tutorials/environmentcreation/4-testing-your-environment.md)
+4. [Testing Your Environment](/tutorials/custom_environment/4-testing-your-environment.md)
 
 For a simpler example environment, including both [AEC](/api/aec/) and [Parallel](/api/aec/) implementations, see our [Environment Creation](/content/environment_creation/) documentation.
 


### PR DESCRIPTION
# Description

Fix some broken links to the code and markdown file in documentation, as the directory `tutorials/EnvironmentCreation` is renamed to` tutorials/CustomEnvironment` and the directory `docs/tutorials/environmentcreation` is renamed to `docs/tutorials/custom_environment `in #1082.


## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

### Screenshots
An example of broken links to the code of the tutorial in https://pettingzoo.farama.org/tutorials/custom_environment/3-action-masking/:
 
<img src="https://github.com/Farama-Foundation/PettingZoo/assets/36284272/7a3ddaa9-d894-43d6-a3ea-ec8f7c6143e5" width="500" />

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
