### PR TITLE
fix the comments for check_for_winner

### DIFF
--- a/pettingzoo/classic/tictactoe/board.py
+++ b/pettingzoo/classic/tictactoe/board.py
@@ -50,8 +50,8 @@ class Board:
 
     # returns:
     # -1 for no winner
-    # 0 -- agent 0 wins
-    # 1 -- agent 1 wins
+    # 1 -- agent 0 wins
+    # 2 -- agent 1 wins
     def check_for_winner(self):
         winner = -1
         for combination in self.winning_combinations:


### PR DESCRIPTION
# Description

To determine the winner, tic tac toe uses `check_for_winner()`, defined in `tictactoe/board.py`. That function describes its returns as **-1, 0, 1** in the comments as follows. However, the `check_for_winner()` function returns **-1, 1, 2**.

https://github.com/Farama-Foundation/PettingZoo/blob/f7a9ef13d0f8ddb599ff8a90f85fc1d0421826b2/pettingzoo/classic/tictactoe/board.py#L51-L65

Other functions that use the `check_for_winner()` function also run the function thinking that the integers it returns are **-1, 1, and 2**. This leads us to believe that we should change the function's comment.

https://github.com/Farama-Foundation/PettingZoo/blob/f7a9ef13d0f8ddb599ff8a90f85fc1d0421826b2/pettingzoo/classic/tictactoe/board.py#L67-L76

https://github.com/Farama-Foundation/PettingZoo/blob/f7a9ef13d0f8ddb599ff8a90f85fc1d0421826b2/pettingzoo/classic/tictactoe/tictactoe.py#L212-L225

The `observe` function also shows a correspondence of 1 -> agent0, 2 -> agent1.
https://github.com/Farama-Foundation/PettingZoo/blob/f7a9ef13d0f8ddb599ff8a90f85fc1d0421826b2/pettingzoo/classic/tictactoe/board.py#L10-L12

## Type of change

* fix comment


### Screenshots

**before**
![image](https://github.com/Farama-Foundation/PettingZoo/assets/54899900/6ade5bd5-b981-4930-bb10-c7ff46483a3f)

**after**

![image](https://github.com/Farama-Foundation/PettingZoo/assets/54899900/ef1efdbe-77b8-45c9-92c5-eb4906c7936a)


# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
