### PR TITLE
Ignore pygame deprecation warnings during testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,3 +106,7 @@ reportMissingImports = false
 
 [tool.pytest.ini_options]
 addopts = [ "--ignore-glob=*/__init__.py", "-n=auto", "--ignore=tutorials", "--ignore=docs/_scripts", "--ignore=conf.py"]
+filterwarnings = [
+    "ignore::DeprecationWarning:pygame.*",
+    "ignore::DeprecationWarning:pkg_resources.*"
+]


### PR DESCRIPTION
# Description

pygame is using a deprecated packaging api. Since it has been raising warnings for years, it seems unlikely that the pygame devs are interested in fixing that any time soon. This change ignores those warnings during testing. If pygame devs ever see the light and correct this, these filters should be removed.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
