### PR TITLE
Changed dead link to correct link in Tianshou tutorial

### DIFF
--- a/docs/tutorials/tianshou/index.md
+++ b/docs/tutorials/tianshou/index.md
@@ -21,7 +21,7 @@ It boasts a large number of algorithms and high quality software engineering sta
 
 ## Examples using PettingZoo
 
-* [Multi-Agent RL](https://tianshou.readthedocs.io/en/master/tutorials/tictactoe.html)
+* [Multi-Agent RL](https://tianshou.org/en/master/01_tutorials/04_tictactoe.html)
 
 ## Architecture
 


### PR DESCRIPTION
# Description

In the documentation for the Tianshou tutorial there is a dead link. I've simply updated the link to the live one. When I ran the sphinx autobuild and viewed the docs in my browser, the new link worked.

Dead link: https://tianshou.readthedocs.io/en/master/tutorials/tictactoe.html

Live link: https://tianshou.org/en/master/01_tutorials/04_tictactoe.html

## Type of change

> Please delete options that are not relevant.

- This change requires a documentation update

### Screenshots

The change does not look visibly different, since on the tutorial page the link is abbreviated to 'Multi-Agent RL' under the examples bullet point. See here: https://pettingzoo.farama.org/tutorials/tianshou/ 

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

