### PR TITLE
Mirror Gymnasium's fix for the pyright upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
             language: node
             pass_filenames: false
             types: [python]
-            additional_dependencies: [pyright]
+            additional_dependencies: [pyright@1.1.347]
             args:
                 - --project=pyproject.toml
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt


### PR DESCRIPTION
This fixes the plethora by pinning the pyright version - mirroring what Gymnasium is doing.