### PR TITLE
Docs: update aec_rps.py

### DIFF
--- a/docs/code_examples/aec_rps.py
+++ b/docs/code_examples/aec_rps.py
@@ -76,10 +76,8 @@ class raw_env(AECEnv):
         )
 
         # optional: we can define the observation and action spaces here as attributes to be used in their corresponding methods
-        self._action_spaces = {agent: Discrete(3) for agent in self.possible_agents}
-        self._observation_spaces = {
-            agent: Discrete(4) for agent in self.possible_agents
-        }
+        self.action_spaces = {agent: Discrete(3) for agent in self.possible_agents}
+        self.observation_spaces = {agent: Discrete(4) for agent in self.possible_agents}
         self.render_mode = render_mode
 
     # Observation space should be defined here.
@@ -88,13 +86,13 @@ class raw_env(AECEnv):
     @functools.lru_cache(maxsize=None)
     def observation_space(self, agent):
         # gymnasium spaces are defined and documented here: https://gymnasium.farama.org/api/spaces/
-        return Discrete(4)
+        return self.observation_spaces[agent]
 
     # Action space should be defined here.
     # If your spaces change over time, remove this line (disable caching).
     @functools.lru_cache(maxsize=None)
     def action_space(self, agent):
-        return Discrete(3)
+        return self.action_spaces[agent]
 
     def render(self):
         """


### PR DESCRIPTION
# Description

Update code in the [documentation](https://pettingzoo.farama.org/content/environment_creation/#example-custom-environment).

## Type of change

- This change requires a documentation update

## Reason

All environments use `self.observation_spaces` and `self.action_spaces` to define observation spaces and action spaces, rather than `self._observation_spaces` and `self._action_spaces`. So, I think it is necessary to fix it to ensure consistency.

In addition, I modified the `observation_space` and `action_space` methods to obtain the observation space and action space through dict `self.observation_spaces` and `self.action_spaces`.

I did not modify the `observation_space` and `action_space` methods in `parallel_rps.py` because `self.observation_spaces` and `self.action_spaces` are not defined there.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->