### PR TITLE
Fix pyright type error to assert that actions can't be an int.

### DIFF
--- a/pettingzoo/utils/average_total_reward.py
+++ b/pettingzoo/utils/average_total_reward.py
@@ -34,7 +34,9 @@ def average_total_reward(
             if termination or truncation:
                 action = None
             elif isinstance(obs, dict) and "action_mask" in obs:
-                action = random.choice(np.flatnonzero(obs["action_mask"]).tolist())
+                actions = np.flatnonzero(obs["action_mask"]).tolist()
+                assert not isinstance(actions, int)
+                action = random.choice(actions)
             else:
                 action = env.action_space(agent).sample()
             env.step(action)

--- a/pettingzoo/utils/random_demo.py
+++ b/pettingzoo/utils/random_demo.py
@@ -23,7 +23,9 @@ def random_demo(env: AECEnv, render: bool = True, episodes: int = 1) -> float:
             if termination or truncation:
                 action = None
             elif isinstance(obs, dict) and "action_mask" in obs:
-                action = random.choice(np.flatnonzero(obs["action_mask"]).tolist())
+                actions = np.flatnonzero(obs["action_mask"]).tolist()
+                assert not isinstance(actions, int)
+                action = random.choice(actions)
             else:
                 action = env.action_space(agent).sample()
             env.step(action)


### PR DESCRIPTION
# Description

When I ran `pre-commit run --all-files` locally, there were two pyright errors, and I think the error is valid - numpy doesn't provide enough type context to tell pyright that `tolist()` will not return a scalar if the instance isn't a scalar. Since `np.flatnonzero` never returns a scalar, asserting that the return value of `tolist()` is never an int seems reasonable to fix pyright error.

Fixes #1269 .

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
