### PR TITLE
Fix tictactoe reset bug (when one agent died)

### DIFF
--- a/pettingzoo/classic/tictactoe/tictactoe.py
+++ b/pettingzoo/classic/tictactoe/tictactoe.py
@@ -226,7 +226,7 @@ class raw_env(AECEnv, EzPickle):
         self.truncations = {i: False for i in self.agents}
         self.infos = {i: {} for i in self.agents}
         # selects the first agent
-        self._agent_selector.reinit(self.agents)
+        self._agent_selector.reinit(self.possible_agents)
         self.agent_selection = self._agent_selector.reset()
 
         if self.render_mode is not None and self.screen is None:


### PR DESCRIPTION
# Description

In a tictactoe environment `env`, if `env` get resetted when an possible agent is not in the `env.agents` list (for invalid action or other reasons), that agent would not be selected forever, since `env._agent_selector` always gets re-initialized with the list `env.agent` which misses that agent. To fix this situation, `env._agent_selector` should get re-initialized with `env.possible_agents` (which contains all possible agents.) rather than `env.agents`.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- 
### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
  - only `Format YAML files.` failed.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
  - there is an error, which also happens before my commit
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
