### PR TITLE
Fix memory leak in waterworld_v4 by clearing old handlers before adding new ones

### DIFF
--- a/pettingzoo/sisl/waterworld/waterworld_base.py
+++ b/pettingzoo/sisl/waterworld/waterworld_base.py
@@ -313,6 +313,8 @@ class WaterworldBase:
 
     def add_handlers(self):
         # Collision handlers for pursuers v.s. evaders & poisons
+        self.handlers = []
+
         for pursuer in self.pursuers:
             for obj in self.evaders:
                 self.handlers.append(


### PR DESCRIPTION
# Description

We recently tested waterworld_v4 with rllib and noticed that it was slowly leaking memory. Over 1M episodes it would slowly fill the 128GB of memory allocated to the test environment. One culprit seems to be the `handlers` list which is not cleared when resetting the environment so each time `add_handlers()` is called, new collision handlers are created and appended to this list. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


### Screenshots

Before fix

![Screenshot from 2024-06-24 05-08-14](https://github.com/Farama-Foundation/PettingZoo/assets/13623704/b0105b58-2734-4d81-ab92-f40074c7312f)

After fix

![Screenshot from 2024-06-24 05-07-37](https://github.com/Farama-Foundation/PettingZoo/assets/13623704/34538e91-03c9-431c-893c-8d303f15364b)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
