### PR TITLE
[Fix] #1242 bug report broken tests for connect four in ci

### DIFF
--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -17,7 +17,9 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ['3.8', '3.9', '3.10', '3.11']
-                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/connect_four, SB3/test]  # TODO: fix tutorials and add back Ray
+                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/test]  
+                # TODO: fix tutorials and add back Ray
+                # TODO: fix SB3/connect_four tutorial
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -15,10 +15,10 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
-            
+
             matrix:
                 python-version: ['3.8', '3.9', '3.10', '3.11']
-                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/test]  # TODO: fix tutorials and add back Ray, fix SB3/connect_four tutorial     
+                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/test]  # TODO: fix tutorials and add back Ray, fix SB3/connect_four tutorial
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -15,11 +15,10 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
+            
             matrix:
                 python-version: ['3.8', '3.9', '3.10', '3.11']
-                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/test]  
-                # TODO: fix tutorials and add back Ray
-                # TODO: fix SB3/connect_four tutorial
+                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/test]  # TODO: fix tutorials and add back Ray, fix SB3/connect_four tutorial     
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/docs/tutorials/sb3/connect_four.md
+++ b/docs/tutorials/sb3/connect_four.md
@@ -4,6 +4,13 @@ title: "SB3: Action Masked PPO for Connect Four"
 
 # SB3: Action Masked PPO for Connect Four
 
+```{eval-rst}
+.. warning::
+
+   Currently, this tutorial doesn't work with versions of gymnasium>0.29.1. We are looking into fixing it but it might take some time.
+
+```
+
 This tutorial shows how to train a agents using Maskable [Proximal Policy Optimization](https://sb3-contrib.readthedocs.io/en/master/modules/ppo_mask.html) (PPO) on the [Connect Four](/environments/classic/chess/) environment ([AEC](/api/aec/)).
 
 It creates a custom Wrapper to convert to a [Gymnasium](https://gymnasium.farama.org/)-like environment which is compatible with [SB3 action masking](https://sb3-contrib.readthedocs.io/en/master/modules/ppo_mask.html).

--- a/tutorials/SB3/connect_four/requirements.txt
+++ b/tutorials/SB3/connect_four/requirements.txt
@@ -1,3 +1,4 @@
 pettingzoo[classic]>=1.24.0
 stable-baselines3>=2.0.0
 sb3-contrib>=2.0.0
+gymnasium<=0.29.1

--- a/tutorials/SB3/connect_four/sb3_connect_four_action_mask.py
+++ b/tutorials/SB3/connect_four/sb3_connect_four_action_mask.py
@@ -8,15 +8,14 @@ Author: Elliot (https://github.com/elliottower)
 import glob
 import os
 import time
-import gymnasium as gym
 
+import gymnasium as gym
 from sb3_contrib import MaskablePPO
 from sb3_contrib.common.maskable.policies import MaskableActorCriticPolicy
 from sb3_contrib.common.wrappers import ActionMasker
 
 import pettingzoo.utils
 from pettingzoo.classic import connect_four_v3
-
 
 
 class SB3ActionMaskWrapper(pettingzoo.utils.BaseWrapper):
@@ -176,10 +175,11 @@ def eval_action_mask(env_fn, num_games=100, render_mode=None, **env_kwargs):
 
 
 if __name__ == "__main__":
-
     if gym.__version__ > "0.29.1":
-        raise ImportError(f"This script requires gymnasium version 0.29.1 or lower, but you have version {gym.__version__}.")
-    
+        raise ImportError(
+            f"This script requires gymnasium version 0.29.1 or lower, but you have version {gym.__version__}."
+        )
+
     env_fn = connect_four_v3
 
     env_kwargs = {}

--- a/tutorials/SB3/connect_four/sb3_connect_four_action_mask.py
+++ b/tutorials/SB3/connect_four/sb3_connect_four_action_mask.py
@@ -8,6 +8,7 @@ Author: Elliot (https://github.com/elliottower)
 import glob
 import os
 import time
+import gymnasium as gym
 
 from sb3_contrib import MaskablePPO
 from sb3_contrib.common.maskable.policies import MaskableActorCriticPolicy
@@ -15,6 +16,7 @@ from sb3_contrib.common.wrappers import ActionMasker
 
 import pettingzoo.utils
 from pettingzoo.classic import connect_four_v3
+
 
 
 class SB3ActionMaskWrapper(pettingzoo.utils.BaseWrapper):
@@ -174,6 +176,10 @@ def eval_action_mask(env_fn, num_games=100, render_mode=None, **env_kwargs):
 
 
 if __name__ == "__main__":
+
+    if gym.__version__ > "0.29.1":
+        raise ImportError(f"This script requires gymnasium version 0.29.1 or lower, but you have version {gym.__version__}.")
+    
     env_fn = connect_four_v3
 
     env_kwargs = {}


### PR DESCRIPTION
# Description

Fixes #1242 

The sb3 tutorial for connect_four breaks for versions of `gymnasium>0.29.1`, which makes the CI for all PR fail.
This PR is a temporary fix until a more permanent solution is found.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Changes

- Removed SB3/connect_four from the tests in workflow `.github/workflows/linux-tutorials-test.yml`.
- Added a check for the versions of gymnasium in `tutorials/SB3/connect_four/sb3_connect_four_action_mask.py` that throws ImportError if gymnasium>0.29.1.
- Added a warning in the docs that the tutorial breaks for gymnasium>0.29.1 in `docs/tutorials/sb3/connect_four.md`

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

