### PR TITLE
Update parallel_test.py to support Ray RLLib MultiAgentEnv

### DIFF
--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -114,7 +114,8 @@ def parallel_api_test(par_env: ParallelEnv, num_cycles=1000):
                     agent
                 ), "action_space should return the exact same space object (not a copy) for an agent (ensures that action space seeding works as expected). Consider decorating your action_space(self, agent) method with @functools.lru_cache(maxsize=None)"
 
-            for agent in live_agents:
+            # we make a copy of live_agents because live_agents changes during iteration
+            for agent in set(live_agents):
                 if terminated[agent] or truncated[agent]:
                     live_agents.remove(agent)
 

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -96,11 +96,8 @@ def parallel_api_test(par_env: ParallelEnv, num_cycles=1000):
 
                 has_finished |= {
                     agent
-                    for agent, d in [
-                        (x[0], x[1] or y[1])
-                        for x, y in zip(terminated.items(), truncated.items())
-                    ]
-                    if d
+                    for agent in live_agents
+                    if terminated[agent] or truncated[agent]
                 }
                 if not par_env.agents and has_finished != set(par_env.possible_agents):
                     warnings.warn(
@@ -117,11 +114,8 @@ def parallel_api_test(par_env: ParallelEnv, num_cycles=1000):
                     agent
                 ), "action_space should return the exact same space object (not a copy) for an agent (ensures that action space seeding works as expected). Consider decorating your action_space(self, agent) method with @functools.lru_cache(maxsize=None)"
 
-            for agent, d in [
-                (x[0], x[1] or y[1])
-                for x, y in zip(terminated.items(), truncated.items())
-            ]:
-                if d:
+            for agent in live_agents:
+                if terminated[agent] or truncated[agent]:
                     live_agents.remove(agent)
 
             assert (

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -115,8 +115,7 @@ def parallel_api_test(par_env: ParallelEnv, num_cycles=1000):
                 ), "action_space should return the exact same space object (not a copy) for an agent (ensures that action space seeding works as expected). Consider decorating your action_space(self, agent) method with @functools.lru_cache(maxsize=None)"
 
             agents_to_remove = {
-                agent for agent in live_agents
-                if terminated[agent] or truncated[agent]
+                agent for agent in live_agents if terminated[agent] or truncated[agent]
             }
             live_agents -= agents_to_remove
 

--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -114,10 +114,11 @@ def parallel_api_test(par_env: ParallelEnv, num_cycles=1000):
                     agent
                 ), "action_space should return the exact same space object (not a copy) for an agent (ensures that action space seeding works as expected). Consider decorating your action_space(self, agent) method with @functools.lru_cache(maxsize=None)"
 
-            # we make a copy of live_agents because live_agents changes during iteration
-            for agent in set(live_agents):
-                if terminated[agent] or truncated[agent]:
-                    live_agents.remove(agent)
+            agents_to_remove = {
+                agent for agent in live_agents
+                if terminated[agent] or truncated[agent]
+            }
+            live_agents -= agents_to_remove
 
             assert (
                 set(par_env.agents) == live_agents


### PR DESCRIPTION
# Description

I updated `parallel_test.py` so that it only checks the truncated/terminated status of agents in `live_agents` (which was created from `self.agents`). This allows `parallel_test.py` to not fail on an environment that tries to implement RLLib's `MultiAgentEnv` API, which requires the `terminated` and `truncated` dicts to include a special `'__all__'` key.

See https://github.com/ray-project/ray/blob/3e8a1dc6064225a5039a171b2dc5afb0beb7f0f8/rllib/env/multi_agent_env.py#L106C14-L106C21

With this change, an environment that inherits from both `pettingzoo.ParallelEnv` and `ray.rllib.env.MultiAgentEnv` will pass the PettingZoo `parallel_api_test()` checker:

```python
from ray.rllib.env import MultiAgentEnv
from sustaingym.envs.cogen import CogenEnv

class CustomMultiAgentEnv(ParallelEnv, MultiAgentEnv):
    ...
```

I do not believe that this pull request changes `parallel_test.py` in any other meaningful way.

# Tests

I tried following the instructions in [CONTRIBUTING.md](https://github.com/Farama-Foundation/PettingZoo/blob/master/CONTRIBUTING.md) but was unable to get `pytest` to work. See #1094.