### PR TITLE
Update build-publish workflow

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -7,31 +7,21 @@
 name: build-publish
 
 on:
+    workflow_dispatch:
+    push:
+        branches: [master]
+    pull_request:
+        paths:
+            - '.github/workflows/build-publish.yml'
     release:
         types: [published]
 
 jobs:
-    build-wheels:
-        runs-on: ${{ matrix.os }}
+    build:
+        name: Build sdist and wheel
+        runs-on: ubuntu-latest
         permissions:
-            contents: read
-        strategy:
-            matrix:
-                include:
-                    - os: ubuntu-latest
-                      python: 39
-                      platform: manylinux_x86_64
-                    - os: ubuntu-latest
-                      python: 310
-                      platform: manylinux_x86_64
-                    - os: ubuntu-latest
-                      python: 311
-                      platform: manylinux_x86_64
-                    - os: ubuntu-latest
-                      python: 312
-                      platform: manylinux_x86_64
-
-
+            contents: read                      
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python
@@ -40,20 +30,21 @@ jobs:
                   python-version: 3.x
             - name: Install dependencies
               run: python -m pip install --upgrade setuptools wheel build
-            - name: Build wheels
+            - name: Build sdist and wheel
               run: python -m build --sdist --wheel
-            - name: Store wheels
+            - name: Store sdist and wheel
               uses: actions/upload-artifact@v4
               with:
+                  name: artifact
                   path: dist
-
     publish:
+        name: Publish to PyPI
+        needs: [build]
         runs-on: ubuntu-latest
-        needs:
-            - build-wheels
+        environment: pypi
         if: github.event_name == 'release' && github.event.action == 'published'
         steps:
-            - name: Download dists
+            - name: Download dist
               uses: actions/download-artifact@v4
               with:
                   name: artifact

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -12,7 +12,7 @@ on:
         branches: [master]
     pull_request:
         paths:
-            - '.github/workflows/build-publish.yml'
+            - .github/workflows/build-publish.yml
     release:
         types: [published]
 
@@ -21,7 +21,7 @@ jobs:
         name: Build sdist and wheel
         runs-on: ubuntu-latest
         permissions:
-            contents: read                      
+            contents: read
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python


### PR DESCRIPTION
# Description

This change updates build-publish workflow. Since PettingZoo is a pure Python package, the matrix of different Python versions was unnecessary. Also added options to trigger it manually as well to test if it builds every time the change to this workflow is proposed, and a new change is introduced to master.

Fixes # (issue), Depends on # (pull request)

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

The following don't really apply to this change.

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
