### PR TITLE
Make AECEnv/ParallelEnv rps examples deterministic by setting the RNG seed properly.

### DIFF
--- a/docs/code_examples/aec_rps.py
+++ b/docs/code_examples/aec_rps.py
@@ -148,6 +148,7 @@ class raw_env(AECEnv):
         can be called without issues.
         Here it sets up the state dictionary which is used by step() and the observations dictionary which is used by step() and observe()
         """
+        # Unlike gymnasium's Env, the environment is responsible for setting the random seed explicitly.
         if seed is not None:
             self.np_random, self.np_random_seed = seeding.np_random(seed)
         self.agents = self.possible_agents[:]

--- a/docs/code_examples/aec_rps.py
+++ b/docs/code_examples/aec_rps.py
@@ -3,6 +3,7 @@ import functools
 import gymnasium
 import numpy as np
 from gymnasium.spaces import Discrete
+from gymnasium.utils import seeding
 
 from pettingzoo import AECEnv
 from pettingzoo.utils import AgentSelector, wrappers
@@ -94,7 +95,8 @@ class raw_env(AECEnv):
     # If your spaces change over time, remove this line (disable caching).
     @functools.lru_cache(maxsize=None)
     def action_space(self, agent):
-        return Discrete(3)
+        # We can seed the action space to make the environment deterministic.
+        return Discrete(3, seed=self.np_random_seed)
 
     def render(self):
         """
@@ -146,6 +148,8 @@ class raw_env(AECEnv):
         can be called without issues.
         Here it sets up the state dictionary which is used by step() and the observations dictionary which is used by step() and observe()
         """
+        if seed is not None:
+            self.np_random, self.np_random_seed = seeding.np_random(seed)
         self.agents = self.possible_agents[:]
         self.rewards = {agent: 0 for agent in self.agents}
         self._cumulative_rewards = {agent: 0 for agent in self.agents}

--- a/docs/code_examples/aec_rps_usage.py
+++ b/docs/code_examples/aec_rps_usage.py
@@ -1,4 +1,4 @@
-import aec_rps
+from . import aec_rps
 
 env = aec_rps.env(render_mode="human")
 env.reset(seed=42)

--- a/docs/code_examples/aec_rps_usage.py
+++ b/docs/code_examples/aec_rps_usage.py
@@ -1,4 +1,4 @@
-from . import aec_rps
+import aec_rps
 
 env = aec_rps.env(render_mode="human")
 env.reset(seed=42)

--- a/docs/code_examples/parallel_rps.py
+++ b/docs/code_examples/parallel_rps.py
@@ -3,6 +3,7 @@ import functools
 import gymnasium
 import numpy as np
 from gymnasium.spaces import Discrete
+from gymnasium.utils import seeding
 
 from pettingzoo import ParallelEnv
 from pettingzoo.utils import parallel_to_aec, wrappers
@@ -91,7 +92,7 @@ class parallel_env(ParallelEnv):
     # If your spaces change over time, remove this line (disable caching).
     @functools.lru_cache(maxsize=None)
     def action_space(self, agent):
-        return Discrete(3)
+        return Discrete(3, seed=self.np_random_seed)
 
     def render(self):
         """
@@ -128,6 +129,8 @@ class parallel_env(ParallelEnv):
         hands that are played.
         Returns the observations for each agent
         """
+        if seed is not None:
+            self.np_random, self.np_random_seed = seeding.np_random(seed)
         self.agents = self.possible_agents[:]
         self.num_moves = 0
         # the observations should be numpy arrays even if there is only one value

--- a/docs/code_examples/parallel_rps_usage.py
+++ b/docs/code_examples/parallel_rps_usage.py
@@ -1,4 +1,4 @@
-import parallel_rps
+from . import parallel_rps
 
 env = parallel_rps.parallel_env(render_mode="human")
 observations, infos = env.reset(seed=42)

--- a/docs/code_examples/parallel_rps_usage.py
+++ b/docs/code_examples/parallel_rps_usage.py
@@ -1,7 +1,7 @@
-from . import parallel_rps
+import parallel_rps
 
 env = parallel_rps.parallel_env(render_mode="human")
-observations, infos = env.reset()
+observations, infos = env.reset(seed=42)
 
 while env.agents:
     # this is where you would insert your policy


### PR DESCRIPTION
# Description

Previously, both AECEnv and ParallelEnv versions of RPS examples in the doc were not running deterministically even though the example set the seed explicitly. This was because both environments silently ignored the set seed. This PR fixes such issue by setting the random seed explicitly in the respective environments using `gymnasium.utils.seeding`.

Fixes #1223 

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes