### PR TITLE
[BUILD]: fix AgileRL tutorial CI/CD workflow by importing PettingZoo from master instead of the latest published version

### DIFF
--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -60,6 +60,9 @@ jobs:
                   # Unlike above workflow, we pip install directly from the requirements.txt file
                   # because we need to install a specific version of pettingzoo until agileRL
                   # updates its gymnasium dependency version.
-                  pip install -r requirements.txt
+                  grep -ivE "pettingzoo" requirements.txt > _requirements.txt
+                  pip install -r _requirements.txt
+                  pip install -e $root_dir[all]
+                  pip install -e $root_dir[testing]
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done


### PR DESCRIPTION
Fixes #1274 

