### PR TITLE
Fix: parallel_api_test accepts action spaces of shapes other than Discrete

### DIFF
--- a/pettingzoo/test/parallel_test.py
+++ b/pettingzoo/test/parallel_test.py
@@ -22,10 +22,7 @@ def sample_action(
 ) -> ActionType:
     agent_obs = obs[agent]
     if isinstance(agent_obs, dict) and "action_mask" in agent_obs:
-        legal_actions = np.flatnonzero(agent_obs["action_mask"])
-        if len(legal_actions) == 0:
-            return 0
-        return random.choice(legal_actions)
+        return env.action_space(agent).sample(mask=agent_obs["action_mask"])
     return env.action_space(agent).sample()
 
 


### PR DESCRIPTION
# Description
The test function parallel_api_test failed and threw an error when testing an environment that had an action space other than Discrete when action masked. This is due to the flattening of the action mask to sample from. This resulted in a single numerical sample consistent with the action mask, which is correct for Discrete but fails for actions spaces such as MultiDiscrete which expect an input as a tuple, e.g. [107, 26] instead of [133]. Motivated by a testing of a custom env that uses a MultiDiscrete action space. Similar issue was found in #1298 where a user reported failing a test due to sampling a Dict space. They ask if there is a proper way to action mask other than the examples, but I believe they masked correctly and the test failed due to this flattening.
New implementation uses the existing sample function from Gymnasium.spaces that takes a mask as a parameter. This will make it easier for users to simply reference the Gymnasium sampling and action-masking examples when creating new environments.
New implementation will not work for Box spaces, as these are unsupported for masking by Gymnasium.

Fixes #1298

## Type of change

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

Before:
<img width="668" height="303" alt="image" src="https://github.com/user-attachments/assets/980143f3-0c0f-4fc5-ab55-0bb9bbdc3902" />
After:
<img width="743" height="231" alt="image" src="https://github.com/user-attachments/assets/e27af92a-719f-4fc6-b753-7cbe60ffa7e6" />


# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have run `pytest -v` and no errors are present.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
