### PR TITLE
[Feat] Deprecate Python 3.8, add Python 3.12 + update CI/CD

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -31,9 +31,7 @@ jobs:
                     - os: ubuntu-latest
                       python: 312
                       platform: manylinux_x86_64
-                    - os: ubuntu-latest
-                      python: 313
-                      platform: manylinux_x86_64
+
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -20,9 +20,6 @@ jobs:
             matrix:
                 include:
                     - os: ubuntu-latest
-                      python: 38
-                      platform: manylinux_x86_64
-                    - os: ubuntu-latest
                       python: 39
                       platform: manylinux_x86_64
                     - os: ubuntu-latest
@@ -33,6 +30,9 @@ jobs:
                       platform: manylinux_x86_64
                     - os: ubuntu-latest
                       python: 312
+                      platform: manylinux_x86_64
+                    - os: ubuntu-latest
+                      python: 313
                       platform: manylinux_x86_64
 
         steps:

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
     docs-test:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+                python-version: ['3.9', '3.10', '3.11', '3.12','3.13']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
     linux-test:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 python-version: ['3.9', '3.10', '3.11', '3.12']

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12','3.13']
+                python-version: ['3.9', '3.10', '3.11', '3.12']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -42,7 +42,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+                python-version: ['3.9', '3.10', '3.11', '3.12']
                 tutorial: [AgileRL]
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -31,7 +31,8 @@ jobs:
                   export PATH=/path/to/parallel:$PATH
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
-                  pip install $(grep -ivE "pettingzoo" requirements.txt)
+                  grep -ivE "pettingzoo" requirements.txt > _requirements.txt
+                  pip install -r _requirements.txt
                   pip install -e $root_dir[all]
                   pip install -e $root_dir[testing]
                   AutoROM -v
@@ -56,7 +57,8 @@ jobs:
                   export PATH=/path/to/parallel:$PATH
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
-                  pip install $(grep -ivE "pettingzoo" requirements.txt)
+                  grep -ivE "pettingzoo" requirements.txt > _requirements.txt
+                  pip install -r _requirements.txt
                   pip install -e $root_dir[all]
                   pip install -e $root_dir[testing]
                   AutoROM -v

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -31,8 +31,7 @@ jobs:
                   export PATH=/path/to/parallel:$PATH
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
-                  pip install -r requirements.txt
-                  pip uninstall -y pettingzoo
+                  pip install $(grep -ivE "pettingzoo" requirements.txt)
                   pip install -e $root_dir[testing]
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done
@@ -56,8 +55,7 @@ jobs:
                   export PATH=/path/to/parallel:$PATH
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
-                  pip install -r requirements.txt
-                  pip uninstall -y pettingzoo
+                  pip install $(grep -ivE "pettingzoo" requirements.txt)
                   pip install -e $root_dir[testing]
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
 
             matrix:
-                python-version: ['3.9', '3.10', '3.11','3.12','3.13']
+                python-version: ['3.9', '3.10', '3.11','3.12']
                 tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/test]  # TODO: fix tutorials and add back Ray, fix SB3/connect_four tutorial
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -32,7 +32,7 @@ jobs:
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
                   pip install $(grep -ivE "pettingzoo" requirements.txt)
-                  pip install -e $root_dir[testing]
+                  pip install -e $root_dir[all,testing]
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done
 
@@ -56,6 +56,6 @@ jobs:
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
                   pip install $(grep -ivE "pettingzoo" requirements.txt)
-                  pip install -e $root_dir[testing]
+                  pip install -e $root_dir[all,testing]
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
 
             matrix:
-                python-version: ['3.9', '3.10', '3.11','3.12']
+                python-version: ['3.9', '3.10', '3.11', '3.12']
                 tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/test]  # TODO: fix tutorials and add back Ray, fix SB3/connect_four tutorial
         steps:
             - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.9', '3.10', '3.11','3.12','3.13']
+                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
                 tutorial: [AgileRL]
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
 
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.9', '3.10', '3.11','3.12','3.13']
                 tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/test]  # TODO: fix tutorials and add back Ray, fix SB3/connect_four tutorial
         steps:
             - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.9', '3.10', '3.11']
+                python-version: ['3.9', '3.10', '3.11','3.12','3.13']
                 tutorial: [AgileRL]
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -43,7 +43,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12']
+                python-version: ['3.9', '3.10', '3.11']
                 tutorial: [AgileRL]
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
     tutorial-test:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             fail-fast: false
 
@@ -37,7 +37,7 @@ jobs:
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done
 
     agilerl-tutorial-test:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -32,7 +32,8 @@ jobs:
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
                   pip install $(grep -ivE "pettingzoo" requirements.txt)
-                  pip install -e $root_dir[all,testing]
+                  pip install -e $root_dir[all]
+                  pip install -e $root_dir[testing]
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done
 
@@ -56,6 +57,7 @@ jobs:
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
                   pip install $(grep -ivE "pettingzoo" requirements.txt)
-                  pip install -e $root_dir[all,testing]
+                  pip install -e $root_dir[all]
+                  pip install -e $root_dir[testing]
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -15,7 +15,7 @@ jobs:
             matrix:
             # Big Sur, Monterey
                 os: [macos-11, macos-12]
-                python-version: ['3.9', '3.10', '3.11','3.12']
+                python-version: ['3.9', '3.10', '3.11', '3.12']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -15,7 +15,7 @@ jobs:
             matrix:
             # Big Sur, Monterey
                 os: [macos-11, macos-12]
-                python-version: ['3.9', '3.10', '3.11','3.12','3.13']
+                python-version: ['3.9', '3.10', '3.11','3.12']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -15,7 +15,7 @@ jobs:
             matrix:
             # Big Sur, Monterey
                 os: [macos-11, macos-12]
-                python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+                python-version: ['3.9', '3.10', '3.11','3.12','3.13']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ ipython_config.py
 
 # MacOS specific
 */.DS_Store
+.DS_Store
 
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This does not include dependencies for all families of environments (some enviro
 
 To install the dependencies for one family, use `pip install 'pettingzoo[atari]'`, or use `pip install 'pettingzoo[all]'` to install all dependencies.
 
-We support and maintain PettingZoo for Python 3.9, 3.10, 3.11, 3.12 and 3.13 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+We support and maintain PettingZoo for Python 3.9, 3.10, 3.11, and 3.12 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 
 Note: Some Linux distributions may require manual installation of `cmake`, `swig`, or `zlib1g-dev` (e.g., `sudo apt install cmake swig zlib1g-dev`)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This does not include dependencies for all families of environments (some enviro
 
 To install the dependencies for one family, use `pip install 'pettingzoo[atari]'`, or use `pip install 'pettingzoo[all]'` to install all dependencies.
 
-We support Python 3.8, 3.9, 3.10 and 3.11 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+We support and maintain PettingZoo for Python 3.9, 3.10, 3.11, 3.12 and 3.13 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 
 Note: Some Linux distributions may require manual installation of `cmake`, `swig`, or `zlib1g-dev` (e.g., `sudo apt install cmake swig zlib1g-dev`)
 

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -11,7 +11,7 @@ This does not include dependencies for all families of environments (some enviro
 
 To install the dependencies for one family, use `pip install 'pettingzoo[atari]'`, or use `pip install 'pettingzoo[all]'` to install all dependencies.
 
-We support and maintain PettingZoo for Python 3.9, 3.10, 3.11, 3.12 and 3.13 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+We support and maintain PettingZoo for Python 3.9, 3.10, 3.11, and 3.12 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 
 ## Initializing Environments
 

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -11,7 +11,7 @@ This does not include dependencies for all families of environments (some enviro
 
 To install the dependencies for one family, use `pip install 'pettingzoo[atari]'`, or use `pip install 'pettingzoo[all]'` to install all dependencies.
 
-We support Python 3.8, 3.9, 3.10 and 3.11 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+We support and maintain PettingZoo for Python 3.9, 3.10, 3.11, 3.12 and 3.13 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 
 ## Initializing Environments
 

--- a/docs/tutorials/agilerl/index.md
+++ b/docs/tutorials/agilerl/index.md
@@ -12,6 +12,13 @@ AgileRL is a deep reinforcement learning framework focused on streamlining train
 
 For more information about AgileRL and what else the library has to offer, check out the [documentation](https://agilerl.readthedocs.io/en/latest/) and [GitHub repo](https://github.com/agilerl/agilerl).
 
+```{eval-rst}
+.. warning::
+
+   AgileRL only supports versions of python <3.12.
+
+```
+
 ## Examples using PettingZoo
 
 * [MADDPG for co-operation: simple speaker listener environment](https://agilerl.readthedocs.io/en/latest/multi_agent_training/index.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "pettingzoo"
 description = "Gymnasium for multi-agent reinforcement learning."
 readme = "README.md"
-requires-python = ">= 3.9"
+requires-python = ">= 3.9, <3.13"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "game", "RL", "AI", "gymnasium"]
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     'Intended Audience :: Science/Research',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,16 +31,16 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
-atari = ["multi_agent_ale_py>=0.1.11", "pygame>=2.6.0"]
+atari = ["multi_agent_ale_py>=0.1.11", "pygame>=2.3.0"]
 classic = [
     "chess>=1.9.4",
     "rlcard>=1.0.5",
-    "pygame>=2.6.0",
+    "pygame>=2.3.0",
     "shimmy[openspiel]>=1.2.0"
 ]
-butterfly = ["pygame>=2.6.0", "pymunk>=6.2.0"]
-mpe = ["pygame>=2.6.0"]
-sisl = ["pygame>=2.6.0", "pymunk>=6.2.0", "box2d-py>=2.3.5", "scipy>=1.4.1"]
+butterfly = ["pygame>=2.3.0", "pymunk>=6.2.0"]
+mpe = ["pygame>=2.3.0"]
+sisl = ["pygame>=2.3.0", "pymunk>=6.2.0", "box2d-py>=2.3.5", "scipy>=1.4.1"]
 other = ["pillow>=8.0.1"]
 testing = [
     "pynput>=1.7.6",
@@ -53,7 +53,7 @@ testing = [
 ]
 all = [
     "multi_agent_ale_py>=0.1.11",
-    "pygame>=2.6.0",
+    "pygame>=2.3.0",
     "chess>=1.9.4",
     "rlcard>=1.0.5",
     "shimmy[openspiel]>=1.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,16 +31,16 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
-atari = ["multi_agent_ale_py>=0.1.11", "pygame>=2.3.0"]
+atari = ["multi_agent_ale_py>=0.1.11", "pygame>=2.6.0"]
 classic = [
     "chess>=1.9.4",
     "rlcard>=1.0.5",
-    "pygame>=2.3.0",
+    "pygame>=2.6.0",
     "shimmy[openspiel]>=1.2.0"
 ]
-butterfly = ["pygame>=2.3.0", "pymunk>=6.2.0"]
-mpe = ["pygame>=2.3.0"]
-sisl = ["pygame>=2.3.0", "pymunk>=6.2.0", "box2d-py>=2.3.5", "scipy>=1.4.1"]
+butterfly = ["pygame>=2.6.0", "pymunk>=6.2.0"]
+mpe = ["pygame>=2.6.0"]
+sisl = ["pygame>=2.6.0", "pymunk>=6.2.0", "box2d-py>=2.3.5", "scipy>=1.4.1"]
 other = ["pillow>=8.0.1"]
 testing = [
     "pynput>=1.7.6",
@@ -53,7 +53,7 @@ testing = [
 ]
 all = [
     "multi_agent_ale_py>=0.1.11",
-    "pygame>=2.3.0",
+    "pygame>=2.6.0",
     "chess>=1.9.4",
     "rlcard>=1.0.5",
     "shimmy[openspiel]>=1.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "pettingzoo"
 description = "Gymnasium for multi-agent reinforcement learning."
 readme = "README.md"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "game", "RL", "AI", "gymnasium"]
@@ -16,11 +16,11 @@ classifiers = [
     "Development Status :: 4 - Beta",  # change to `5 - Production/Stable` when ready
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     'Intended Audience :: Science/Research',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ]

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -1,7 +1,4 @@
-# Enforce Python version constraint
-python_version < '3.12'
-
-agilerl==0.1.22; python_version >= '3.9'
+agilerl==0.1.22; python_version >= '3.9' and python_version < '3.12'
 pettingzoo[classic,atari,mpe]>=1.23.1
 SuperSuit>=3.9.0
 torch>=2.0.1

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -1,3 +1,6 @@
+# Enforce Python version constraint
+python_version < '3.12'
+
 agilerl==0.1.22; python_version >= '3.9'
 pettingzoo[classic,atari,mpe]>=1.23.1
 SuperSuit>=3.9.0

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -1,4 +1,4 @@
-agilerl==0.1.22; python_version >= '3.9'
+agilerl==0.1.22
 pettingzoo[classic,atari,mpe]>=1.23.1
 SuperSuit>=3.9.0
 torch>=2.0.1

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -1,4 +1,4 @@
-agilerl==0.1.22
+agilerl==0.1.22; python_version >= '3.9'
 pettingzoo[classic,atari,mpe]>=1.23.1
 SuperSuit>=3.9.0
 torch>=2.0.1
@@ -9,4 +9,3 @@ gymnasium>=0.28.1
 imageio>=2.31.1
 Pillow>=9.5.0
 PyYAML>=5.4.1
-wandb>=0.16.0

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -9,4 +9,4 @@ gymnasium>=0.28.1
 imageio>=2.31.1
 Pillow>=9.5.0
 PyYAML>=5.4.1
-wandb>=0.13.10
+wandb>=0.16.0

--- a/tutorials/CustomEnvironment/requirements.txt
+++ b/tutorials/CustomEnvironment/requirements.txt
@@ -1,1 +1,2 @@
-pettingzoo==1.24.0
+numpy>=1.21.0
+pettingzoo>=1.24.0

--- a/tutorials/SB3/waterworld/requirements.txt
+++ b/tutorials/SB3/waterworld/requirements.txt
@@ -1,3 +1,4 @@
+pygame==2.6.0
 pettingzoo[sisl]>=1.24.0
 stable-baselines3>=2.0.0
 supersuit>=3.9.0

--- a/tutorials/SB3/waterworld/requirements.txt
+++ b/tutorials/SB3/waterworld/requirements.txt
@@ -1,4 +1,3 @@
-pygame==2.6.0
 pettingzoo[sisl]>=1.24.0
 stable-baselines3>=2.0.0
 supersuit>=3.9.0


### PR DESCRIPTION
# Description

As planned for the release of version 1.24.4, we are removing support for python >3.9, and adding python 3.12 .

## Type of change


- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


