### PR TITLE
Fix test failing due to __getattr__ in module

### DIFF
--- a/pettingzoo/utils/deprecated_module.py
+++ b/pettingzoo/utils/deprecated_module.py
@@ -37,7 +37,9 @@ def deprecated_handler(
         # It wasn't able to find this module
         # You should do your deprecation notice here.
         if not is_env(env_name):
-            raise ImportError(f"cannot import name '{env_name}' from '{module_name}'")
+            raise AttributeError(
+                f"cannot import name '{env_name}' from '{module_name}'"
+            )
         name, version = env_name.rsplit("_v")
 
         for loader, alt_env_name, is_pkg in pkgutil.iter_modules(module_path):
@@ -47,7 +49,7 @@ def deprecated_handler(
                     if int(alt_version) > int(version):
                         return DeprecatedModule(name, version, alt_version)
                     else:
-                        raise ImportError(
+                        raise AttributeError(
                             f"cannot import name '{env_name}' from '{module_name}'"
                         )
 


### PR DESCRIPTION
# Description

The deprecated_handler() function is called by module level __getattr__ functions. It raised an ImportError when a module wasn't an env. This breaks getattr's behaviour when it is called with a default value. It expects __getattr__ to raise an AttributeError if the attr is not found.

Pytest was apparently updated to call getattr(obj, key, default) for several values of key. The import error isn't caught by getattr, breaking the test.

Changing ImportError to AttributeError fixes this. The missing attribute raises the correct error, which is caught by getattr, which sets the value to the default and everything works as intended.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
