### PR TITLE
Remove unneeded Maze Craze warning

### DIFF
--- a/pettingzoo/atari/maze_craze/maze_craze.py
+++ b/pettingzoo/atari/maze_craze/maze_craze.py
@@ -85,7 +85,6 @@ In any given turn, an agent can choose from one of 18 actions.
 """
 
 import os
-import warnings
 from glob import glob
 
 from pettingzoo.atari.base_atari_env import (
@@ -102,10 +101,6 @@ avaliable_versions = {
 
 
 def raw_env(game_version="robbers", visibilty_level=0, **kwargs):
-    if game_version == "robbers" and visibilty_level == 0:
-        warnings.warn(
-            "maze_craze has different versions of the game via the `game_version` argument, consider overriding."
-        )
     assert (
         game_version in avaliable_versions
     ), f"`game_version` parameter must be one of {avaliable_versions.keys()}"


### PR DESCRIPTION
# Description

Removes the informational warning that Craze Atari env output on init.
The information is clearly stated in the documentation for the env so not
needed as a warning.

Fixes #1158

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

