### PR TITLE
Fix Github Workflow for Building Documentations

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,7 +3,6 @@ name: Build Documentation website
 on:
     push:
         branches: [master]
-    workflow_dispatch:
 permissions:
     contents: write
 jobs:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,6 +3,7 @@ name: Build Documentation website
 on:
     push:
         branches: [master]
+    workflow_dispatch:
 permissions:
     contents: write
 jobs:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
     docs:
         name: Generate Website
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         env:
             SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:


### PR DESCRIPTION
# Description

This PR fixes Github Workflow build-docs, which has issues building multi_agent_ale_py.

Manually ran build documentation workflow and succeeded (https://github.com/Farama-Foundation/PettingZoo/actions/runs/13484600508).

I don't fully understand why ubuntu-latest has a build failure (I pattern matched based on [this PR](https://github.com/Farama-Foundation/PettingZoo/pull/1246)), but building it with a fixed ubuntu version (ubuntu-22.04) fixed the installation issue.

Fixes # (1267)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
