### PR TITLE
Fix: Swapped colors in waterworld description

### DIFF
--- a/pettingzoo/sisl/waterworld/waterworld.py
+++ b/pettingzoo/sisl/waterworld/waterworld.py
@@ -33,7 +33,7 @@ The observation shape of each agent is a vector of length > 4 that is dependent 
 poison respectively. The number of features per sensor is 8 by default with `speed_features` enabled, or 5 if `speed_features` is turned off. Therefore with `speed_features` enabled, the observation shape takes the full form of `(8 × n_sensors) + 2`. Elements of the observation vector take on
 values in the range [-1, 1].
 
-For example, by default there are 5 agents (purple), 5 food targets (red) and 10 poison targets (green). Each agent has 30 range-limited sensors, depicted by the black lines, to detect neighboring entities (food and poison targets) resulting in 242 element vector of computed values about the
+For example, by default there are 5 agents (purple), 5 food targets (green) and 10 poison targets (red). Each agent has 30 range-limited sensors, depicted by the black lines, to detect neighboring entities (food and poison targets) resulting in 242 element vector of computed values about the
 environment for the observation space. These values represent the distances and speeds sensed by each sensor on the archea. Sensors that do not sense any objects within their range report 0 for speed and 1 for distance.
 
 This has been fixed from the reference environments to keep items floating off screen and being lost forever.


### PR DESCRIPTION
# Description

The gif for the [waterworld documentation](https://pettingzoo.farama.org/environments/sisl/waterworld/) shows 5 big green food and 10 small red poison targets. 
In the section "Observation Space" the colors for food and poison targets are swapped.


## Type of change

- This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
