### PR TITLE
Update Ray tutorials to RLlib 2.7.0

### DIFF
--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.8', '3.9', '3.10', '3.11']
-                tutorial: [Tianshou, CustomEnvironment, CleanRL, Ray, SB3/kaz, SB3/waterworld, SB3/connect_four, SB3/test, AgileRL]
+                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/connect_four, SB3/test, AgileRL]
         steps:
             - uses: actions/checkout@v3
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.8', '3.9', '3.10', '3.11']
-                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/connect_four, SB3/test, AgileRL]       # TODO: add back Ray once next release after 2.6.2
+                tutorial: [Tianshou, CustomEnvironment, CleanRL, Ray, SB3/kaz, SB3/waterworld, SB3/connect_four, SB3/test, AgileRL]
         steps:
             - uses: actions/checkout@v3
             - name: Set up Python ${{ matrix.python-version }}

--- a/tutorials/Ray/render_rllib_leduc_holdem.py
+++ b/tutorials/Ray/render_rllib_leduc_holdem.py
@@ -7,12 +7,12 @@ import argparse
 import os
 
 import numpy as np
-# import ray
-# from ray.rllib.algorithms.algorithm import Algorithm
-# from ray.rllib.env.wrappers.pettingzoo_env import PettingZooEnv
-# from ray.rllib.models import ModelCatalog
-# from ray.tune.registry import register_env
-# from rllib_leduc_holdem import TorchMaskedActions
+import ray
+from ray.rllib.algorithms.algorithm import Algorithm
+from ray.rllib.env.wrappers.pettingzoo_env import PettingZooEnv
+from ray.rllib.models import ModelCatalog
+from ray.tune.registry import register_env
+from rllib_leduc_holdem import TorchMaskedActions
 
 from pettingzoo.classic import leduc_holdem_v4
 

--- a/tutorials/Ray/render_rllib_leduc_holdem.py
+++ b/tutorials/Ray/render_rllib_leduc_holdem.py
@@ -7,12 +7,12 @@ import argparse
 import os
 
 import numpy as np
-import ray
-from ray.rllib.algorithms.algorithm import Algorithm
-from ray.rllib.env.wrappers.pettingzoo_env import PettingZooEnv
-from ray.rllib.models import ModelCatalog
-from ray.tune.registry import register_env
-from rllib_leduc_holdem import TorchMaskedActions
+# import ray
+# from ray.rllib.algorithms.algorithm import Algorithm
+# from ray.rllib.env.wrappers.pettingzoo_env import PettingZooEnv
+# from ray.rllib.models import ModelCatalog
+# from ray.tune.registry import register_env
+# from rllib_leduc_holdem import TorchMaskedActions
 
 from pettingzoo.classic import leduc_holdem_v4
 
@@ -27,6 +27,11 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
+
+
+if args.checkpoint_path is None:
+    print("The following arguments are required: --checkpoint-path")
+    exit(0)
 
 checkpoint_path = os.path.expanduser(args.checkpoint_path)
 

--- a/tutorials/Ray/render_rllib_pistonball.py
+++ b/tutorials/Ray/render_rllib_pistonball.py
@@ -29,6 +29,10 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+if args.checkpoint_path is None:
+    print("The following arguments are required: --checkpoint-path")
+    exit(0)
+
 checkpoint_path = os.path.expanduser(args.checkpoint_path)
 
 ModelCatalog.register_custom_model("CNNModelV2", CNNModelV2)

--- a/tutorials/Ray/render_rllib_pistonball.py
+++ b/tutorials/Ray/render_rllib_pistonball.py
@@ -12,10 +12,39 @@ from PIL import Image
 from ray.rllib.algorithms.ppo import PPO
 from ray.rllib.env.wrappers.pettingzoo_env import PettingZooEnv
 from ray.rllib.models import ModelCatalog
+from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
 from ray.tune.registry import register_env
-from tutorials.Ray.rllib_pistonball import CNNModelV2
+from torch import nn
 
 from pettingzoo.butterfly import pistonball_v6
+
+
+class CNNModelV2(TorchModelV2, nn.Module):
+    def __init__(self, obs_space, act_space, num_outputs, *args, **kwargs):
+        TorchModelV2.__init__(self, obs_space, act_space, num_outputs, *args, **kwargs)
+        nn.Module.__init__(self)
+        self.model = nn.Sequential(
+            nn.Conv2d(3, 32, [8, 8], stride=(4, 4)),
+            nn.ReLU(),
+            nn.Conv2d(32, 64, [4, 4], stride=(2, 2)),
+            nn.ReLU(),
+            nn.Conv2d(64, 64, [3, 3], stride=(1, 1)),
+            nn.ReLU(),
+            nn.Flatten(),
+            (nn.Linear(3136, 512)),
+            nn.ReLU(),
+        )
+        self.policy_fn = nn.Linear(512, num_outputs)
+        self.value_fn = nn.Linear(512, 1)
+
+    def forward(self, input_dict, state, seq_lens):
+        model_out = self.model(input_dict["obs"].permute(0, 3, 1, 2))
+        self._value_out = self.value_fn(model_out)
+        return self.policy_fn(model_out), state
+
+    def value_function(self):
+        return self._value_out.flatten()
+
 
 os.environ["SDL_VIDEODRIVER"] = "dummy"
 

--- a/tutorials/Ray/requirements.txt
+++ b/tutorials/Ray/requirements.txt
@@ -1,7 +1,6 @@
 PettingZoo[classic,butterfly]>=1.24.0
 Pillow>=9.4.0
-# note: currently requires nightly release, see https://docs.ray.io/en/latest/ray-overview/installation.html#daily-releases-nightlies
-ray[rllib]>2.6.3
+ray[rllib]>=2.7.0
 SuperSuit>=3.9.0
 torch>=1.13.1
 tensorflow-probability>=0.19.0


### PR DESCRIPTION
# Description

Ray 2.7.0 is out now so it should work with the PettingZoo changes incorporated (there was previously a TODO about adding this once the next release from 2.6.2 was out).

Edit: looks like the tutorial code takes 35+ minutes to run. Going to just leave it disabled in CI, after confirming that it does work locally and in CI.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
