### PR TITLE
Remove unneeded Maze Craze warning

### DIFF
--- a/pettingzoo/atari/maze_craze/maze_craze.py
+++ b/pettingzoo/atari/maze_craze/maze_craze.py
@@ -85,7 +85,6 @@ In any given turn, an agent can choose from one of 18 actions.
 """
 
 import os
-import warnings
 from glob import glob
 
 from pettingzoo.atari.base_atari_env import (
@@ -102,10 +101,6 @@ avaliable_versions = {
 
 
 def raw_env(game_version="robbers", visibilty_level=0, **kwargs):
-    if game_version == "robbers" and visibilty_level == 0:
-        warnings.warn(
-            "maze_craze has different versions of the game via the `game_version` argument, consider overriding."
-        )
     assert (
         game_version in avaliable_versions
     ), f"`game_version` parameter must be one of {avaliable_versions.keys()}"

--- a/pettingzoo/butterfly/pistonball/pistonball.py
+++ b/pettingzoo/butterfly/pistonball/pistonball.py
@@ -621,7 +621,8 @@ class raw_env(AECEnv, EzPickle):
         action = np.asarray(action)
         agent = self.agent_selection
         if self.continuous:
-            self.move_piston(self.pistonList[self.agent_name_mapping[agent]], action)
+            # action is a 1 item numpy array, move_piston expects a scalar
+            self.move_piston(self.pistonList[self.agent_name_mapping[agent]], action[0])
         else:
             self.move_piston(
                 self.pistonList[self.agent_name_mapping[agent]], action - 1

--- a/pettingzoo/sisl/waterworld/waterworld_base.py
+++ b/pettingzoo/sisl/waterworld/waterworld_base.py
@@ -180,8 +180,8 @@ class WaterworldBase:
                 Evaders(
                     x,
                     y,
-                    vx,
-                    vy,
+                    vx[0],
+                    vy[0],
                     radius=2 * self.base_radius,
                     collision_type=i + 1000,
                     max_speed=self.evader_speed,
@@ -198,8 +198,8 @@ class WaterworldBase:
                 Poisons(
                     x,
                     y,
-                    vx,
-                    vy,
+                    vx[0],
+                    vy[0],
                     radius=0.75 * self.base_radius,
                     collision_type=i + 2000,
                     max_speed=self.poison_speed,


### PR DESCRIPTION
# Description

Removes the informational warning that Craze Atari env output on init.
The information is clearly stated in the documentation for the env so not
needed as a warning.

Fixes #1158

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
