### PR TITLE
[DOC] Add version table to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This does not include dependencies for all families of environments (some enviro
 
 To install the dependencies for one family, use `pip install pettingzoo[atari]`, or use `pip install pettingzoo[all]` to install all dependencies.
 
-PettingZoo supports Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+PettingZoo supports Python 3.8, 3.9, 3.10 and 3.11 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 
 The following table shows how PettingZoo versions correspond to supported Gymnasium and Python versions.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,16 @@ This does not include dependencies for all families of environments (some enviro
 
 To install the dependencies for one family, use `pip install pettingzoo[atari]`, or use `pip install pettingzoo[all]` to install all dependencies.
 
-We support Python 3.8, 3.9, 3.10 and 3.11 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+PettingZoo supports Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+
+The following table shows how PettingZoo versions correspond to supported Gymnasium and Python versions.
+
+| Gymnasium | PettingZoo | Python |
+|-----------|------------|--------|
+| `0.29`    | `1.24`     | `>=3.8`, `<=3.11`
+| `0.28`    | `1.23`     | `>=3.7`, `<=3.11`
+| `0.27`    | `1.22`     | `>=3.7`, `<=3.11`
+| `0.26`    | `1.22`     | `>=3.7`, `<=3.10` (`3.11` supported in PettingZoo `>=1.22.3`)
 
 ## Getting started
 


### PR DESCRIPTION
# Description

I'd like to add a compatibility version table to the main README file to help myself and others track which versions of Gymnasium and Python are supported by each version of PettingZoo. This table is inspired by the table listed in the README of the [torchvision](https://github.com/pytorch/vision) package.

I've pieced together the compatibility information based on the [`pyproject.toml`](https://github.com/Farama-Foundation/PettingZoo/blob/master/pyproject.toml) file. However, I'm not 100% sure that I did this correctly, so I would appreciate a core PettingZoo maintainer double-checking this information.

## Type of change

Documentation