### PR TITLE
Added single quotes around pip install arguments with square brackets

### DIFF
--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -9,7 +9,7 @@ To install the base PettingZoo library: `pip install pettingzoo`.
 
 This does not include dependencies for all families of environments (some environments can be problematic to install on certain systems).
 
-To install the dependencies for one family, use `pip install pettingzoo[atari]`, or use `pip install pettingzoo[all]` to install all dependencies.
+To install the dependencies for one family, use `pip install 'pettingzoo[atari]'`, or use `pip install 'pettingzoo[all]'` to install all dependencies.
 
 We support Python 3.8, 3.9, 3.10 and 3.11 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 


### PR DESCRIPTION
>pip install pettingzoo[atari]

Results in zsh complaining as zsh by default uses [square brackets for globbing](https://stackoverflow.com/questions/30539798/zsh-no-matches-found-requestssecurity).

Putting pettingzoo[atari] and pettingzoo[all] inside single quotes makes these commands work with zsh.

# Description

Updated pip install commands in README.md to work with zsh.

## Type of change


- Documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have made corresponding changes to the documentation

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
