### PR TITLE
Fix 30,000-ish warnings from pytest

### DIFF
--- a/pettingzoo/butterfly/pistonball/pistonball.py
+++ b/pettingzoo/butterfly/pistonball/pistonball.py
@@ -621,7 +621,8 @@ class raw_env(AECEnv, EzPickle):
         action = np.asarray(action)
         agent = self.agent_selection
         if self.continuous:
-            self.move_piston(self.pistonList[self.agent_name_mapping[agent]], action)
+            # action is a 1 item numpy array, move_piston expects a scalar
+            self.move_piston(self.pistonList[self.agent_name_mapping[agent]], action[0])
         else:
             self.move_piston(
                 self.pistonList[self.agent_name_mapping[agent]], action - 1

--- a/pettingzoo/sisl/waterworld/waterworld_base.py
+++ b/pettingzoo/sisl/waterworld/waterworld_base.py
@@ -180,8 +180,8 @@ class WaterworldBase:
                 Evaders(
                     x,
                     y,
-                    vx,
-                    vy,
+                    vx[0],
+                    vy[0],
                     radius=2 * self.base_radius,
                     collision_type=i + 1000,
                     max_speed=self.evader_speed,
@@ -198,8 +198,8 @@ class WaterworldBase:
                 Poisons(
                     x,
                     y,
-                    vx,
-                    vy,
+                    vx[0],
+                    vy[0],
                     radius=0.75 * self.base_radius,
                     collision_type=i + 2000,
                     max_speed=self.poison_speed,


### PR DESCRIPTION
# Description

This fixes a large number of warnings generated when running pytest. These were due to a change in numpy that deprecated using single item arrays as scalars. This fix passes scalars instead to avoid using the deprecated code.
There are still ~70 warnings for unrelated reasons. These will be addressed in a future change.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
