### PR TITLE
Add a third party environment: Box Jump

### DIFF
--- a/docs/environments/third_party_envs.md
+++ b/docs/environments/third_party_envs.md
@@ -62,6 +62,13 @@ Using [Google DeepMind](https://www.deepmind.com/)'s [MuZero](https://en.wikiped
 
 CookingZoo: a gym-cooking derivative to simulate a complex cooking environment.
 
+### [Box Jump](https://github.com/DavidRother/gym-cooking)
+
+[![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.24.3-blue)]()
+[![GitHub stars](https://img.shields.io/github/stars/zzbuzzard/boxjump)]()
+
+Box Jump is a fully co-operative 2D physics-based MARL environment in which agents jump on top of each other to build a tower.
+
 ### [Crazy-RL](https://github.com/ffelten/CrazyRL)
 
 [![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.22.3-blue)]()

--- a/docs/environments/third_party_envs.md
+++ b/docs/environments/third_party_envs.md
@@ -62,12 +62,12 @@ Using [Google DeepMind](https://www.deepmind.com/)'s [MuZero](https://en.wikiped
 
 CookingZoo: a gym-cooking derivative to simulate a complex cooking environment.
 
-### [Box Jump](https://github.com/DavidRother/gym-cooking)
+### [Box Jump](https://github.com/zzbuzzard/boxjump)
 
 [![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.24.3-blue)]()
 [![GitHub stars](https://img.shields.io/github/stars/zzbuzzard/boxjump)]()
 
-Box Jump is a fully co-operative 2D physics-based MARL environment in which agents jump on top of each other to build a tower.
+Box Jump is a fully co-operative, 2D physics-based MARL environment in which agents jump on top of each other to build a tower.
 
 ### [Crazy-RL](https://github.com/ffelten/CrazyRL)
 


### PR DESCRIPTION
# Description

Hi! I've just finished documenting and releasing [Box Jump](https://github.com/zzbuzzard/boxjump), a custom PettingZoo environment I made recently which aims to be a simple co-op environment that can scale to many agents. This pull request simply adds it to the third party environment list.

## Type of change
- This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
