### PR TITLE
Fix seed test to work with action_mask in info, add tests to ensure info action masking works

### DIFF
--- a/pettingzoo/test/example_envs/generated_agents_env_action_mask_info_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_action_mask_info_v0.py
@@ -10,6 +10,7 @@ from pettingzoo.utils.agent_selector import agent_selector
 
 def env():
     env = raw_env()
+    env = wrappers.TerminateIllegalWrapper(env, illegal_reward=-1)
     env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.OrderEnforcingWrapper(env)
     return env
@@ -73,7 +74,8 @@ class raw_env(AECEnv[str, np.ndarray, Union[int, None]]):
         self.truncations[agent] = False
         self.rewards[agent] = 0
         self._cumulative_rewards[agent] = 0
-        self.infos[agent] = {}
+        num_actions = self._act_spaces[type].n
+        self.infos[agent] = {"action_mask": np.eye(num_actions)[self.np_random.choice(num_actions)].astype(np.int8)}
         return agent
 
     def reset(self, seed=None, options=None):
@@ -146,6 +148,11 @@ class raw_env(AECEnv[str, np.ndarray, Union[int, None]]):
 
         self._accumulate_rewards()
         self._deads_step_first()
+
+        # Sample info action mask randomly
+        type = self.agent_selection.split("_")[0]
+        num_actions = self._act_spaces[type].n
+        self.infos[self.agent_selection] = {"action_mask": np.eye(num_actions)[self.np_random.choice(num_actions)].astype(np.int8)}
 
         # Cycle agents
         self.agent_selection = self._agent_selector.next()

--- a/pettingzoo/test/example_envs/generated_agents_env_action_mask_info_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_action_mask_info_v0.py
@@ -75,7 +75,11 @@ class raw_env(AECEnv[str, np.ndarray, Union[int, None]]):
         self.rewards[agent] = 0
         self._cumulative_rewards[agent] = 0
         num_actions = self._act_spaces[type].n
-        self.infos[agent] = {"action_mask": np.eye(num_actions)[self.np_random.choice(num_actions)].astype(np.int8)}
+        self.infos[agent] = {
+            "action_mask": np.eye(num_actions)[
+                self.np_random.choice(num_actions)
+            ].astype(np.int8)
+        }
         return agent
 
     def reset(self, seed=None, options=None):
@@ -152,7 +156,11 @@ class raw_env(AECEnv[str, np.ndarray, Union[int, None]]):
         # Sample info action mask randomly
         type = self.agent_selection.split("_")[0]
         num_actions = self._act_spaces[type].n
-        self.infos[self.agent_selection] = {"action_mask": np.eye(num_actions)[self.np_random.choice(num_actions)].astype(np.int8)}
+        self.infos[self.agent_selection] = {
+            "action_mask": np.eye(num_actions)[
+                self.np_random.choice(num_actions)
+            ].astype(np.int8)
+        }
 
         # Cycle agents
         self.agent_selection = self._agent_selector.next()

--- a/pettingzoo/test/example_envs/generated_agents_env_action_mask_obs_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_action_mask_obs_v0.py
@@ -59,7 +59,9 @@ class raw_env(AECEnv[str, np.ndarray, Union[int, None]]):
         obs_space = gymnasium.spaces.Dict(
             {
                 "observation": gymnasium.spaces.Box(low=0, high=1, shape=(obs_size,)),
-                "action_mask": gymnasium.spaces.Box(low=0, high=1, shape=(num_actions,), dtype=np.int8),
+                "action_mask": gymnasium.spaces.Box(
+                    low=0, high=1, shape=(num_actions,), dtype=np.int8
+                ),
             }
         )
         act_space = gymnasium.spaces.Discrete(num_actions)

--- a/pettingzoo/test/example_envs/generated_agents_env_action_mask_obs_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_action_mask_obs_v0.py
@@ -10,6 +10,7 @@ from pettingzoo.utils.agent_selector import agent_selector
 
 def env():
     env = raw_env()
+    env = wrappers.TerminateIllegalWrapper(env, illegal_reward=-1)
     env = wrappers.AssertOutOfBoundsWrapper(env)
     env = wrappers.OrderEnforcingWrapper(env)
     return env
@@ -55,7 +56,12 @@ class raw_env(AECEnv[str, np.ndarray, Union[int, None]]):
         type_id = len(self.types)
         num_actions = self.np_random.integers(3, 10)
         obs_size = self.np_random.integers(10, 50)
-        obs_space = gymnasium.spaces.Box(low=0, high=1, shape=(obs_size,))
+        obs_space = gymnasium.spaces.Dict(
+            {
+                "observation": gymnasium.spaces.Box(low=0, high=1, shape=(obs_size,)),
+                "action_mask": gymnasium.spaces.Box(low=0, high=1, shape=(num_actions,), dtype=np.int8),
+            }
+        )
         act_space = gymnasium.spaces.Discrete(num_actions)
         new_type = f"type{type_id}"
         self.types.append(new_type)

--- a/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
+++ b/pettingzoo/test/example_envs/generated_agents_env_cust_agentid_v0.py
@@ -146,6 +146,10 @@ class raw_env(AECEnv[Tuple[str, int], np.ndarray, Union[int, None]]):
 
         self._accumulate_rewards()
         self._deads_step_first()
+
+        # Cycle agents
+        self.agent_selection = self._agent_selector.next()
+
         if self.render_mode == "human":
             self.render()
 

--- a/pettingzoo/test/seed_test.py
+++ b/pettingzoo/test/seed_test.py
@@ -47,8 +47,17 @@ def check_environment_deterministic(env1, env2, num_cycles):
         if termination1 or truncation1:
             break
 
-        mask1 = obs1.get("action_mask") if isinstance(obs1, dict) else None
-        mask2 = obs2.get("action_mask") if isinstance(obs2, dict) else None
+        mask1 = (
+            obs1.get("action_mask")
+            if (isinstance(obs1, dict) and "action_mask" in obs1)
+            else (info1.get("action_mask") if "action_mask" in info1 else None)
+        )
+        mask2 = (
+            obs2.get("action_mask")
+            if (isinstance(obs2, dict) and "action_mask" in obs2)
+            else (info2.get("action_mask") if "action_mask" in info2 else None)
+        )
+
         assert data_equivalence(mask1, mask2), f"Incorrect action mask: {mask1} {mask2}"
 
         action1 = env1.action_space(agent1).sample(mask1)

--- a/test/action_mask_test.py
+++ b/test/action_mask_test.py
@@ -1,0 +1,36 @@
+from typing import Type
+
+import pytest
+from pettingzoo.utils.env import AECEnv
+
+from pettingzoo.test import seed_test, api_test
+
+from pettingzoo.test.example_envs import generated_agents_env_action_mask_obs_v0, generated_agents_env_action_mask_info_v0
+
+@pytest.mark.parametrize("env_constructor", [generated_agents_env_action_mask_info_v0.env, generated_agents_env_action_mask_obs_v0.env])
+def test_action_mask(env_constructor: Type[AECEnv]):
+    """Test that environments function deterministically in cases where action mask is in observation, or in info."""
+    seed_test(env_constructor)
+    api_test(env_constructor())
+
+    # Step through the environment according to example code given in AEC documentation (following action mask)
+    env = env_constructor()
+    env.reset(seed=42)
+    for agent in env.agent_iter():
+        observation, reward, termination, truncation, info = env.last()
+
+        if termination or truncation:
+            action = None
+        else:
+            # invalid action masking is optional and environment-dependent
+            if "action_mask" in info:
+                mask = info["action_mask"]
+            elif isinstance(observation, dict) and "action_mask" in observation:
+                mask = observation["action_mask"]
+            else:
+                mask = None
+            action = env.action_space(agent).sample(mask)
+        env.step(action)
+    env.close()
+
+

--- a/test/action_mask_test.py
+++ b/test/action_mask_test.py
@@ -1,13 +1,22 @@
 from typing import Type
 
 import pytest
+
+from pettingzoo.test import api_test, seed_test
+from pettingzoo.test.example_envs import (
+    generated_agents_env_action_mask_info_v0,
+    generated_agents_env_action_mask_obs_v0,
+)
 from pettingzoo.utils.env import AECEnv
 
-from pettingzoo.test import seed_test, api_test
 
-from pettingzoo.test.example_envs import generated_agents_env_action_mask_obs_v0, generated_agents_env_action_mask_info_v0
-
-@pytest.mark.parametrize("env_constructor", [generated_agents_env_action_mask_info_v0.env, generated_agents_env_action_mask_obs_v0.env])
+@pytest.mark.parametrize(
+    "env_constructor",
+    [
+        generated_agents_env_action_mask_info_v0.env,
+        generated_agents_env_action_mask_obs_v0.env,
+    ],
+)
 def test_action_mask(env_constructor: Type[AECEnv]):
     """Test that environments function deterministically in cases where action mask is in observation, or in info."""
     seed_test(env_constructor)
@@ -32,5 +41,3 @@ def test_action_mask(env_constructor: Type[AECEnv]):
             action = env.action_space(agent).sample(mask)
         env.step(action)
     env.close()
-
-


### PR DESCRIPTION
# Description

It turns out all of the other tests and code I can find at least, uses dynamic checks to see if the action mask is in obs or info, so this was the only change required to make info action masks fully work as intended.

Fixes https://github.com/Farama-Foundation/PettingZoo/issues/1117

Fixes # (issue), Depends on # (pull request)

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
