### PR TITLE
Order enforcing wrapper fix

### DIFF
--- a/pettingzoo/utils/env_logger.py
+++ b/pettingzoo/utils/env_logger.py
@@ -62,20 +62,6 @@ class EnvLogger:
         )
 
     @staticmethod
-    def warn_close_unrendered_env() -> None:
-        """Warns: ``[WARNING]: Called close on an unrendered environment.``."""
-        EnvLogger._generic_warning(
-            "[WARNING]: Called close on an unrendered environment."
-        )
-
-    @staticmethod
-    def warn_close_before_reset() -> None:
-        """Warns: ``[WARNING]: reset() needs to be called before close.``."""
-        EnvLogger._generic_warning(
-            "[WARNING]: reset() needs to be called before close."
-        )
-
-    @staticmethod
     def warn_on_illegal_move() -> None:
         """Warns: ``[WARNING]: Illegal move made, game terminating with current player losing.``."""
         EnvLogger._generic_warning(

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -110,22 +110,15 @@ class AECOrderEnforcingIterator(AECIterator[AgentID, ObsType, ActionType]):
     def __init__(
         self, env: OrderEnforcingWrapper[AgentID, ObsType, ActionType], max_iter: int
     ):
-        assert hasattr(
-            env, "_has_updated"
+        assert isinstance(
+            env, OrderEnforcingWrapper
         ), "env must be wrapped by OrderEnforcingWrapper"
-        # this is set during the super call to init, so setting it here
-        # is redundant. However, it silences pyright errors because it tells
-        # pyright that self.env is an OrderEnforcingWrapper (which may not be
-        # strictly true, but it should have OrderEnforcingWrapper somewhere
-        # in the wrapper list). This might be better handled by Protocols,
-        # but this approach works.
-        self.env = env  # silence pyright errors
         super().__init__(env, max_iter)
 
     def __next__(self) -> AgentID:
         agent = super().__next__()
         assert (
-            self.env._has_updated
+            self.env._has_updated  # pyright: ignore[reportGeneralTypeIssues]
         ), "need to call step() or reset() in a loop over `agent_iter`"
-        self.env._has_updated = False
+        self.env._has_updated = False  # pyright: ignore[reportGeneralTypeIssues]
         return agent

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -107,13 +107,25 @@ class AECOrderEnforcingIterable(AECIterable[AgentID, ObsType, ActionType]):
 
 
 class AECOrderEnforcingIterator(AECIterator[AgentID, ObsType, ActionType]):
+    def __init__(
+        self, env: OrderEnforcingWrapper[AgentID, ObsType, ActionType], max_iter: int
+    ):
+        assert hasattr(
+            env, "_has_updated"
+        ), "env must be wrapped by OrderEnforcingWrapper"
+        # this is set during the super call to init, so setting it here
+        # is redundant. However, it silences pyright errors because it tells
+        # pyright that self.env is an OrderEnforcingWrapper (which may not be
+        # strictly true, but it should have OrderEnforcingWrapper somewhere
+        # in the wrapper list). This might be better handled by Protocols,
+        # but this approach works.
+        self.env = env  # silence pyright errors
+        super().__init__(env, max_iter)
+
     def __next__(self) -> AgentID:
         agent = super().__next__()
-        assert hasattr(
-            self.env, "_has_updated"
-        ), "env must be wrapped by OrderEnforcingWrapper"
         assert (
-            self.env._has_updated  # pyright: ignore[reportGeneralTypeIssues]
+            self.env._has_updated
         ), "need to call step() or reset() in a loop over `agent_iter`"
-        self.env._has_updated = False  # pyright: ignore[reportGeneralTypeIssues]
+        self.env._has_updated = False
         return agent

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -36,32 +36,8 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
         super().__init__(env)
 
     def __getattr__(self, value: str) -> Any:
-        """Raises an error message when data is gotten from the env.
-
-        Should only be gotten after reset
-        """
-        if value == "unwrapped":
-            return self.env.unwrapped
-        elif value == "render_mode" and hasattr(self.env, "render_mode"):
-            return self.env.render_mode  # pyright: ignore[reportGeneralTypeIssues]
-        elif value == "possible_agents":
-            try:
-                return self.env.possible_agents
-            except AttributeError:
-                EnvLogger.error_possible_agents_attribute_missing("possible_agents")
-        elif value == "observation_spaces":
-            raise AttributeError(
-                "The base environment does not have an possible_agents attribute. Use the environments `observation_space` method instead"
-            )
-        elif value == "action_spaces":
-            raise AttributeError(
-                "The base environment does not have an possible_agents attribute. Use the environments `action_space` method instead"
-            )
-        elif value == "agent_order":
-            raise AttributeError(
-                "agent_order has been removed from the API. Please consider using agent_iter instead."
-            )
-        elif (
+        """Raises an error if certain data is accessed before reset."""
+        if (
             value
             in {
                 "rewards",

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -19,11 +19,13 @@ from pettingzoo.utils.wrappers.base import BaseWrapper
 class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
     """Checks if function calls or attribute access are in a disallowed order.
 
-    * error on getting rewards, terminations, truncations, infos, agent_selection before reset
-    * error on calling step, observe before reset
-    * error on iterating without stepping or resetting environment.
-    * warn on calling close before render or reset
-    * warn on calling step after environment is terminated or truncated
+    The following are raised:
+    * AttributeError if any of the following are accessed before reset():
+      rewards, terminations, truncations, infos, agent_selection,
+      num_agents, agents.
+    * An error if any of the following are called before reset:
+      render(), step(), observe(), state(), agent_iter()
+    * A warning if step() is called when there are no agents remaining.
     """
 
     def __init__(self, env: AECEnv[AgentID, ObsType, ActionType]):

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -52,8 +52,7 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
             and not self._has_reset
         ):
             raise AttributeError(f"{value} cannot be accessed before reset")
-        else:
-            return super().__getattr__(value)
+        return super().__getattr__(value)
 
     def render(self) -> None | np.ndarray | str | list:
         if not self._has_reset:
@@ -66,7 +65,6 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
         elif not self.agents:
             self._has_updated = True
             EnvLogger.warn_step_after_terminated_truncated()
-            return None
         else:
             self._has_updated = True
             super().step(action)
@@ -100,8 +98,7 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
                 if self.__class__ is OrderEnforcingWrapper
                 else f"{type(self).__name__}<{str(self.env)}>"
             )
-        else:
-            return repr(self)
+        return repr(self)
 
 
 class AECOrderEnforcingIterable(AECIterable[AgentID, ObsType, ActionType]):

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -33,7 +33,6 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
             env, AECEnv
         ), "OrderEnforcingWrapper is only compatible with AEC environments"
         self._has_reset = False
-        self._has_rendered = False
         self._has_updated = False
         super().__init__(env)
 
@@ -59,7 +58,6 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
     def render(self) -> None | np.ndarray | str | list:
         if not self._has_reset:
             EnvLogger.error_render_before_reset()
-        self._has_rendered = True
         return super().render()
 
     def step(self, action: ActionType) -> None:


### PR DESCRIPTION
# Description

Fix several issues related to `OrderEnforcingWrapper`

* Update docstrings to correctly describe what is happening
* remove checks in `__getattr__` that are unrelated to the wrapper (see #1174)
* fix pyright errors in `AECOrderEnforcingIterator`
* clean up a few unneeded `return` and `else` statements

Fixes #1174 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

