### PR TITLE
Added radius rescaling to simple env

### DIFF
--- a/pettingzoo/mpe/_mpe_utils/simple_env.py
+++ b/pettingzoo/mpe/_mpe_utils/simple_env.py
@@ -122,7 +122,7 @@ class SimpleEnv(AECEnv):
         # This will be used to scale the rendering
         all_poses = [entity.state.p_pos for entity in self.world.entities]
         self.original_cam_range = np.max(np.abs(np.array(all_poses)))
-        
+
         self.steps = 0
 
         self.current_actions = [None] * self.num_agents
@@ -327,12 +327,8 @@ class SimpleEnv(AECEnv):
             else:
                 radius = entity.size * 350
 
-            pygame.draw.circle(
-                self.screen, entity.color * 200, (x, y), radius
-            )  
-            pygame.draw.circle(
-                self.screen, (0, 0, 0), (x, y), radius, 1
-            )  # borders
+            pygame.draw.circle(self.screen, entity.color * 200, (x, y), radius)
+            pygame.draw.circle(self.screen, (0, 0, 0), (x, y), radius, 1)  # borders
             assert (
                 0 < x < self.width and 0 < y < self.height
             ), f"Coordinates {(x, y)} are out of bounds."

--- a/pettingzoo/mpe/_mpe_utils/simple_env.py
+++ b/pettingzoo/mpe/_mpe_utils/simple_env.py
@@ -12,7 +12,6 @@ from pettingzoo.utils import wrappers
 from pettingzoo.utils.agent_selector import AgentSelector
 
 alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-DYNAMIC_RESCALING = True
 
 
 def make_env(raw_env):
@@ -43,6 +42,7 @@ class SimpleEnv(AECEnv):
         render_mode=None,
         continuous_actions=False,
         local_ratio=None,
+        dynamic_rescaling=False,
     ):
         super().__init__()
 
@@ -67,6 +67,7 @@ class SimpleEnv(AECEnv):
         self.world = world
         self.continuous_actions = continuous_actions
         self.local_ratio = local_ratio
+        self.dynamic_rescaling = dynamic_rescaling
 
         self.scenario.reset_world(self.world, self.np_random)
 
@@ -321,7 +322,7 @@ class SimpleEnv(AECEnv):
             y += self.height // 2
 
             # 350 is an arbitrary scale factor to get pygame to render similar sizes as pyglet
-            if DYNAMIC_RESCALING:
+            if self.dynamic_rescaling:
                 radius = entity.size * 350 * scaling_factor
             else:
                 radius = entity.size * 350

--- a/pettingzoo/mpe/_mpe_utils/simple_env.py
+++ b/pettingzoo/mpe/_mpe_utils/simple_env.py
@@ -12,7 +12,7 @@ from pettingzoo.utils import wrappers
 from pettingzoo.utils.agent_selector import AgentSelector
 
 alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-DYNAMIC_RESCALING = False
+DYNAMIC_RESCALING = True
 
 
 def make_env(raw_env):

--- a/pettingzoo/mpe/simple/simple.py
+++ b/pettingzoo/mpe/simple/simple.py
@@ -52,7 +52,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None):
+    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
         EzPickle.__init__(
             self,
             max_cycles=max_cycles,
@@ -68,6 +68,7 @@ class raw_env(SimpleEnv, EzPickle):
             render_mode=render_mode,
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
+            dynamic_rescaling=dynamic_rescaling,
         )
         self.metadata["name"] = "simple_v3"
 

--- a/pettingzoo/mpe/simple/simple.py
+++ b/pettingzoo/mpe/simple/simple.py
@@ -31,7 +31,7 @@ Observation space: `[self_vel, landmark_rel_position]`
 ### Arguments
 
 ``` python
-simple_v3.env(max_cycles=25, continuous_actions=False)
+simple_v3.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
 ```
 
 
@@ -39,6 +39,8 @@ simple_v3.env(max_cycles=25, continuous_actions=False)
 `max_cycles`:  number of frames (a step for each agent) until game terminates
 
 `continuous_actions`: Whether agent action spaces are discrete(default) or continuous
+
+`dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
 
 """
 

--- a/pettingzoo/mpe/simple/simple.py
+++ b/pettingzoo/mpe/simple/simple.py
@@ -54,7 +54,13 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
+    def __init__(
+        self,
+        max_cycles=25,
+        continuous_actions=False,
+        render_mode=None,
+        dynamic_rescaling=False,
+    ):
         EzPickle.__init__(
             self,
             max_cycles=max_cycles,

--- a/pettingzoo/mpe/simple_adversary/simple_adversary.py
+++ b/pettingzoo/mpe/simple_adversary/simple_adversary.py
@@ -62,7 +62,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, N=2, max_cycles=25, continuous_actions=False, render_mode=None):
+    def __init__(self, N=2, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
         EzPickle.__init__(
             self,
             N=N,
@@ -79,6 +79,7 @@ class raw_env(SimpleEnv, EzPickle):
             render_mode=render_mode,
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
+            dynamic_rescaling=dynamic_rescaling,
         )
         self.metadata["name"] = "simple_adversary_v3"
 

--- a/pettingzoo/mpe/simple_adversary/simple_adversary.py
+++ b/pettingzoo/mpe/simple_adversary/simple_adversary.py
@@ -64,7 +64,14 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, N=2, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
+    def __init__(
+        self,
+        N=2,
+        max_cycles=25,
+        continuous_actions=False,
+        render_mode=None,
+        dynamic_rescaling=False,
+    ):
         EzPickle.__init__(
             self,
             N=N,

--- a/pettingzoo/mpe/simple_adversary/simple_adversary.py
+++ b/pettingzoo/mpe/simple_adversary/simple_adversary.py
@@ -39,7 +39,7 @@ Adversary action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_adversary_v3.env(N=2, max_cycles=25, continuous_actions=False)
+simple_adversary_v3.env(N=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
 ```
 
 
@@ -49,6 +49,8 @@ simple_adversary_v3.env(N=2, max_cycles=25, continuous_actions=False)
 `max_cycles`:  number of frames (a step for each agent) until game terminates
 
 `continuous_actions`: Whether agent action spaces are discrete(default) or continuous
+
+`dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
 
 """
 

--- a/pettingzoo/mpe/simple_crypto/simple_crypto.py
+++ b/pettingzoo/mpe/simple_crypto/simple_crypto.py
@@ -45,7 +45,7 @@ For Bob and Eve, their communication is checked to be the 1 bit of information t
 ### Arguments
 
 ``` python
-simple_crypto_v3.env(max_cycles=25, continuous_actions=False)
+simple_crypto_v3.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
 ```
 
 
@@ -53,6 +53,8 @@ simple_crypto_v3.env(max_cycles=25, continuous_actions=False)
 `max_cycles`:  number of frames (a step for each agent) until game terminates
 
 `continuous_actions`: Whether agent action spaces are discrete(default) or continuous
+
+`dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
 
 """
 

--- a/pettingzoo/mpe/simple_crypto/simple_crypto.py
+++ b/pettingzoo/mpe/simple_crypto/simple_crypto.py
@@ -73,7 +73,7 @@ adversary to goal. Adversary is rewarded for its distance to the goal.
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None):
+    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
         EzPickle.__init__(
             self,
             max_cycles=max_cycles,
@@ -89,6 +89,7 @@ class raw_env(SimpleEnv, EzPickle):
             render_mode=render_mode,
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
+            dynamic_rescaling=dynamic_rescaling,
         )
         self.metadata["name"] = "simple_crypto_v3"
 

--- a/pettingzoo/mpe/simple_crypto/simple_crypto.py
+++ b/pettingzoo/mpe/simple_crypto/simple_crypto.py
@@ -75,7 +75,13 @@ adversary to goal. Adversary is rewarded for its distance to the goal.
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
+    def __init__(
+        self,
+        max_cycles=25,
+        continuous_actions=False,
+        render_mode=None,
+        dynamic_rescaling=False,
+    ):
         EzPickle.__init__(
             self,
             max_cycles=max_cycles,

--- a/pettingzoo/mpe/simple_push/simple_push.py
+++ b/pettingzoo/mpe/simple_push/simple_push.py
@@ -60,7 +60,13 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
+    def __init__(
+        self,
+        max_cycles=25,
+        continuous_actions=False,
+        render_mode=None,
+        dynamic_rescaling=False,
+    ):
         EzPickle.__init__(
             self,
             max_cycles=max_cycles,

--- a/pettingzoo/mpe/simple_push/simple_push.py
+++ b/pettingzoo/mpe/simple_push/simple_push.py
@@ -38,12 +38,15 @@ Adversary action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_push_v3.env(max_cycles=25, continuous_actions=False)
+simple_push_v3.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
 ```
 
 
 
 `max_cycles`:  number of frames (a step for each agent) until game terminates
+
+`dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
+
 
 """
 

--- a/pettingzoo/mpe/simple_push/simple_push.py
+++ b/pettingzoo/mpe/simple_push/simple_push.py
@@ -57,7 +57,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None):
+    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
         EzPickle.__init__(
             self,
             max_cycles=max_cycles,
@@ -73,6 +73,7 @@ class raw_env(SimpleEnv, EzPickle):
             render_mode=render_mode,
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
+            dynamic_rescaling=dynamic_rescaling,
         )
         self.metadata["name"] = "simple_push_v3"
 

--- a/pettingzoo/mpe/simple_reference/simple_reference.py
+++ b/pettingzoo/mpe/simple_reference/simple_reference.py
@@ -64,7 +64,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 class raw_env(SimpleEnv, EzPickle):
     def __init__(
-        self, local_ratio=0.5, max_cycles=25, continuous_actions=False, render_mode=None
+        self, local_ratio=0.5, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False
     ):
         EzPickle.__init__(
             self,
@@ -86,6 +86,7 @@ class raw_env(SimpleEnv, EzPickle):
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
             local_ratio=local_ratio,
+            dynamic_rescaling=dynamic_rescaling,
         )
         self.metadata["name"] = "simple_reference_v3"
 

--- a/pettingzoo/mpe/simple_reference/simple_reference.py
+++ b/pettingzoo/mpe/simple_reference/simple_reference.py
@@ -66,7 +66,12 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 class raw_env(SimpleEnv, EzPickle):
     def __init__(
-        self, local_ratio=0.5, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False
+        self,
+        local_ratio=0.5,
+        max_cycles=25,
+        continuous_actions=False,
+        render_mode=None,
+        dynamic_rescaling=False,
     ):
         EzPickle.__init__(
             self,

--- a/pettingzoo/mpe/simple_reference/simple_reference.py
+++ b/pettingzoo/mpe/simple_reference/simple_reference.py
@@ -40,7 +40,7 @@ Agent continuous action space: `[no_action, move_left, move_right, move_down, mo
 
 
 ``` python
-simple_reference_v3.env(local_ratio=0.5, max_cycles=25, continuous_actions=False)
+simple_reference_v3.env(local_ratio=0.5, max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
 ```
 
 
@@ -50,6 +50,8 @@ simple_reference_v3.env(local_ratio=0.5, max_cycles=25, continuous_actions=False
 `max_cycles`:  number of frames (a step for each agent) until game terminates
 
 `continuous_actions`: Whether agent action spaces are discrete(default) or continuous
+
+`dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
 
 """
 

--- a/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
+++ b/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
@@ -37,7 +37,7 @@ Listener action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_speaker_listener_v4.env(max_cycles=25, continuous_actions=False)
+simple_speaker_listener_v4.env(max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
 ```
 
 
@@ -45,6 +45,8 @@ simple_speaker_listener_v4.env(max_cycles=25, continuous_actions=False)
 `max_cycles`:  number of frames (a step for each agent) until game terminates
 
 `continuous_actions`: Whether agent action spaces are discrete(default) or continuous
+
+`dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
 
 """
 

--- a/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
+++ b/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
@@ -60,7 +60,13 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
+    def __init__(
+        self,
+        max_cycles=25,
+        continuous_actions=False,
+        render_mode=None,
+        dynamic_rescaling=False,
+    ):
         EzPickle.__init__(
             self,
             max_cycles=max_cycles,

--- a/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
+++ b/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
@@ -58,7 +58,7 @@ from pettingzoo.utils.conversions import parallel_wrapper_fn
 
 
 class raw_env(SimpleEnv, EzPickle):
-    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None):
+    def __init__(self, max_cycles=25, continuous_actions=False, render_mode=None, dynamic_rescaling=False):
         EzPickle.__init__(
             self,
             max_cycles=max_cycles,
@@ -74,6 +74,7 @@ class raw_env(SimpleEnv, EzPickle):
             render_mode=render_mode,
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
+            dynamic_rescaling=dynamic_rescaling,
         )
         self.metadata["name"] = "simple_speaker_listener_v4"
 

--- a/pettingzoo/mpe/simple_spread/simple_spread.py
+++ b/pettingzoo/mpe/simple_spread/simple_spread.py
@@ -36,7 +36,7 @@ Agent action space: `[no_action, move_left, move_right, move_down, move_up]`
 ### Arguments
 
 ``` python
-simple_spread_v3.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False)
+simple_spread_v3.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
 ```
 
 
@@ -48,6 +48,8 @@ simple_spread_v3.env(N=3, local_ratio=0.5, max_cycles=25, continuous_actions=Fal
 `max_cycles`:  number of frames (a step for each agent) until game terminates
 
 `continuous_actions`: Whether agent action spaces are discrete(default) or continuous
+
+`dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
 
 """
 

--- a/pettingzoo/mpe/simple_spread/simple_spread.py
+++ b/pettingzoo/mpe/simple_spread/simple_spread.py
@@ -68,6 +68,7 @@ class raw_env(SimpleEnv, EzPickle):
         max_cycles=25,
         continuous_actions=False,
         render_mode=None,
+        dynamic_rescaling=False,
     ):
         EzPickle.__init__(
             self,
@@ -90,6 +91,7 @@ class raw_env(SimpleEnv, EzPickle):
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
             local_ratio=local_ratio,
+            dynamic_rescaling=dynamic_rescaling,
         )
         self.metadata["name"] = "simple_spread_v3"
 

--- a/pettingzoo/mpe/simple_tag/simple_tag.py
+++ b/pettingzoo/mpe/simple_tag/simple_tag.py
@@ -80,6 +80,7 @@ class raw_env(SimpleEnv, EzPickle):
         max_cycles=25,
         continuous_actions=False,
         render_mode=None,
+        dynamic_rescaling=False,
     ):
         EzPickle.__init__(
             self,
@@ -99,6 +100,7 @@ class raw_env(SimpleEnv, EzPickle):
             render_mode=render_mode,
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
+            dynamic_rescaling=dynamic_rescaling,
         )
         self.metadata["name"] = "simple_tag_v3"
 

--- a/pettingzoo/mpe/simple_tag/simple_tag.py
+++ b/pettingzoo/mpe/simple_tag/simple_tag.py
@@ -45,7 +45,7 @@ Agent and adversary action space: `[no_action, move_left, move_right, move_down,
 ### Arguments
 
 ``` python
-simple_tag_v3.env(num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=25, continuous_actions=False)
+simple_tag_v3.env(num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=25, continuous_actions=False, dynamic_rescaling=False)
 ```
 
 
@@ -59,6 +59,8 @@ simple_tag_v3.env(num_good=1, num_adversaries=3, num_obstacles=2, max_cycles=25,
 `max_cycles`:  number of frames (a step for each agent) until game terminates
 
 `continuous_actions`: Whether agent action spaces are discrete(default) or continuous
+
+`dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
 
 """
 

--- a/pettingzoo/mpe/simple_world_comm/simple_world_comm.py
+++ b/pettingzoo/mpe/simple_world_comm/simple_world_comm.py
@@ -93,6 +93,7 @@ class raw_env(SimpleEnv, EzPickle):
         num_forests=2,
         continuous_actions=False,
         render_mode=None,
+        dynamic_rescaling=False,
     ):
         EzPickle.__init__(
             self,
@@ -116,6 +117,7 @@ class raw_env(SimpleEnv, EzPickle):
             render_mode=render_mode,
             max_cycles=max_cycles,
             continuous_actions=continuous_actions,
+            dynamic_rescaling=dynamic_rescaling,
         )
         self.metadata["name"] = "simple_world_comm_v3"
 

--- a/pettingzoo/mpe/simple_world_comm/simple_world_comm.py
+++ b/pettingzoo/mpe/simple_world_comm/simple_world_comm.py
@@ -52,7 +52,7 @@ Adversary leader continuous action space: `[no_action, move_left, move_right, mo
 
 ``` python
 simple_world_comm_v3.env(num_good=2, num_adversaries=4, num_obstacles=1,
-                num_food=2, max_cycles=25, num_forests=2, continuous_actions=False)
+                num_food=2, max_cycles=25, num_forests=2, continuous_actions=False, dynamic_rescaling=False)
 ```
 
 
@@ -70,6 +70,8 @@ simple_world_comm_v3.env(num_good=2, num_adversaries=4, num_obstacles=1,
 `num_forests`: number of forests that can hide agents inside from being seen
 
 `continuous_actions`: Whether agent action spaces are discrete(default) or continuous
+
+`dynamic_rescaling`: Whether to rescale the size of agents and landmarks based on the screen size
 
 """
 


### PR DESCRIPTION
# Description

This PR implements dynamic rescaling of the entity radius as we 'Zoom In' or 'Zoom out' of the rendering. This fixes #1188 which mentions that keeping the radius constant when rescaling the coordinates leads to an illusion of fixed obstacles coming closer or moving away from each other when in reality they are fixed.

Files modified: simple_env.py
High-level overview: Extended the concept of cam_range and recorded the original cam_range to scale the radius

Fixes #1188 , Depends on None

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update [Mentioning this in the documentation may be helpful]

### Screenshots

**Notice how the zoom out effect is more intuitive in the dynamic resizing case**

Before dynamic resizing:
![before](https://github.com/Farama-Foundation/PettingZoo/assets/60848863/baed8f8c-7a5c-4a64-ae87-b27fc49b9e96)

After dynamic resizing:
![after](https://github.com/Farama-Foundation/PettingZoo/assets/60848863/97972dba-2f77-4b12-b97e-ab7ac7dd8e70)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no new errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
