### PR TITLE
[FEAT]: Add deprecation warnings to MPE environment to prepare for their future migration to the MPE2 package

### DIFF
--- a/docs/environments/mpe.md
+++ b/docs/environments/mpe.md
@@ -18,6 +18,14 @@ mpe/simple_tag
 mpe/simple_world_comm
 ```
 
+```{eval-rst}
+.. warning::
+
+    The package `pettingzoo.mpe` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your imports to `mpe2`.
+
+```
+
 ```{raw} html
     :file: mpe/list.html
 ```

--- a/pettingzoo/mpe/__init__.py
+++ b/pettingzoo/mpe/__init__.py
@@ -3,3 +3,7 @@ from pettingzoo.utils.deprecated_module import deprecated_handler
 
 def __getattr__(env_name):
     return deprecated_handler(env_name, __path__, __name__)
+
+
+# TODO: in a future release, remove all the MPE environments and uncomment the following lines to raise a warning
+# instead of importing the environments

--- a/pettingzoo/mpe/__init__.py
+++ b/pettingzoo/mpe/__init__.py
@@ -1,9 +1,18 @@
+import warnings
+
 from pettingzoo.utils.deprecated_module import deprecated_handler
 
 
 def __getattr__(env_name):
     return deprecated_handler(env_name, __path__, __name__)
 
+
+warnings.warn(
+    "The environment `pettingzoo.mpe` has been moved to `mpe2` and will be removed in a future release."
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 # TODO: in a future release, remove all the MPE environments and uncomment the following lines to raise a warning
 # instead of importing the environments

--- a/pettingzoo/mpe/simple/simple.py
+++ b/pettingzoo/mpe/simple/simple.py
@@ -7,6 +7,14 @@
 :name: simple
 ```
 
+```{eval-rst}
+.. warning::
+
+    The environment `pettingzoo.mpe.simple_v3` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your import to `mpe2.simple_v3`.
+
+```
+
 This environment is part of the <a href='..'>MPE environments</a>. Please read that page first for general information.
 
 | Import             | `from pettingzoo.mpe import simple_v3` |

--- a/pettingzoo/mpe/simple_adversary/simple_adversary.py
+++ b/pettingzoo/mpe/simple_adversary/simple_adversary.py
@@ -7,6 +7,14 @@
 :name: simple_adversary
 ```
 
+```{eval-rst}
+.. warning::
+
+    The environment `pettingzoo.mpe.simple_adversary_v3` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your import to `mpe2.simple_adversary_v3`.
+
+```
+
 This environment is part of the <a href='..'>MPE environments</a>. Please read that page first for general information.
 
 | Import             | `from pettingzoo.mpe import simple_adversary_v3` |

--- a/pettingzoo/mpe/simple_adversary_v3.py
+++ b/pettingzoo/mpe/simple_adversary_v3.py
@@ -1,6 +1,6 @@
 import warnings
 
-from pettingzoo.mpe.simple_crypto.simple_crypto import env, parallel_env, raw_env
+from pettingzoo.mpe.simple_adversary.simple_adversary import env, parallel_env, raw_env
 
 warnings.warn(
     "The environment `pettingzoo.mpe.simple_adversary_v3` has been moved to `mpe2.simple_adversary_v3` and will be removed in a future release. "

--- a/pettingzoo/mpe/simple_adversary_v3.py
+++ b/pettingzoo/mpe/simple_adversary_v3.py
@@ -1,3 +1,12 @@
-from pettingzoo.mpe.simple_adversary.simple_adversary import env, parallel_env, raw_env
+import warnings
+
+from pettingzoo.mpe.simple_crypto.simple_crypto import env, parallel_env, raw_env
+
+warnings.warn(
+    "The environment `pettingzoo.mpe.simple_adversary_v3` has been moved to `mpe2.simple_adversary_v3` and will be removed in a future release. "
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/mpe/simple_crypto/simple_crypto.py
+++ b/pettingzoo/mpe/simple_crypto/simple_crypto.py
@@ -7,6 +7,14 @@
 :name: simple_crypto
 ```
 
+```{eval-rst}
+.. warning::
+
+    The environment `pettingzoo.mpe.simple_crypto_v3` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your import to `mpe2.simple_crypto_v3`.
+
+```
+
 This environment is part of the <a href='..'>MPE environments</a>. Please read that page first for general information.
 
 | Import             | `from pettingzoo.mpe import simple_crypto_v3` |

--- a/pettingzoo/mpe/simple_crypto_v3.py
+++ b/pettingzoo/mpe/simple_crypto_v3.py
@@ -1,3 +1,13 @@
+import warnings
+
 from pettingzoo.mpe.simple_crypto.simple_crypto import env, parallel_env, raw_env
+
+warnings.warn(
+    "The environment `pettingzoo.mpe.simple_crypto_v3` has been moved to `mpe2.simple_crypto_v3` and will be removed in a future release. "
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/mpe/simple_push/simple_push.py
+++ b/pettingzoo/mpe/simple_push/simple_push.py
@@ -7,6 +7,14 @@
 :name: simple_push
 ```
 
+```{eval-rst}
+.. warning::
+
+    The environment `pettingzoo.mpe.simple_push_v3` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your import to `mpe2.simple_push_v3`.
+
+```
+
 This environment is part of the <a href='..'>MPE environments</a>. Please read that page first for general information.
 
 | Import             | `from pettingzoo.mpe import simple_push_v3` |

--- a/pettingzoo/mpe/simple_push_v3.py
+++ b/pettingzoo/mpe/simple_push_v3.py
@@ -1,3 +1,13 @@
+import warnings
+
 from pettingzoo.mpe.simple_push.simple_push import env, parallel_env, raw_env
+
+warnings.warn(
+    "The environment `pettingzoo.mpe.simple_push_v3` has been moved to `mpe2.simple_push_v3` and will be removed in a future release. "
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/mpe/simple_reference/simple_reference.py
+++ b/pettingzoo/mpe/simple_reference/simple_reference.py
@@ -7,6 +7,14 @@
 :name: simple_reference
 ```
 
+```{eval-rst}
+.. warning::
+
+    The environment `pettingzoo.mpe.simple_reference_v3` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your import to `mpe2.simple_reference_v3`.
+
+```
+
 This environment is part of the <a href='..'>MPE environments</a>. Please read that page first for general information.
 
 | Import             | `from pettingzoo.mpe import simple_reference_v3` |

--- a/pettingzoo/mpe/simple_reference_v3.py
+++ b/pettingzoo/mpe/simple_reference_v3.py
@@ -1,3 +1,13 @@
+import warnings
+
 from pettingzoo.mpe.simple_reference.simple_reference import env, parallel_env, raw_env
+
+warnings.warn(
+    "The environment `pettingzoo.mpe.simple_reference_v3` has been moved to `mpe2.simple_reference_v3` and will be removed in a future release. "
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
+++ b/pettingzoo/mpe/simple_speaker_listener/simple_speaker_listener.py
@@ -7,6 +7,14 @@
 :name: simple_speaker_listener
 ```
 
+```{eval-rst}
+.. warning::
+
+    The environment `pettingzoo.mpe.simple_speaker_listener_v4` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your import to `mpe2.simple_speaker_listener_v4`.
+
+```
+
 This environment is part of the <a href='..'>MPE environments</a>. Please read that page first for general information.
 
 | Import               | `from pettingzoo.mpe import simple_speaker_listener_v4` |

--- a/pettingzoo/mpe/simple_speaker_listener_v4.py
+++ b/pettingzoo/mpe/simple_speaker_listener_v4.py
@@ -1,7 +1,17 @@
+import warnings
+
 from pettingzoo.mpe.simple_speaker_listener.simple_speaker_listener import (
     env,
     parallel_env,
     raw_env,
 )
+
+warnings.warn(
+    "The environment `pettingzoo.mpe.speaker_listener_v4` has been moved to `mpe2.simple_speaker_listener_v4` and will be removed in a future release. "
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/mpe/simple_spread/simple_spread.py
+++ b/pettingzoo/mpe/simple_spread/simple_spread.py
@@ -7,6 +7,14 @@
 :name: simple_spread
 ```
 
+```{eval-rst}
+.. warning::
+
+    The environment `pettingzoo.mpe.simple_spread_v3` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your import to `mpe2.simple_spread_v3`.
+
+```
+
 This environment is part of the <a href='..'>MPE environments</a>. Please read that page first for general information.
 
 | Import               | `from pettingzoo.mpe import simple_spread_v3` |

--- a/pettingzoo/mpe/simple_spread_v3.py
+++ b/pettingzoo/mpe/simple_spread_v3.py
@@ -1,3 +1,13 @@
+import warnings
+
 from pettingzoo.mpe.simple_spread.simple_spread import env, parallel_env, raw_env
+
+warnings.warn(
+    "The environment `pettingzoo.mpe.simple_spread_v3` has been moved to `mpe2.simple_spread_v3` and will be removed in a future release. "
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/mpe/simple_tag/simple_tag.py
+++ b/pettingzoo/mpe/simple_tag/simple_tag.py
@@ -7,6 +7,14 @@
 :name: simple_tag
 ```
 
+```{eval-rst}
+.. warning::
+
+    The environment `pettingzoo.mpe.simple_tag_v3` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your import to `mpe2.simple_tag_v3`.
+
+```
+
 This environment is part of the <a href='..'>MPE environments</a>. Please read that page first for general information.
 
 | Import             | `from pettingzoo.mpe import simple_tag_v3`                 |

--- a/pettingzoo/mpe/simple_tag_v3.py
+++ b/pettingzoo/mpe/simple_tag_v3.py
@@ -1,3 +1,13 @@
+import warnings
+
 from pettingzoo.mpe.simple_tag.simple_tag import env, parallel_env, raw_env
+
+warnings.warn(
+    "The environment `pettingzoo.mpe.simple_tag_v3` has been moved to `mpe2.simple_tag_v3` and will be removed in a future release. "
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/mpe/simple_v3.py
+++ b/pettingzoo/mpe/simple_v3.py
@@ -1,3 +1,13 @@
+import warnings
+
 from pettingzoo.mpe.simple.simple import env, parallel_env, raw_env
+
+warnings.warn(
+    "The environment `pettingzoo.mpe.simple_v3` has been moved to `mpe2.simple_v3` and will be removed in a future release. "
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/mpe/simple_world_comm/simple_world_comm.py
+++ b/pettingzoo/mpe/simple_world_comm/simple_world_comm.py
@@ -7,6 +7,14 @@
 :name: simple_world_comm
 ```
 
+```{eval-rst}
+.. warning::
+
+    The environment `pettingzoo.mpe.simple_world_comm_v3` has been moved to the new `MPE2 package <https://mpe2.farama.org>`_, and will be removed from PettingZoo in a future release.
+    Please update your import to `mpe2.simple_world_comm_v3`.
+
+```
+
 This environment is part of the <a href='..'>MPE environments</a>. Please read that page first for general information.
 
 | Import             | `from pettingzoo.mpe import simple_world_comm_v3`                                   |

--- a/pettingzoo/mpe/simple_world_comm_v3.py
+++ b/pettingzoo/mpe/simple_world_comm_v3.py
@@ -1,7 +1,17 @@
+import warnings
+
 from pettingzoo.mpe.simple_world_comm.simple_world_comm import (
     env,
     parallel_env,
     raw_env,
 )
+
+warnings.warn(
+    "The environment `pettingzoo.mpe.simple_world_comm_v3` has been moved to `mpe2.simple_world_comm_v3` and will be removed in a future release. "
+    "Please update your imports.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 __all__ = ["env", "parallel_env", "raw_env"]


### PR DESCRIPTION
# Description
In a future version, the MPE environments will be removed from PettingZoo, and will have to be installed from [MPE2](https://mpe2.farama.org).

This PR aims at giving notice for this future change, without breaking codebase right away.

> [!NOTE]
> This is my first time implementing deprecation warnings, and need some feedback on good practice, as well as what unit testing (if any) to implement.

Closes #1265 

## Type of change


- Soon to be breaking change 
- This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes



