### PR TITLE
Remove duplicate code in RLCard environments

### DIFF
--- a/docs/_scripts/gen_envs_mds.py
+++ b/docs/_scripts/gen_envs_mds.py
@@ -54,6 +54,7 @@ if __name__ == "__main__":
                     not os.path.isdir(os.path.join(env_type_path, "rlcard_envs", i))
                     and i != "__init__.py"
                     and i != "rlcard_base.py"
+                    and i != "rlcard_utils.py"
                 ):
                     envs_list.append(os.path.join("rlcard_envs", i[:-3]))
             envs_list = sorted(envs_list)

--- a/pettingzoo/classic/rlcard_envs/gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/gin_rummy.py
@@ -122,23 +122,8 @@ from rlcard.games.gin_rummy.utils import utils
 from rlcard.games.gin_rummy.utils.action_event import GinAction, KnockAction
 
 from pettingzoo.classic.rlcard_envs.rlcard_base import RLCardBase
+from pettingzoo.classic.rlcard_envs.rlcard_utils import get_image, get_font
 from pettingzoo.utils import wrappers
-
-
-def get_image(path):
-    from os import path as os_path
-
-    cwd = os_path.dirname(__file__)
-    image = pygame.image.load(cwd + "/" + path)
-    return image
-
-
-def get_font(path, size):
-    from os import path as os_path
-
-    cwd = os_path.dirname(__file__)
-    font = pygame.font.Font((cwd + "/" + path), size)
-    return font
 
 
 def env(**kwargs):

--- a/pettingzoo/classic/rlcard_envs/gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/gin_rummy.py
@@ -211,12 +211,6 @@ class raw_env(RLCardBase, EzPickle):
 
         return {"observation": observation, "action_mask": action_mask}
 
-    def step(self, action):
-        super().step(action)
-
-        if self.render_mode == "human":
-            self.render()
-
     """
     To render:
     state: {'player_id', 'hand', 'top_discard'}

--- a/pettingzoo/classic/rlcard_envs/gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/gin_rummy.py
@@ -122,7 +122,13 @@ from rlcard.games.gin_rummy.utils import utils
 from rlcard.games.gin_rummy.utils.action_event import GinAction, KnockAction
 
 from pettingzoo.classic.rlcard_envs.rlcard_base import RLCardBase
-from pettingzoo.classic.rlcard_envs.rlcard_utils import get_image, get_font
+from pettingzoo.classic.rlcard_envs.rlcard_utils import (
+    calculate_height,
+    calculate_offset,
+    calculate_width,
+    get_font,
+    get_image,
+)
 from pettingzoo.utils import wrappers
 
 
@@ -223,24 +229,6 @@ class raw_env(RLCardBase, EzPickle):
             )
             return
 
-        def calculate_width(self, screen_width, i):
-            return int(
-                (
-                    screen_width
-                    / (np.ceil(len(self.possible_agents) / 2) + 1)
-                    * np.ceil((i + 1) / 2)
-                )
-                + (tile_size * 31 / 616)
-            )
-
-        def calculate_offset(hand, j, tile_size):
-            return int(
-                (len(hand) * (tile_size * 23 / 56)) - ((j) * (tile_size * 23 / 28))
-            )
-
-        def calculate_height(screen_height, divisor, multiplier, tile_size, offset):
-            return int(multiplier * screen_height / divisor + tile_size * offset)
-
         def draw_borders(x, y, width, height, bw, color):
             pygame.draw.line(
                 self.screen, color, (x - bw // 2 + 1, y), (x + width + bw // 2, y), bw
@@ -305,7 +293,13 @@ class raw_env(RLCardBase, EzPickle):
                         card_img,
                         (
                             (
-                                calculate_width(self, screen_width, i)
+                                calculate_width(
+                                    self.possible_agents,
+                                    screen_width,
+                                    i,
+                                    tile_size,
+                                    tile_scale=31,
+                                )
                                 - calculate_offset(state["hand"], j, tile_size)
                             ),
                             calculate_height(screen_height, 4, 1, tile_size, -1),
@@ -317,7 +311,13 @@ class raw_env(RLCardBase, EzPickle):
                         card_img,
                         (
                             (
-                                calculate_width(self, screen_width, i)
+                                calculate_width(
+                                    self.possible_agents,
+                                    screen_width,
+                                    i,
+                                    tile_size,
+                                    tile_scale=31,
+                                )
                                 - calculate_offset(state["hand"], j, tile_size)
                             ),
                             calculate_height(screen_height, 4, 3, tile_size, 0),
@@ -373,7 +373,11 @@ class raw_env(RLCardBase, EzPickle):
             text = font.render("Top Discarded Card", True, white)
             textRect = text.get_rect()
             textRect.center = (
-                (calculate_width(self, screen_width, 0)),
+                (
+                    calculate_width(
+                        self.possible_agents, screen_width, 0, tile_size, tile_scale=31
+                    )
+                ),
                 calculate_height(screen_height, 2, 1, tile_size, (-2 / 3))
                 + (tile_size * (13 / 200)),
             )

--- a/pettingzoo/classic/rlcard_envs/leduc_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/leduc_holdem.py
@@ -120,12 +120,6 @@ class raw_env(RLCardBase, EzPickle):
         if self.render_mode == "human":
             self.clock = pygame.time.Clock()
 
-    def step(self, action):
-        super().step(action)
-
-        if self.render_mode == "human":
-            self.render()
-
     def render(self):
         if self.render_mode is None:
             gymnasium.logger.warn(

--- a/pettingzoo/classic/rlcard_envs/leduc_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/leduc_holdem.py
@@ -82,7 +82,12 @@ import pygame
 from gymnasium.utils import EzPickle
 
 from pettingzoo.classic.rlcard_envs.rlcard_base import RLCardBase
-from pettingzoo.classic.rlcard_envs.rlcard_utils import get_image, get_font
+from pettingzoo.classic.rlcard_envs.rlcard_utils import (
+    calculate_height,
+    calculate_width,
+    get_font,
+    get_image,
+)
 from pettingzoo.utils import wrappers
 
 
@@ -128,21 +133,8 @@ class raw_env(RLCardBase, EzPickle):
             )
             return
 
-        def calculate_width(self, screen_width, i):
-            return int(
-                (
-                    screen_width
-                    / (np.ceil(len(self.possible_agents) / 2) + 1)
-                    * np.ceil((i + 1) / 2)
-                )
-                + (tile_size * 31 / 616)
-            )
-
         def calculate_offset(tile_size):
-            return int(tile_size * 23 / 28)  # - ((j) * (tile_size * 23 / 28))
-
-        def calculate_height(screen_height, divisor, multiplier, tile_size, offset):
-            return int(multiplier * screen_height / divisor + tile_size * offset)
+            return int(tile_size * 23 / 28)
 
         screen_height = self.screen_height
         screen_width = int(
@@ -194,7 +186,13 @@ class raw_env(RLCardBase, EzPickle):
                     card_img,
                     (
                         (
-                            calculate_width(self, screen_width, i)
+                            calculate_width(
+                                self.possible_agents,
+                                screen_width,
+                                i,
+                                tile_size,
+                                tile_scale=31,
+                            )
                             - calculate_offset(tile_size)
                         ),
                         calculate_height(screen_height, 4, 1, tile_size, -1),
@@ -206,7 +204,13 @@ class raw_env(RLCardBase, EzPickle):
                     card_img,
                     (
                         (
-                            calculate_width(self, screen_width, i)
+                            calculate_width(
+                                self.possible_agents,
+                                screen_width,
+                                i,
+                                tile_size,
+                                tile_scale=31,
+                            )
                             - calculate_offset(tile_size)
                         ),
                         calculate_height(screen_height, 4, 3, tile_size, 0),
@@ -264,7 +268,13 @@ class raw_env(RLCardBase, EzPickle):
                             chip_img,
                             (
                                 (
-                                    calculate_width(self, screen_width, i)
+                                    calculate_width(
+                                        self.possible_agents,
+                                        screen_width,
+                                        i,
+                                        tile_size,
+                                        tile_scale=31,
+                                    )
                                     + tile_size * (2 / 10)
                                 ),
                                 calculate_height(screen_height, 4, 1, tile_size, -1 / 2)
@@ -276,7 +286,13 @@ class raw_env(RLCardBase, EzPickle):
                             chip_img,
                             (
                                 (
-                                    calculate_width(self, screen_width, i)
+                                    calculate_width(
+                                        self.possible_agents,
+                                        screen_width,
+                                        i,
+                                        tile_size,
+                                        tile_scale=31,
+                                    )
                                     + tile_size * (2 / 10)
                                 ),
                                 calculate_height(screen_height, 4, 3, tile_size, 1 / 2)
@@ -288,13 +304,31 @@ class raw_env(RLCardBase, EzPickle):
             # Blit text number
             if i % 2 == 0:
                 textRect.center = (
-                    (calculate_width(self, screen_width, i) + tile_size * (9 / 20)),
+                    (
+                        calculate_width(
+                            self.possible_agents,
+                            screen_width,
+                            i,
+                            tile_size,
+                            tile_scale=31,
+                        )
+                        + tile_size * (9 / 20)
+                    ),
                     calculate_height(screen_height, 4, 1, tile_size, -1 / 2)
                     - ((height + 1) * tile_size / 15),
                 )
             else:
                 textRect.center = (
-                    (calculate_width(self, screen_width, i) + tile_size * (9 / 20)),
+                    (
+                        calculate_width(
+                            self.possible_agents,
+                            screen_width,
+                            i,
+                            tile_size,
+                            tile_scale=31,
+                        )
+                        + tile_size * (9 / 20)
+                    ),
                     calculate_height(screen_height, 4, 3, tile_size, 1 / 2)
                     - ((height + 1) * tile_size / 15),
                 )

--- a/pettingzoo/classic/rlcard_envs/leduc_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/leduc_holdem.py
@@ -82,23 +82,8 @@ import pygame
 from gymnasium.utils import EzPickle
 
 from pettingzoo.classic.rlcard_envs.rlcard_base import RLCardBase
+from pettingzoo.classic.rlcard_envs.rlcard_utils import get_image, get_font
 from pettingzoo.utils import wrappers
-
-
-def get_image(path):
-    from os import path as os_path
-
-    cwd = os_path.dirname(__file__)
-    image = pygame.image.load(cwd + "/" + path)
-    return image
-
-
-def get_font(path, size):
-    from os import path as os_path
-
-    cwd = os_path.dirname(__file__)
-    font = pygame.font.Font((cwd + "/" + path), size)
-    return font
 
 
 def env(**kwargs):

--- a/pettingzoo/classic/rlcard_envs/rlcard_base.py
+++ b/pettingzoo/classic/rlcard_envs/rlcard_base.py
@@ -113,6 +113,9 @@ class RLCardBase(AECEnv):
         self._accumulate_rewards()
         self._deads_step_first()
 
+        if self.render_mode == "human":
+            self.render()
+
     def reset(self, seed=None, options=None):
         if seed is not None:
             self._seed(seed=seed)

--- a/pettingzoo/classic/rlcard_envs/rlcard_utils.py
+++ b/pettingzoo/classic/rlcard_envs/rlcard_utils.py
@@ -1,7 +1,9 @@
 """Contains utility functions used by several rlcard envs."""
 
 import os
+from typing import Any
 
+import numpy as np
 import pygame
 
 
@@ -24,3 +26,33 @@ def get_font(path: str, size: int) -> pygame.font.Font:
     full_path = _get_full_path(path)
     font = pygame.font.Font(full_path, size)
     return font
+
+
+def calculate_width(
+    possible_agents_list: list[Any],
+    screen_width: int,
+    i: int,
+    tile_size: int,
+    tile_scale: int = 31,
+) -> int:
+    """Calculate the width to use in rendering."""
+    return int(
+        (
+            screen_width
+            / (np.ceil(len(possible_agents_list) / 2) + 1)
+            * np.ceil((i + 1) / 2)
+        )
+        + (tile_size * tile_scale / 616)
+    )
+
+
+def calculate_offset(hand: list[Any], j: int, tile_size: int) -> int:
+    """Calculate the offset to use in rendering."""
+    return int((len(hand) * (tile_size * 23 / 56)) - ((j) * (tile_size * 23 / 28)))
+
+
+def calculate_height(
+    screen_height: int, divisor: int, multiplier: int, tile_size: int, offset: float
+) -> int:
+    """Calculate the height to use in rendering."""
+    return int(multiplier * screen_height / divisor + tile_size * offset)

--- a/pettingzoo/classic/rlcard_envs/rlcard_utils.py
+++ b/pettingzoo/classic/rlcard_envs/rlcard_utils.py
@@ -1,0 +1,26 @@
+"""Contains utility functions used by several rlcard envs."""
+
+import os
+
+import pygame
+
+
+def _get_full_path(path: str) -> str:
+    """Return the path as the given path in this file's directory."""
+    cwd = os.path.dirname(__file__)
+    full_path = os.path.join(cwd, path)
+    return full_path
+
+
+def get_image(path: str) -> pygame.Surface:
+    """Return an image from the given path."""
+    full_path = _get_full_path(path)
+    image = pygame.image.load(full_path)
+    return image
+
+
+def get_font(path: str, size: int) -> pygame.font.Font:
+    """Return a font from the given path."""
+    full_path = _get_full_path(path)
+    font = pygame.font.Font(full_path, size)
+    return font

--- a/pettingzoo/classic/rlcard_envs/texas_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem.py
@@ -114,6 +114,9 @@ class raw_env(RLCardBase, EzPickle):
         "render_fps": 1,
     }
 
+    game_name = "limit-holdem"
+    obs_shape = (72,)
+
     def __init__(
         self,
         num_players: int = 2,
@@ -121,9 +124,10 @@ class raw_env(RLCardBase, EzPickle):
         screen_height: int | None = 1000,
     ):
         EzPickle.__init__(self, num_players, render_mode, screen_height)
-        super().__init__("limit-holdem", num_players, (72,))
+        super().__init__(self.game_name, num_players, self.obs_shape)
         self.render_mode = render_mode
         self.screen_height = screen_height
+        self.caption = "Texas Hold'em"
 
         if self.render_mode == "human":
             self.clock = pygame.time.Clock()
@@ -146,7 +150,7 @@ class raw_env(RLCardBase, EzPickle):
 
             if self.render_mode == "human":
                 self.screen = pygame.display.set_mode((screen_width, screen_height))
-                pygame.display.set_caption("Texas Hold'em")
+                pygame.display.set_caption(self.caption)
             else:
                 self.screen = pygame.Surface((screen_width, screen_height))
 

--- a/pettingzoo/classic/rlcard_envs/texas_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem.py
@@ -86,25 +86,10 @@ import pygame
 from gymnasium.utils import EzPickle
 
 from pettingzoo.classic.rlcard_envs.rlcard_base import RLCardBase
+from pettingzoo.classic.rlcard_envs.rlcard_utils import get_image, get_font
 from pettingzoo.utils import wrappers
 
 # Pixel art from Mariia Khmelnytska (https://www.123rf.com/photo_104453049_stock-vector-pixel-art-playing-cards-standart-deck-vector-set.html)
-
-
-def get_image(path):
-    from os import path as os_path
-
-    cwd = os_path.dirname(__file__)
-    image = pygame.image.load(cwd + "/" + path)
-    return image
-
-
-def get_font(path, size):
-    from os import path as os_path
-
-    cwd = os_path.dirname(__file__)
-    font = pygame.font.Font((cwd + "/" + path), size)
-    return font
 
 
 def env(**kwargs):

--- a/pettingzoo/classic/rlcard_envs/texas_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem.py
@@ -86,7 +86,13 @@ import pygame
 from gymnasium.utils import EzPickle
 
 from pettingzoo.classic.rlcard_envs.rlcard_base import RLCardBase
-from pettingzoo.classic.rlcard_envs.rlcard_utils import get_image, get_font
+from pettingzoo.classic.rlcard_envs.rlcard_utils import (
+    calculate_height,
+    calculate_offset,
+    calculate_width,
+    get_font,
+    get_image,
+)
 from pettingzoo.utils import wrappers
 
 # Pixel art from Mariia Khmelnytska (https://www.123rf.com/photo_104453049_stock-vector-pixel-art-playing-cards-standart-deck-vector-set.html)
@@ -134,24 +140,6 @@ class raw_env(RLCardBase, EzPickle):
                 "You are calling render method without specifying any render mode."
             )
             return
-
-        def calculate_width(self, screen_width, i):
-            return int(
-                (
-                    screen_width
-                    / (np.ceil(len(self.possible_agents) / 2) + 1)
-                    * np.ceil((i + 1) / 2)
-                )
-                + (tile_size * 33 / 616)
-            )
-
-        def calculate_offset(hand, j, tile_size):
-            return int(
-                (len(hand) * (tile_size * 23 / 56)) - ((j) * (tile_size * 23 / 28))
-            )
-
-        def calculate_height(screen_height, divisor, multiplier, tile_size, offset):
-            return int(multiplier * screen_height / divisor + tile_size * offset)
 
         screen_height = self.screen_height
         screen_width = int(
@@ -202,7 +190,13 @@ class raw_env(RLCardBase, EzPickle):
                         card_img,
                         (
                             (
-                                calculate_width(self, screen_width, i)
+                                calculate_width(
+                                    self.possible_agents,
+                                    screen_width,
+                                    i,
+                                    tile_size,
+                                    tile_scale=33,
+                                )
                                 - calculate_offset(state["hand"], j, tile_size)
                                 - tile_size
                                 * (8 / 10)
@@ -218,7 +212,13 @@ class raw_env(RLCardBase, EzPickle):
                         card_img,
                         (
                             (
-                                calculate_width(self, screen_width, i)
+                                calculate_width(
+                                    self.possible_agents,
+                                    screen_width,
+                                    i,
+                                    tile_size,
+                                    tile_scale=33,
+                                )
                                 - calculate_offset(state["hand"], j, tile_size)
                                 - tile_size
                                 * (8 / 10)
@@ -286,7 +286,13 @@ class raw_env(RLCardBase, EzPickle):
                             chip_img,
                             (
                                 (
-                                    calculate_width(self, screen_width, i)
+                                    calculate_width(
+                                        self.possible_agents,
+                                        screen_width,
+                                        i,
+                                        tile_size,
+                                        tile_scale=33,
+                                    )
                                     + tile_size
                                     * (8 / 10)
                                     * (
@@ -304,7 +310,13 @@ class raw_env(RLCardBase, EzPickle):
                             chip_img,
                             (
                                 (
-                                    calculate_width(self, screen_width, i)
+                                    calculate_width(
+                                        self.possible_agents,
+                                        screen_width,
+                                        i,
+                                        tile_size,
+                                        tile_scale=33,
+                                    )
                                     + tile_size
                                     * (8 / 10)
                                     * (
@@ -323,7 +335,13 @@ class raw_env(RLCardBase, EzPickle):
             if i % 2 == 0:
                 textRect.center = (
                     (
-                        calculate_width(self, screen_width, i)
+                        calculate_width(
+                            self.possible_agents,
+                            screen_width,
+                            i,
+                            tile_size,
+                            tile_scale=33,
+                        )
                         + (tile_size * (5 / 20))
                         + tile_size
                         * (8 / 10)
@@ -335,7 +353,13 @@ class raw_env(RLCardBase, EzPickle):
             else:
                 textRect.center = (
                     (
-                        calculate_width(self, screen_width, i)
+                        calculate_width(
+                            self.possible_agents,
+                            screen_width,
+                            i,
+                            tile_size,
+                            tile_scale=33,
+                        )
                         + (tile_size * (5 / 20))
                         + tile_size
                         * (8 / 10)

--- a/pettingzoo/classic/rlcard_envs/texas_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem.py
@@ -128,12 +128,6 @@ class raw_env(RLCardBase, EzPickle):
         if self.render_mode == "human":
             self.clock = pygame.time.Clock()
 
-    def step(self, action):
-        super().step(action)
-
-        if self.render_mode == "human":
-            self.render()
-
     def render(self):
         if self.render_mode is None:
             gymnasium.logger.warn(

--- a/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
@@ -90,22 +90,11 @@ whose turn it is. Taking an illegal move ends the game with a reward of -1 for t
 """
 from __future__ import annotations
 
-import os
-
-import gymnasium
 import numpy as np
-import pygame
 from gymnasium import spaces
 from gymnasium.utils import EzPickle
 
-from pettingzoo.classic.rlcard_envs.rlcard_base import RLCardBase
-from pettingzoo.classic.rlcard_envs.rlcard_utils import (
-    calculate_height,
-    calculate_offset,
-    calculate_width,
-    get_font,
-    get_image,
-)
+from pettingzoo.classic.rlcard_envs.texas_holdem import raw_env as TexasHoldem
 from pettingzoo.utils import wrappers
 
 # Pixel art from Mariia Khmelnytska (https://www.123rf.com/photo_104453049_stock-vector-pixel-art-playing-cards-standart-deck-vector-set.html)
@@ -119,13 +108,16 @@ def env(**kwargs):
     return env
 
 
-class raw_env(RLCardBase, EzPickle):
+class raw_env(TexasHoldem, EzPickle):
     metadata = {
         "render_modes": ["human", "rgb_array"],
         "name": "texas_holdem_no_limit_v6",
         "is_parallelizable": False,
         "render_fps": 1,
     }
+
+    game_name = "no-limit-holdem"
+    obs_shape = (54,)
 
     def __init__(
         self,
@@ -134,7 +126,7 @@ class raw_env(RLCardBase, EzPickle):
         screen_height: int | None = 1000,
     ):
         EzPickle.__init__(self, num_players, render_mode, screen_height)
-        super().__init__("no-limit-holdem", num_players, (54,))
+        super().__init__(num_players, render_mode, screen_height)
         self.observation_spaces = self._convert_to_dict(
             [
                 spaces.Dict(
@@ -160,315 +152,4 @@ class raw_env(RLCardBase, EzPickle):
             ]
         )
 
-        self.render_mode = render_mode
-        self.screen_height = screen_height
-
-        if self.render_mode == "human":
-            self.clock = pygame.time.Clock()
-
-    def render(self):
-        if self.render_mode is None:
-            gymnasium.logger.warn(
-                "You are calling render method without specifying any render mode."
-            )
-            return
-
-        screen_height = self.screen_height
-        screen_width = int(
-            screen_height * (1 / 20)
-            + np.ceil(len(self.possible_agents) / 2) * (screen_height * 12 / 20)
-        )
-
-        if self.screen is None:
-            pygame.init()
-
-            if self.render_mode == "human":
-                self.screen = pygame.display.set_mode((screen_width, screen_height))
-                pygame.display.set_caption("Texas Hold'em No Limit")
-            else:
-                self.screen = pygame.Surface((screen_width, screen_height))
-
-        # Setup dimensions for card size and setup for colors
-        tile_size = screen_height * 2 / 10
-
-        bg_color = (7, 99, 36)
-        white = (255, 255, 255)
-        self.screen.fill(bg_color)
-
-        chips = {
-            0: {"value": 10000, "img": "ChipOrange.png", "number": 0},
-            1: {"value": 5000, "img": "ChipPink.png", "number": 0},
-            2: {"value": 1000, "img": "ChipYellow.png", "number": 0},
-            3: {"value": 100, "img": "ChipBlack.png", "number": 0},
-            4: {"value": 50, "img": "ChipBlue.png", "number": 0},
-            5: {"value": 25, "img": "ChipGreen.png", "number": 0},
-            6: {"value": 10, "img": "ChipLightBlue.png", "number": 0},
-            7: {"value": 5, "img": "ChipRed.png", "number": 0},
-            8: {"value": 1, "img": "ChipWhite.png", "number": 0},
-        }
-
-        # Load and blit all images for each card in each player's hand
-        for i, player in enumerate(self.possible_agents):
-            state = self.env.game.get_state(self._name_to_int(player))
-            for j, card in enumerate(state["hand"]):
-                # Load specified card
-                card_img = get_image(os.path.join("img", card + ".png"))
-                card_img = pygame.transform.scale(
-                    card_img, (int(tile_size * (142 / 197)), int(tile_size))
-                )
-                # Players with even id go above public cards
-                if i % 2 == 0:
-                    self.screen.blit(
-                        card_img,
-                        (
-                            (
-                                calculate_width(
-                                    self.possible_agents,
-                                    screen_width,
-                                    i,
-                                    tile_size,
-                                    tile_scale=33,
-                                )
-                                - calculate_offset(state["hand"], j, tile_size)
-                                - tile_size
-                                * (8 / 10)
-                                * (1 - np.ceil(i / 2))
-                                * (0 if len(self.possible_agents) == 2 else 1)
-                            ),
-                            calculate_height(screen_height, 4, 1, tile_size, -1),
-                        ),
-                    )
-                # Players with odd id go below public cards
-                else:
-                    self.screen.blit(
-                        card_img,
-                        (
-                            (
-                                calculate_width(
-                                    self.possible_agents,
-                                    screen_width,
-                                    i,
-                                    tile_size,
-                                    tile_scale=33,
-                                )
-                                - calculate_offset(state["hand"], j, tile_size)
-                                - tile_size
-                                * (8 / 10)
-                                * (1 - np.ceil((i - 1) / 2))
-                                * (0 if len(self.possible_agents) == 2 else 1)
-                            ),
-                            calculate_height(screen_height, 4, 3, tile_size, 0),
-                        ),
-                    )
-
-            # Load and blit text for player name
-            font = get_font(os.path.join("font", "Minecraft.ttf"), 36)
-            text = font.render("Player " + str(i + 1), True, white)
-            textRect = text.get_rect()
-            if i % 2 == 0:
-                textRect.center = (
-                    (
-                        screen_width
-                        / (np.ceil(len(self.possible_agents) / 2) + 1)
-                        * np.ceil((i + 1) / 2)
-                        - tile_size
-                        * (8 / 10)
-                        * (1 - np.ceil(i / 2))
-                        * (0 if len(self.possible_agents) == 2 else 1)
-                    ),
-                    calculate_height(screen_height, 4, 1, tile_size, -(22 / 20)),
-                )
-            else:
-                textRect.center = (
-                    (
-                        screen_width
-                        / (np.ceil(len(self.possible_agents) / 2) + 1)
-                        * np.ceil((i + 1) / 2)
-                        - tile_size
-                        * (8 / 10)
-                        * (1 - np.ceil((i - 1) / 2))
-                        * (0 if len(self.possible_agents) == 2 else 1)
-                    ),
-                    calculate_height(screen_height, 4, 3, tile_size, (23 / 20)),
-                )
-            self.screen.blit(text, textRect)
-
-            # Load and blit number of poker chips for each player
-            font = get_font(os.path.join("font", "Minecraft.ttf"), 24)
-            text = font.render(str(state["my_chips"]), True, white)
-            textRect = text.get_rect()
-
-            # Calculate number of each chip
-            total = state["my_chips"]
-            height = 0
-            for key in chips:
-                num = total / chips[key]["value"]
-                chips[key]["number"] = int(num)
-                total %= chips[key]["value"]
-
-                chip_img = get_image(os.path.join("img", chips[key]["img"]))
-                chip_img = pygame.transform.scale(
-                    chip_img, (int(tile_size / 2), int(tile_size * 16 / 45))
-                )
-
-                # Blit poker chip img
-                for j in range(0, int(chips[key]["number"])):
-                    if i % 2 == 0:
-                        self.screen.blit(
-                            chip_img,
-                            (
-                                (
-                                    calculate_width(
-                                        self.possible_agents,
-                                        screen_width,
-                                        i,
-                                        tile_size,
-                                        tile_scale=33,
-                                    )
-                                    + tile_size
-                                    * (8 / 10)
-                                    * (
-                                        1
-                                        if len(self.possible_agents) == 2
-                                        else np.ceil(i / 2)
-                                    )
-                                ),
-                                calculate_height(screen_height, 4, 1, tile_size, -1 / 2)
-                                - ((j + height) * tile_size / 15),
-                            ),
-                        )
-                    else:
-                        self.screen.blit(
-                            chip_img,
-                            (
-                                (
-                                    calculate_width(
-                                        self.possible_agents,
-                                        screen_width,
-                                        i,
-                                        tile_size,
-                                        tile_scale=33,
-                                    )
-                                    + tile_size
-                                    * (8 / 10)
-                                    * (
-                                        1
-                                        if len(self.possible_agents) == 2
-                                        else np.ceil((i - 1) / 2)
-                                    )
-                                ),
-                                calculate_height(screen_height, 4, 3, tile_size, 1 / 2)
-                                - ((j + height) * tile_size / 15),
-                            ),
-                        )
-                height += chips[key]["number"]
-
-            # Blit text number
-            if i % 2 == 0:
-                textRect.center = (
-                    (
-                        calculate_width(
-                            self.possible_agents,
-                            screen_width,
-                            i,
-                            tile_size,
-                            tile_scale=33,
-                        )
-                        + (tile_size * (5 / 20))
-                        + tile_size
-                        * (8 / 10)
-                        * (1 if len(self.possible_agents) == 2 else np.ceil(i / 2))
-                    ),
-                    calculate_height(screen_height, 4, 1, tile_size, -1 / 2)
-                    - ((height + 1) * tile_size / 15),
-                )
-            else:
-                textRect.center = (
-                    (
-                        calculate_width(
-                            self.possible_agents,
-                            screen_width,
-                            i,
-                            tile_size,
-                            tile_scale=33,
-                        )
-                        + (tile_size * (5 / 20))
-                        + tile_size
-                        * (8 / 10)
-                        * (
-                            1
-                            if len(self.possible_agents) == 2
-                            else np.ceil((i - 1) / 2)
-                        )
-                    ),
-                    calculate_height(screen_height, 4, 3, tile_size, 1 / 2)
-                    - ((height + 1) * tile_size / 15),
-                )
-            self.screen.blit(text, textRect)
-
-        # Load and blit public cards
-        for i, card in enumerate(state["public_cards"]):
-            card_img = get_image(os.path.join("img", card + ".png"))
-            card_img = pygame.transform.scale(
-                card_img, (int(tile_size * (142 / 197)), int(tile_size))
-            )
-            if len(state["public_cards"]) <= 3:
-                self.screen.blit(
-                    card_img,
-                    (
-                        (
-                            (
-                                ((screen_width / 2) + (tile_size * 31 / 616))
-                                - calculate_offset(state["public_cards"], i, tile_size)
-                            ),
-                            calculate_height(screen_height, 2, 1, tile_size, -(1 / 2)),
-                        )
-                    ),
-                )
-            else:
-                if i <= 2:
-                    self.screen.blit(
-                        card_img,
-                        (
-                            (
-                                (
-                                    ((screen_width / 2) + (tile_size * 31 / 616))
-                                    - calculate_offset(
-                                        state["public_cards"][:3], i, tile_size
-                                    )
-                                ),
-                                calculate_height(
-                                    screen_height, 2, 1, tile_size, -21 / 20
-                                ),
-                            )
-                        ),
-                    )
-                else:
-                    self.screen.blit(
-                        card_img,
-                        (
-                            (
-                                (
-                                    ((screen_width / 2) + (tile_size * 31 / 616))
-                                    - calculate_offset(
-                                        state["public_cards"][3:], i - 3, tile_size
-                                    )
-                                ),
-                                calculate_height(
-                                    screen_height, 2, 1, tile_size, 1 / 20
-                                ),
-                            )
-                        ),
-                    )
-
-        if self.render_mode == "human":
-            pygame.display.update()
-            self.clock.tick(self.metadata["render_fps"])
-
-        observation = np.array(pygame.surfarray.pixels3d(self.screen))
-
-        return (
-            np.transpose(observation, axes=(1, 0, 2))
-            if self.render_mode == "rgb_array"
-            else None
-        )
+        self.caption = "Texas Hold'em No Limit"

--- a/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
@@ -99,7 +99,13 @@ from gymnasium import spaces
 from gymnasium.utils import EzPickle
 
 from pettingzoo.classic.rlcard_envs.rlcard_base import RLCardBase
-from pettingzoo.classic.rlcard_envs.rlcard_utils import get_image, get_font
+from pettingzoo.classic.rlcard_envs.rlcard_utils import (
+    calculate_height,
+    calculate_offset,
+    calculate_width,
+    get_font,
+    get_image,
+)
 from pettingzoo.utils import wrappers
 
 # Pixel art from Mariia Khmelnytska (https://www.123rf.com/photo_104453049_stock-vector-pixel-art-playing-cards-standart-deck-vector-set.html)
@@ -173,24 +179,6 @@ class raw_env(RLCardBase, EzPickle):
             )
             return
 
-        def calculate_width(self, screen_width, i):
-            return int(
-                (
-                    screen_width
-                    / (np.ceil(len(self.possible_agents) / 2) + 1)
-                    * np.ceil((i + 1) / 2)
-                )
-                + (tile_size * 33 / 616)
-            )
-
-        def calculate_offset(hand, j, tile_size):
-            return int(
-                (len(hand) * (tile_size * 23 / 56)) - ((j) * (tile_size * 23 / 28))
-            )
-
-        def calculate_height(screen_height, divisor, multiplier, tile_size, offset):
-            return int(multiplier * screen_height / divisor + tile_size * offset)
-
         screen_height = self.screen_height
         screen_width = int(
             screen_height * (1 / 20)
@@ -240,7 +228,13 @@ class raw_env(RLCardBase, EzPickle):
                         card_img,
                         (
                             (
-                                calculate_width(self, screen_width, i)
+                                calculate_width(
+                                    self.possible_agents,
+                                    screen_width,
+                                    i,
+                                    tile_size,
+                                    tile_scale=33,
+                                )
                                 - calculate_offset(state["hand"], j, tile_size)
                                 - tile_size
                                 * (8 / 10)
@@ -256,7 +250,13 @@ class raw_env(RLCardBase, EzPickle):
                         card_img,
                         (
                             (
-                                calculate_width(self, screen_width, i)
+                                calculate_width(
+                                    self.possible_agents,
+                                    screen_width,
+                                    i,
+                                    tile_size,
+                                    tile_scale=33,
+                                )
                                 - calculate_offset(state["hand"], j, tile_size)
                                 - tile_size
                                 * (8 / 10)
@@ -324,7 +324,13 @@ class raw_env(RLCardBase, EzPickle):
                             chip_img,
                             (
                                 (
-                                    calculate_width(self, screen_width, i)
+                                    calculate_width(
+                                        self.possible_agents,
+                                        screen_width,
+                                        i,
+                                        tile_size,
+                                        tile_scale=33,
+                                    )
                                     + tile_size
                                     * (8 / 10)
                                     * (
@@ -342,7 +348,13 @@ class raw_env(RLCardBase, EzPickle):
                             chip_img,
                             (
                                 (
-                                    calculate_width(self, screen_width, i)
+                                    calculate_width(
+                                        self.possible_agents,
+                                        screen_width,
+                                        i,
+                                        tile_size,
+                                        tile_scale=33,
+                                    )
                                     + tile_size
                                     * (8 / 10)
                                     * (
@@ -361,7 +373,13 @@ class raw_env(RLCardBase, EzPickle):
             if i % 2 == 0:
                 textRect.center = (
                     (
-                        calculate_width(self, screen_width, i)
+                        calculate_width(
+                            self.possible_agents,
+                            screen_width,
+                            i,
+                            tile_size,
+                            tile_scale=33,
+                        )
                         + (tile_size * (5 / 20))
                         + tile_size
                         * (8 / 10)
@@ -373,7 +391,13 @@ class raw_env(RLCardBase, EzPickle):
             else:
                 textRect.center = (
                     (
-                        calculate_width(self, screen_width, i)
+                        calculate_width(
+                            self.possible_agents,
+                            screen_width,
+                            i,
+                            tile_size,
+                            tile_scale=33,
+                        )
                         + (tile_size * (5 / 20))
                         + tile_size
                         * (8 / 10)

--- a/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
@@ -166,12 +166,6 @@ class raw_env(RLCardBase, EzPickle):
         if self.render_mode == "human":
             self.clock = pygame.time.Clock()
 
-    def step(self, action):
-        super().step(action)
-
-        if self.render_mode == "human":
-            self.render()
-
     def render(self):
         if self.render_mode is None:
             gymnasium.logger.warn(

--- a/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem_no_limit.py
@@ -99,25 +99,10 @@ from gymnasium import spaces
 from gymnasium.utils import EzPickle
 
 from pettingzoo.classic.rlcard_envs.rlcard_base import RLCardBase
+from pettingzoo.classic.rlcard_envs.rlcard_utils import get_image, get_font
 from pettingzoo.utils import wrappers
 
 # Pixel art from Mariia Khmelnytska (https://www.123rf.com/photo_104453049_stock-vector-pixel-art-playing-cards-standart-deck-vector-set.html)
-
-
-def get_image(path):
-    from os import path as os_path
-
-    cwd = os_path.dirname(__file__)
-    image = pygame.image.load(cwd + "/" + path)
-    return image
-
-
-def get_font(path, size):
-    from os import path as os_path
-
-    cwd = os_path.dirname(__file__)
-    font = pygame.font.Font((cwd + "/" + path), size)
-    return font
 
 
 def env(**kwargs):


### PR DESCRIPTION
# Description

The RLCard envs had duplicate functions - step, get_image, get_font, calculate_height, calculate_width, calculate_offset. These were repeated in most/all files and identical. They are now in a utils file and imported as needed.
Additionally, TexaHold'em and no limit TexasHold'em were nearly identical code. One now is a child class of the other to remove duplicate code. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
