### PR TITLE
Correct obs type in parallel_rps doc example

### DIFF
--- a/docs/code_examples/parallel_rps.py
+++ b/docs/code_examples/parallel_rps.py
@@ -1,6 +1,7 @@
 import functools
 
 import gymnasium
+import numpy as np
 from gymnasium.spaces import Discrete
 
 from pettingzoo import ParallelEnv
@@ -83,6 +84,7 @@ class parallel_env(ParallelEnv):
     @functools.lru_cache(maxsize=None)
     def observation_space(self, agent):
         # gymnasium spaces are defined and documented here: https://gymnasium.farama.org/api/spaces/
+        # Discrete(4) means an integer in range(0, 4)
         return Discrete(4)
 
     # Action space should be defined here.
@@ -128,7 +130,8 @@ class parallel_env(ParallelEnv):
         """
         self.agents = self.possible_agents[:]
         self.num_moves = 0
-        observations = {agent: NONE for agent in self.agents}
+        # the observations should be numpy arrays even if there is only one value
+        observations = {agent: np.array(NONE) for agent in self.agents}
         infos = {agent: {} for agent in self.agents}
         self.state = observations
 
@@ -161,9 +164,11 @@ class parallel_env(ParallelEnv):
         env_truncation = self.num_moves >= NUM_ITERS
         truncations = {agent: env_truncation for agent in self.agents}
 
-        # current observation is just the other player's most recent action
+        # Current observation is just the other player's most recent action
+        # This is converted to a numpy value of type int to match the type
+        # that we declared in observation_space()
         observations = {
-            self.agents[i]: int(actions[self.agents[1 - i]])
+            self.agents[i]: np.array(actions[self.agents[1 - i]], dtype=np.int_)
             for i in range(len(self.agents))
         }
         self.state = observations

--- a/docs/code_examples/parallel_rps.py
+++ b/docs/code_examples/parallel_rps.py
@@ -10,7 +10,7 @@ from pettingzoo.utils import parallel_to_aec, wrappers
 ROCK = 0
 PAPER = 1
 SCISSORS = 2
-NONE = 3
+NO_MOVE = 3
 MOVES = ["ROCK", "PAPER", "SCISSORS", "None"]
 NUM_ITERS = 100
 REWARD_MAP = {
@@ -131,7 +131,7 @@ class parallel_env(ParallelEnv):
         self.agents = self.possible_agents[:]
         self.num_moves = 0
         # the observations should be numpy arrays even if there is only one value
-        observations = {agent: np.array(NONE) for agent in self.agents}
+        observations = {agent: np.array(NO_MOVE) for agent in self.agents}
         infos = {agent: {} for agent in self.agents}
         self.state = observations
 
@@ -168,7 +168,7 @@ class parallel_env(ParallelEnv):
         # This is converted to a numpy value of type int to match the type
         # that we declared in observation_space()
         observations = {
-            self.agents[i]: np.array(actions[self.agents[1 - i]], dtype=np.int_)
+            self.agents[i]: np.array(actions[self.agents[1 - i]], dtype=np.int64)
             for i in range(len(self.agents))
         }
         self.state = observations


### PR DESCRIPTION
The value was an int, but all the testing expects observations to be numpy types. This has been changed with updated comments to explain.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
