### PR TITLE
Add type hinting to Atari envs

### DIFF
--- a/pettingzoo/atari/__init__.py
+++ b/pettingzoo/atari/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from types import ModuleType
 
 from pettingzoo.utils.deprecated_module import DeprecatedModule, deprecated_handler

--- a/pettingzoo/atari/__init__.py
+++ b/pettingzoo/atari/__init__.py
@@ -1,5 +1,7 @@
-from pettingzoo.utils.deprecated_module import deprecated_handler
+from types import ModuleType
+
+from pettingzoo.utils.deprecated_module import DeprecatedModule, deprecated_handler
 
 
-def __getattr__(env_name):
+def __getattr__(env_name: str) -> DeprecatedModule | ModuleType:
     return deprecated_handler(env_name, __path__, __name__)

--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, NewType, TypeAlias, cast

--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, NewType, TypeAlias, cast
+from typing import Any, NewType, cast
 
 import gymnasium
 import multi_agent_ale_py  # type: ignore[import-untyped]
@@ -28,8 +28,8 @@ __all__ = [
 AgentID = NewType("AgentID", str)
 ObsType = NewType("ObsType", npt.NDArray[np.integer])
 ActionType = NewType("ActionType", int)
-AtariAECEnv: TypeAlias = AECEnv[AgentID, ObsType, ActionType]
-StateType: TypeAlias = npt.NDArray[np.int8]
+AtariAECEnv = AECEnv[AgentID, ObsType, ActionType]
+StateType = npt.NDArray[np.int8]
 
 
 def base_env_wrapper_fn(

--- a/pettingzoo/atari/basketball_pong/basketball_pong.py
+++ b/pettingzoo/atari/basketball_pong/basketball_pong.py
@@ -67,15 +67,17 @@ In any given turn, an agent can choose from one of 6 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(num_players=2, **kwargs):
+def raw_env(num_players: int = 2, **kwargs: Any) -> AtariAECEnv:
     assert num_players == 2 or num_players == 4, "pong only supports 2 or 4 players"
     mode_mapping = {2: 45, 4: 49}
     mode = mode_mapping[num_players]

--- a/pettingzoo/atari/boxing/boxing.py
+++ b/pettingzoo/atari/boxing/boxing.py
@@ -77,15 +77,17 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/combat_plane/combat_plane.py
+++ b/pettingzoo/atari/combat_plane/combat_plane.py
@@ -87,8 +87,10 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
@@ -100,7 +102,9 @@ avaliable_versions = {
 }
 
 
-def raw_env(game_version="bi-plane", guided_missile=True, **kwargs):
+def raw_env(
+    game_version: str = "bi-plane", guided_missile: bool = True, **kwargs: Any
+) -> AtariAECEnv:
     assert (
         game_version in avaliable_versions
     ), "game_version must be either 'jet' or 'bi-plane'"

--- a/pettingzoo/atari/combat_tank/combat_tank.py
+++ b/pettingzoo/atari/combat_tank/combat_tank.py
@@ -85,15 +85,22 @@ In any given turn, an agent can choose from one of 18 actions.
 import os
 import warnings
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(has_maze=True, is_invisible=False, billiard_hit=True, **kwargs):
+def raw_env(
+    has_maze: bool = True,
+    is_invisible: bool = False,
+    billiard_hit: bool = True,
+    **kwargs: Any,
+) -> AtariAECEnv:
     if has_maze is False and is_invisible is False and billiard_hit is False:
         warnings.warn(
             "combat_tank has interesting parameters to consider overriding including is_invisible, billiard_hit and has_maze"

--- a/pettingzoo/atari/double_dunk/double_dunk.py
+++ b/pettingzoo/atari/double_dunk/double_dunk.py
@@ -77,15 +77,17 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/entombed_competitive/entombed_competitive.py
+++ b/pettingzoo/atari/entombed_competitive/entombed_competitive.py
@@ -74,15 +74,17 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/entombed_cooperative/entombed_cooperative.py
+++ b/pettingzoo/atari/entombed_cooperative/entombed_cooperative.py
@@ -82,15 +82,17 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/flag_capture/flag_capture.py
+++ b/pettingzoo/atari/flag_capture/flag_capture.py
@@ -71,15 +71,17 @@ In any given turn, an agent can choose from one of 10 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/foozpong/foozpong.py
+++ b/pettingzoo/atari/foozpong/foozpong.py
@@ -72,15 +72,17 @@ In any given turn, an agent can choose from one of 6 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(num_players=4, **kwargs):
+def raw_env(num_players: int = 4, **kwargs: Any) -> AtariAECEnv:
     assert num_players == 2 or num_players == 4, "pong only supports 2 or 4 players"
     mode_mapping = {2: 19, 4: 21}
     mode = mode_mapping[num_players]

--- a/pettingzoo/atari/ice_hockey/ice_hockey.py
+++ b/pettingzoo/atari/ice_hockey/ice_hockey.py
@@ -70,15 +70,17 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/joust/joust.py
+++ b/pettingzoo/atari/joust/joust.py
@@ -74,15 +74,17 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/mario_bros/mario_bros.py
+++ b/pettingzoo/atari/mario_bros/mario_bros.py
@@ -78,15 +78,17 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/maze_craze/maze_craze.py
+++ b/pettingzoo/atari/maze_craze/maze_craze.py
@@ -86,8 +86,10 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
@@ -100,7 +102,9 @@ avaliable_versions = {
 }
 
 
-def raw_env(game_version="robbers", visibilty_level=0, **kwargs):
+def raw_env(
+    game_version: str = "robbers", visibilty_level: int = 0, **kwargs: Any
+) -> AtariAECEnv:
     assert (
         game_version in avaliable_versions
     ), f"`game_version` parameter must be one of {avaliable_versions.keys()}"

--- a/pettingzoo/atari/othello/othello.py
+++ b/pettingzoo/atari/othello/othello.py
@@ -74,15 +74,17 @@ In any given turn, an agent can choose from one of 10 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/pong/pong.py
+++ b/pettingzoo/atari/pong/pong.py
@@ -69,8 +69,10 @@ In any given turn, an agent can choose from one of 6 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
@@ -99,7 +101,9 @@ avaliable_4p_versions = {
 }
 
 
-def raw_env(num_players=2, game_version="classic", **kwargs):
+def raw_env(
+    num_players: int = 2, game_version: str = "classic", **kwargs: Any
+) -> AtariAECEnv:
     assert num_players == 2 or num_players == 4, "pong only supports 2 or 4 players"
     versions = avaliable_2p_versions if num_players == 2 else avaliable_4p_versions
     assert (

--- a/pettingzoo/atari/quadrapong/quadrapong.py
+++ b/pettingzoo/atari/quadrapong/quadrapong.py
@@ -64,15 +64,17 @@ In any given turn, an agent can choose from one of 6 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     mode = 33
     num_players = 4
     name = os.path.basename(__file__).split(".")[0]

--- a/pettingzoo/atari/space_invaders/space_invaders.py
+++ b/pettingzoo/atari/space_invaders/space_invaders.py
@@ -77,8 +77,10 @@ In any given turn, an agent can choose from one of 6 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
@@ -86,13 +88,13 @@ from pettingzoo.atari.base_atari_env import (
 
 
 def raw_env(
-    alternating_control=False,
-    moving_shields=True,
-    zigzaging_bombs=False,
-    fast_bomb=False,
-    invisible_invaders=False,
-    **kwargs,
-):
+    alternating_control: bool = False,
+    moving_shields: bool = True,
+    zigzaging_bombs: bool = False,
+    fast_bomb: bool = False,
+    invisible_invaders: bool = False,
+    **kwargs: Any,
+) -> AtariAECEnv:
     mode = 33 + (
         moving_shields * 1
         + zigzaging_bombs * 2

--- a/pettingzoo/atari/space_war/space_war.py
+++ b/pettingzoo/atari/space_war/space_war.py
@@ -71,15 +71,17 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/surround/surround.py
+++ b/pettingzoo/atari/surround/surround.py
@@ -59,15 +59,17 @@ In any given turn, an agent can choose from one of 6 actions. (Fire is dummy act
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/tennis/tennis.py
+++ b/pettingzoo/atari/tennis/tennis.py
@@ -73,15 +73,17 @@ In any given turn, an agent can choose from one of 18 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/video_checkers/video_checkers.py
+++ b/pettingzoo/atari/video_checkers/video_checkers.py
@@ -63,15 +63,17 @@ In any given turn, an agent can choose from one of 5 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/volleyball_pong/volleyball_pong.py
+++ b/pettingzoo/atari/volleyball_pong/volleyball_pong.py
@@ -72,15 +72,17 @@ In any given turn, an agent can choose from one of 6 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(num_players=4, **kwargs):
+def raw_env(num_players: int = 4, **kwargs: Any) -> AtariAECEnv:
     assert num_players == 2 or num_players == 4, "pong only supports 2 or 4 players"
     mode_mapping = {2: 39, 4: 41}
     mode = mode_mapping[num_players]

--- a/pettingzoo/atari/warlords/warlords.py
+++ b/pettingzoo/atari/warlords/warlords.py
@@ -59,15 +59,17 @@ In any given turn, an agent can choose from one of 6 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")

--- a/pettingzoo/atari/wizard_of_wor/wizard_of_wor.py
+++ b/pettingzoo/atari/wizard_of_wor/wizard_of_wor.py
@@ -65,15 +65,17 @@ In any given turn, an agent can choose from one of 9 actions.
 
 import os
 from glob import glob
+from typing import Any
 
 from pettingzoo.atari.base_atari_env import (
+    AtariAECEnv,
     BaseAtariEnv,
     base_env_wrapper_fn,
     parallel_wrapper_fn,
 )
 
 
-def raw_env(**kwargs):
+def raw_env(**kwargs: Any) -> AtariAECEnv:
     name = os.path.basename(__file__).split(".")[0]
     parent_file = glob(
         os.path.join(os.path.dirname(os.path.dirname(__file__)), name + "*.py")


### PR DESCRIPTION
# Description

This adds type hinting to the atari envs

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
