### PR TITLE
[FIX]: fix build-publish 

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -3,7 +3,6 @@
 # For more information see:
 #   - https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 #   - https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
-#
 
 name: build-publish
 


### PR DESCRIPTION
# Description

I pushed changes to the failing build-publish workflow to master directly, but the release tool needs PRs to detect changes.

The changes changed upload_artifact and download_artifact from v2 to v4.
