### PR TITLE
Fixed error in render function for CustomActionMaskedEnvironment Class

### DIFF
--- a/tutorials/CustomEnvironment/tutorial3_action_masking.py
+++ b/tutorials/CustomEnvironment/tutorial3_action_masking.py
@@ -193,7 +193,7 @@ class CustomActionMaskedEnvironment(ParallelEnv):
 
     def render(self):
         """Renders the environment."""
-        grid = np.zeros((7, 7))
+        grid = np.zeros((8, 8), dtype=object)
         grid[self.prisoner_y, self.prisoner_x] = "P"
         grid[self.guard_y, self.guard_x] = "G"
         grid[self.escape_y, self.escape_x] = "E"


### PR DESCRIPTION
# Description

Changed the data type of grid so that strings could be added to the numpy array without throwing an error. Increased the dimensions of grid since pieces could be moved one step beyond its previous boundaries.

Found this issue when testing out the tutorial code and attempted to render it. It threw an error because the array was expecting numerical data, but was given strings.