### PR TITLE
Fix minor bug in TerminateIllegal wrapper indexing empty info dict

### DIFF
--- a/pettingzoo/utils/wrappers/terminate_illegal.py
+++ b/pettingzoo/utils/wrappers/terminate_illegal.py
@@ -31,7 +31,10 @@ class TerminateIllegalWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
         obs = super().observe(agent)
         if agent == self.agent_selection:
             self._prev_obs = obs
-            self._prev_info = self.infos[self.agent_selection]
+            if self.agent_selection in self.infos:
+                self._prev_info = self.infos[self.agent_selection]
+            else:
+                self._prev_info = {}
         return obs
 
     def step(self, action: ActionType) -> None:


### PR DESCRIPTION
This fixes an issue with this PR https://github.com/Farama-Foundation/SuperSuit/pull/233

The tests all now pass with that PR locally, was just due to indexing an empty `infos` dict which does not contain the agent ID. This happens at termination, when you try to observe, there are no agents therefore there is nothing in the info dict or terminations dicts either, so it doesn't make sense to check `infos[self.agent_selection]` in that case.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
