### PR TITLE
Allow parallel envs to have other optional keys in info/obs dicts (e.g., "common")

### DIFF
--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -49,8 +49,9 @@ def parallel_api_test(par_env: ParallelEnv, num_cycles=1000):
 
         assert isinstance(obs, dict)
         assert isinstance(infos, dict)
-        assert set(obs.keys()) == (set(par_env.agents))
-        assert set(infos.keys()) == (set(par_env.agents))
+        # Note: obs and info dicts must contain all AgentIDs, but can also have other additional keys (e.g., "common")
+        assert set(par_env.agents).issubset(set(obs.keys()))
+        assert set(par_env.agents).issubset(set(infos.keys()))
         terminated = {agent: False for agent in par_env.agents}
         truncated = {agent: False for agent in par_env.agents}
         live_agents = set(par_env.agents[:])


### PR DESCRIPTION
This fixes https://github.com/Farama-Foundation/PettingZoo/issues/1102

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
