### PR TITLE
Fix typo in simple_reference docstring

### DIFF
--- a/pettingzoo/mpe/simple_reference/simple_reference.py
+++ b/pettingzoo/mpe/simple_reference/simple_reference.py
@@ -14,7 +14,7 @@ This environment is part of the <a href='..'>MPE environments</a>. Please read t
 | Actions            | Discrete/Continuous                              |
 | Parallel API       | Yes                                              |
 | Manual Control     | No                                               |
-| Agents             | `agents= [adversary_0, agent_0,agent_1]`         |
+| Agents             | `agents= [agent_0,agent_1]`                      |
 | Agents             | 3                                                |
 | Action Shape       | (5)                                              |
 | Action Values      | Discrete(5)/Box(0.0, 1.0, (5))                   |


### PR DESCRIPTION
Testing this out because another PR had a weird pre-commit error, expect this to also fail the same way but just want to be sure

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
