### PR TITLE
Return reset and step output in base wrapper

### DIFF
--- a/pettingzoo/utils/wrappers/base.py
+++ b/pettingzoo/utils/wrappers/base.py
@@ -35,7 +35,7 @@ class BaseWrapper(AECEnv[AgentID, ObsType, ActionType]):
         return self.env.render()
 
     def reset(self, seed: int | None = None, options: dict | None = None):
-        self.env.reset(seed=seed, options=options)
+        return self.env.reset(seed=seed, options=options)
 
     def observe(self, agent: AgentID) -> ObsType | None:
         return self.env.observe(agent)
@@ -44,7 +44,7 @@ class BaseWrapper(AECEnv[AgentID, ObsType, ActionType]):
         return self.env.state()
 
     def step(self, action: ActionType) -> None:
-        self.env.step(action)
+        return self.env.step(action)
 
     def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space:
         return self.env.observation_space(agent)


### PR DESCRIPTION
# Description

The base wrapper doesn't return the result of reset and step, contrary to the expected behavior for the API.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
