### PR TITLE
Add an easy-to-install gfootball environment, SMAC and SMACv2 with pettingzoo apis in `third_party_envs`

### DIFF
--- a/docs/environments/third_party_envs.md
+++ b/docs/environments/third_party_envs.md
@@ -12,6 +12,12 @@ lastpage:
 ## Environments using the latest versions of PettingZoo
 *Due to a very recent major release of PettingZoo, there are currently few contributed third-party environments. If you'd like to contribute one, please reach out on [Discord](https://discord.gg/nHg2JRN489).*
 
+### [gfootball-gymnasium-pettingzoo](https://github.com/xihuai18/gfootball-gymnasium-pettingzoo)
+[![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.24.3-blue)]()
+[![GitHub stars](https://img.shields.io/github/stars/xihuai18/gfootball-gymnasium-pettingzoo)]()
+
+Google Research Football ([GRF](https://github.com/google-research/football)) with Gymnasium and PettingZoo Compatibility.
+
 ### [Sumo-RL](https://github.com/LucasAlegre/sumo-rl)
 
 [![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.22.2-blue)]()

--- a/docs/environments/third_party_envs.md
+++ b/docs/environments/third_party_envs.md
@@ -18,7 +18,7 @@ lastpage:
 
 Google Research Football ([GRF](https://github.com/google-research/football)) with Gymnasium and PettingZoo Compatibility.
 
-### [SMAC and SMACv2 with latest PettingZoo APIs]
+### [SMAC and SMACv2 with latest PettingZoo APIs](https://github.com/xihuai18/SMAC-PettingZoo)
 [![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.24.3-blue)]()
 [![GitHub stars](https://img.shields.io/github/stars/xihuai18/gfootball-gymnasium-pettingzoo)]()
 

--- a/docs/environments/third_party_envs.md
+++ b/docs/environments/third_party_envs.md
@@ -18,6 +18,12 @@ lastpage:
 
 Google Research Football ([GRF](https://github.com/google-research/football)) with Gymnasium and PettingZoo Compatibility.
 
+### [SMAC and SMACv2 with latest PettingZoo APIs]
+[![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.24.3-blue)]()
+[![GitHub stars](https://img.shields.io/github/stars/xihuai18/gfootball-gymnasium-pettingzoo)]()
+
+[SMAC](https://github.com/oxwhirl/smac) and [SMACv2](https://github.com/oxwhirl/smacv2) with the latest PettingZoo Parallel APIs.
+
 ### [Sumo-RL](https://github.com/LucasAlegre/sumo-rl)
 
 [![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.22.2-blue)]()


### PR DESCRIPTION
Add introduction of  https://github.com/xihuai18/gfootball-gymnasium-pettingzoo and https://github.com/xihuai18/SMAC-PettingZoo.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This PR includes the introduction of two environment wrappers using the PettingZoo APIs.
- Google Research Football
- SMAC and SMACv2

These environments are some of the most used cooperative marl benchmarks.

Fixes #1215 

## Type of change

> Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
