### PR TITLE
fix the rendering bug of MPE environment

### DIFF
--- a/pettingzoo/mpe/_mpe_utils/simple_env.py
+++ b/pettingzoo/mpe/_mpe_utils/simple_env.py
@@ -265,6 +265,7 @@ class SimpleEnv(AECEnv):
     def enable_render(self, mode="human"):
         if not self.renderOn and mode == "human":
             self.screen = pygame.display.set_mode(self.screen.get_size())
+            self.clock = pygame.time.Clock()
             self.renderOn = True
 
     def render(self):
@@ -282,6 +283,7 @@ class SimpleEnv(AECEnv):
             return np.transpose(observation, axes=(1, 0, 2))
         elif self.render_mode == "human":
             pygame.display.flip()
+            self.clock.tick(self.metadata["render_fps"])
             return
 
     def draw(self):


### PR DESCRIPTION
# Description

* **Bug Description**: When using the following example code of environment **simple_adversary_v3**  as provided in the [PettingZoo Doc](https://pettingzoo.farama.org/environments/mpe/simple_adversary/), the rendering window disappears in a flash. 
  ```python
  from pettingzoo.mpe import simple_adversary_v3
  
  env = simple_adversary_v3.parallel_env(render_mode="human")
  observations, infos = env.reset()

  while env.agents:
      # this is where you would insert your policy
      actions = {agent: env.action_space(agent).sample() for agent in env.agents}
  
      observations, rewards, terminations, truncations, infos = env.step(actions)
  env.close()
* **Bug location**: In file `pettingzoo/mpe/_mpe_utils/simple_env.py`
The variable `"render_fps": 10` in line 34 is not used to control the rendering speed.


## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
