### PR TITLE
fix: tictactoe doc

### DIFF
--- a/pettingzoo/classic/tictactoe/tictactoe.py
+++ b/pettingzoo/classic/tictactoe/tictactoe.py
@@ -12,7 +12,7 @@ This environment is part of the <a href='..'>classic environments</a>. Please re
 | Import             | `from pettingzoo.classic import tictactoe_v3` |
 |--------------------|-----------------------------------------------|
 | Actions            | Discrete                                      |
-| Parallel API       | Yes                                           |
+| Parallel API       | No                                            |
 | Manual Control     | No                                            |
 | Agents             | `agents= ['player_1', 'player_2']`            |
 | Agents             | 2                                             |


### PR DESCRIPTION
# Description

No parallel API is not possible in tic-tac-toe. The docstring was wrongfully said that parallel API is available.

## Type of change

- This change requires a documentation update