### PR TITLE
Add compatibility with pytest version 8

### DIFF
--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -148,5 +148,6 @@ In certain cases, separating agent from environment actions is helpful for study
 Environments are by default wrapped in a handful of lightweight wrappers that handle error messages and ensure reasonable behavior given incorrect usage (i.e. playing illegal moves or stepping before resetting). However, these add a very small amount of overhead. If you want to create an environment without them, you can do so by using the `raw_env()` constructor contained within each module:
 
 ``` python
-env = knights_archers_zombies_v10.raw_env(<environment parameters>)
+environment_parameters = {}  # any parameters to pass to the environment
+env = knights_archers_zombies_v10.raw_env(**environment_parameters)
 ```

--- a/docs/content/environment_tests.md
+++ b/docs/content/environment_tests.md
@@ -80,10 +80,14 @@ render_test(env_func)
 The render test method takes in an optional argument `custom_tests` that allows for additional tests in non-standard modes.
 
 ``` python
+from pettingzoo.test import render_test
+from pettingzoo.butterfly import pistonball_v6
+env_func = pistonball_v6.env
+
 custom_tests = {
-    "svg": lambda render_result: return isinstance(render_result, str)
+    "svg": lambda render_result: isinstance(render_result, str)
 }
-render_test(env, custom_tests=custom_tests)
+render_test(env_func, custom_tests=custom_tests)
 ```
 
 ## Performance Benchmark Test

--- a/docs/environments/atari.md
+++ b/docs/environments/atari.md
@@ -121,7 +121,10 @@ env = supersuit.frame_stack_v1(env, 4)
 All the Atari environments have the following environment parameters:
 
 ``` python
-<atari_game>.env(obs_type='rgb_image', full_action_space=True, max_cycles=100000, auto_rom_install_path=None)
+# using space invaders as an example, but replace with any atari game
+from pettingzoo.atari import space_invaders_v2
+
+space_invaders_v2.env(obs_type='rgb_image', full_action_space=True, max_cycles=100000, auto_rom_install_path=None)
 ```
 
 `obs_type`:  There are three possible values for this parameter:

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,11 +78,18 @@ The [AEC API](/api/aec/) supports sequential turn based environments, while the 
 Environments can be interacted with using a similar interface to [Gymnasium](https://gymnasium.farama.org):
 
 ```python
-  from pettingzoo.butterfly import knights_archers_zombies_v10
-  env = knights_archers_zombies_v10.env(render_mode="human")
-  env.reset(seed=42)
-  for agent in env.agent_iter():
-      observation, reward, termination, truncation, info = env.last()
-      action = policy(observation, agent)
-      env.step(action)
+from pettingzoo.butterfly import knights_archers_zombies_v10
+env = knights_archers_zombies_v10.env(render_mode="human")
+env.reset(seed=42)
+
+for agent in env.agent_iter():
+    observation, reward, termination, truncation, info = env.last()
+
+    if termination or truncation:
+        action = None
+    else:
+        # this is where you would insert your policy
+        action = env.action_space(agent).sample()
+
+    env.step(action)
 ```

--- a/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
@@ -132,6 +132,7 @@ knights_archers_zombies_v10.env(
   vector_state=True,
   use_typemasks=False,
   sequence_space=False,
+)
 ```
 
 `spawn_rate`:  how many cycles before a new zombie is spawned. A lower number means zombies are spawned at a higher rate.

--- a/pettingzoo/utils/deprecated_module.py
+++ b/pettingzoo/utils/deprecated_module.py
@@ -37,7 +37,9 @@ def deprecated_handler(
         # It wasn't able to find this module
         # You should do your deprecation notice here.
         if not is_env(env_name):
-            raise ImportError(f"cannot import name '{env_name}' from '{module_name}'")
+            raise AttributeError(
+                f"cannot import name '{env_name}' from '{module_name}'"
+            )
         name, version = env_name.rsplit("_v")
 
         for loader, alt_env_name, is_pkg in pkgutil.iter_modules(module_path):
@@ -47,7 +49,7 @@ def deprecated_handler(
                     if int(alt_version) > int(version):
                         return DeprecatedModule(name, version, alt_version)
                     else:
-                        raise ImportError(
+                        raise AttributeError(
                             f"cannot import name '{env_name}' from '{module_name}'"
                         )
 

--- a/pettingzoo/utils/deprecated_module.py
+++ b/pettingzoo/utils/deprecated_module.py
@@ -37,6 +37,14 @@ def deprecated_handler(
         # It wasn't able to find this module
         # You should do your deprecation notice here.
         if not is_env(env_name):
+            # Although this seems like an import error, it needs to be an
+            # AttributeError because it is the failure to find the
+            # 'env_name' attribute in module_name.
+            # The distinction is important because this function is used in
+            # a __getattr__() function to get modules. Raising an error
+            # other than AttributeError will break the default value handling
+            # in a call like: getattr(obj, "key", default="value")
+            # Pytest uses that and will fail if this isn't an AttributeError
             raise AttributeError(
                 f"cannot import name '{env_name}' from '{module_name}'"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,13 @@ mpe = ["pygame==2.3.0"]
 sisl = ["pygame==2.3.0", "pymunk==6.2.0", "box2d-py==2.3.5", "scipy>=1.4.1"]
 other = ["pillow>=8.0.1"]
 testing = [
-    "pynput",
-    "pytest",
-    "AutoROM",
-    "pytest",
-    "pytest-cov",
-    "pytest-xdist",
-    "pre-commit",
-    "pytest-markdown-docs>=0.5.0"
+    "pynput==1.7.6",
+    "pytest==8.0.0",
+    "AutoROM==0.6.1",
+    "pytest-cov==4.1.0",
+    "pytest-xdist==3.5.0",
+    "pre-commit==3.6.1",
+    "pytest-markdown-docs==0.5.0"
 ]
 all = [
     "multi_agent_ale_py==0.1.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ testing = [
     "pytest-cov",
     "pytest-xdist",
     "pre-commit",
-    "pytest-markdown-docs"
+    "pytest-markdown-docs>=0.5.0"
 ]
 all = [
     "multi_agent_ale_py==0.1.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ testing = [
     "AutoROM==0.6.1",
     "pytest-cov==4.1.0",
     "pytest-xdist==3.5.0",
-    "pre-commit==3.6.1",
+    "pre-commit==3.5.0",
     "pytest-markdown-docs==0.5.0"
 ]
 all = [

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -1,4 +1,4 @@
-agilerl>=0.1.16
+agilerl==0.1.19
 pettingzoo[classic,atari,mpe]>=1.23.1
 SuperSuit>=3.9.0
 torch>=2.0.1


### PR DESCRIPTION
# Description

Fixes a problem in deprecation handler that failed with version 8 of pytest

Upgraded to a version of pytest-markdown-docs that is compatible with pytest version 8.
That found several errors in the sample docs that have been fixed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
