### PR TITLE
1249 feat upgrade to gymnasium 1.0.0

### DIFF
--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -58,9 +58,6 @@ jobs:
                   export PATH=/path/to/parallel:$PATH
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
-                  grep -ivE "pettingzoo" requirements.txt > _requirements.txt
-                  pip install -r _requirements.txt
-                  pip install -e $root_dir[all]
-                  pip install -e $root_dir[testing]
+                  pip install -r requirements.txt
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -19,7 +19,7 @@ jobs:
 
             matrix:
                 python-version: ['3.9', '3.10', '3.11', '3.12']
-                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/kaz, SB3/waterworld, SB3/test]  # TODO: fix tutorials and add back Ray, fix SB3/connect_four tutorial
+                tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/connect_four, SB3/kaz, SB3/waterworld, SB3/test]  # TODO: fix tutorials and add back Ray.
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -57,6 +57,9 @@ jobs:
                   export PATH=/path/to/parallel:$PATH
                   export root_dir=$(pwd)
                   cd tutorials/${{ matrix.tutorial }}
+                  # Unlike above workflow, we pip install directly from the requirements.txt file
+                  # because we need to install a specific version of pettingzoo until agileRL
+                  # updates its gymnasium dependency version.
                   pip install -r requirements.txt
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -6,6 +6,7 @@ on:
         branches: [master]
     pull_request:
         branches: [master]
+    workflow_dispatch:
 
 permissions:
     contents: read

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -6,7 +6,6 @@ on:
         branches: [master]
     pull_request:
         branches: [master]
-    workflow_dispatch:
 
 permissions:
     contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.21.0",
-    "gymnasium>=0.28.1",
+    "gymnasium>=1.0.0",
 ]
 dynamic = ["version"]
 

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -1,5 +1,9 @@
 agilerl==0.1.22; python_version >= '3.9' and python_version < '3.12'
-pettingzoo[classic,atari,mpe]>=1.23.1
+# agileRL doesn't currently support gymnasium version greater
+# than 0.28.1, so we can only run with an older version of
+# pettingzoo. Fix this once agileRL can support newer
+# gymnasium version.
+pettingzoo[classic,atari,mpe]>=1.23.1,<1.24.3
 SuperSuit>=3.9.0
 torch>=2.0.1
 numpy>=1.24.2

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -3,7 +3,7 @@ agilerl==0.1.22; python_version >= '3.9' and python_version < '3.12'
 # than 0.28.1, so we can only run with an older version of
 # pettingzoo. Fix this once agileRL can support newer
 # gymnasium version.
-pettingzoo[classic,atari,mpe]>=1.23.1,<1.24.3
+pettingzoo[classic,atari,mpe]>=1.23.1,<=1.24.3
 AutoROM>=0.6.1
 SuperSuit>=3.9.0
 torch>=2.0.1

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -4,6 +4,7 @@ agilerl==0.1.22; python_version >= '3.9' and python_version < '3.12'
 # pettingzoo. Fix this once agileRL can support newer
 # gymnasium version.
 pettingzoo[classic,atari,mpe]>=1.23.1,<1.24.3
+AutoROM>=0.6.1
 SuperSuit>=3.9.0
 torch>=2.0.1
 numpy>=1.24.2

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -5,7 +5,7 @@ torch>=2.0.1
 numpy>=1.24.2
 tqdm>=4.65.0
 fastrand==1.3.0
-gymnasium>=0.28.1
+gymnasium>=1.0.0
 imageio>=2.31.1
 Pillow>=9.5.0
 PyYAML>=5.4.1

--- a/tutorials/AgileRL/requirements.txt
+++ b/tutorials/AgileRL/requirements.txt
@@ -5,7 +5,7 @@ torch>=2.0.1
 numpy>=1.24.2
 tqdm>=4.65.0
 fastrand==1.3.0
-gymnasium>=1.0.0
+gymnasium>=0.28.1
 imageio>=2.31.1
 Pillow>=9.5.0
 PyYAML>=5.4.1

--- a/tutorials/SB3/connect_four/requirements.txt
+++ b/tutorials/SB3/connect_four/requirements.txt
@@ -1,7 +1,3 @@
-# This tutorial requires gymnasium version 0.29.1 or lower, but pettingzoo
-# 1.24.4 and above now requires gymnasium version 1.0.0 or higher. Thus,
-# we set an upper limit of pettingzoo version to 1.24.3 until the tutorial
-# gets updated.
 pettingzoo[classic]>=1.24.0
 stable-baselines3>=2.0.0
 sb3-contrib>=2.0.0

--- a/tutorials/SB3/connect_four/requirements.txt
+++ b/tutorials/SB3/connect_four/requirements.txt
@@ -1,4 +1,8 @@
-pettingzoo[classic]>=1.24.0
+# This tutorial requires gymnasium version 0.29.1 or lower, but pettingzoo
+# 1.24.4 and above now requires gymnasium version 1.0.0 or higher. Thus,
+# we set an upper limit of pettingzoo version to 1.24.3 until the tutorial
+# gets updated.
+pettingzoo[classic]>=1.24.0,<=1.24.3
 stable-baselines3>=2.0.0
 sb3-contrib>=2.0.0
-gymnasium>=1.0.0
+gymnasium<=0.29.1

--- a/tutorials/SB3/connect_four/requirements.txt
+++ b/tutorials/SB3/connect_four/requirements.txt
@@ -2,7 +2,6 @@
 # 1.24.4 and above now requires gymnasium version 1.0.0 or higher. Thus,
 # we set an upper limit of pettingzoo version to 1.24.3 until the tutorial
 # gets updated.
-pettingzoo[classic]>=1.24.0,<=1.24.3
+pettingzoo[classic]>=1.24.0
 stable-baselines3>=2.0.0
 sb3-contrib>=2.0.0
-gymnasium<=0.29.1

--- a/tutorials/SB3/connect_four/requirements.txt
+++ b/tutorials/SB3/connect_four/requirements.txt
@@ -1,4 +1,4 @@
 pettingzoo[classic]>=1.24.0
 stable-baselines3>=2.0.0
 sb3-contrib>=2.0.0
-gymnasium<=0.29.1
+gymnasium>=1.0.0

--- a/tutorials/SB3/connect_four/sb3_connect_four_action_mask.py
+++ b/tutorials/SB3/connect_four/sb3_connect_four_action_mask.py
@@ -5,6 +5,7 @@ For more information about invalid action masking in SB3, see https://sb3-contri
 
 Author: Elliot (https://github.com/elliottower)
 """
+
 import glob
 import os
 import time
@@ -18,7 +19,9 @@ import pettingzoo.utils
 from pettingzoo.classic import connect_four_v3
 
 
-class SB3ActionMaskWrapper(pettingzoo.utils.BaseWrapper):
+# To pass into other gymnasium wrappers, we need to ensure that pettingzoo's wrappper
+# can also be a gymnasium Env. Thus, we subclass under gym.Env as well.
+class SB3ActionMaskWrapper(pettingzoo.utils.BaseWrapper, gym.Env):
     """Wrapper to allow PettingZoo environments to be used with SB3 illegal action masking."""
 
     def reset(self, seed=None, options=None):
@@ -175,11 +178,6 @@ def eval_action_mask(env_fn, num_games=100, render_mode=None, **env_kwargs):
 
 
 if __name__ == "__main__":
-    if gym.__version__ > "0.29.1":
-        raise ImportError(
-            f"This script requires gymnasium version 0.29.1 or lower, but you have version {gym.__version__}."
-        )
-
     env_fn = connect_four_v3
 
     env_kwargs = {}


### PR DESCRIPTION
# Description

This PR upgrade pettingzoo's gymnasium dependency version to 1.0.0. While upgrading its version, we had to set an upper limit on agileRL tutorial because its gymnasium version is upper limited by 0.28.1. We update github workflow to reflect that, too.

We also add SB3's connect_four tutorial back by fixing the env instance check bug (https://github.com/Farama-Foundation/PettingZoo/pull/1243 for reference).

Fixes #1249 

## Type of change

> Please delete options that are not relevant.

- Breaking change by upgrading gymnasium version to 1.0.0.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes