### PR TITLE
Fix CleanRL Advanced PPO video recording by replacing RecordVideo with custom RGB recorder

### DIFF
--- a/tutorials/CleanRL/requirements.txt
+++ b/tutorials/CleanRL/requirements.txt
@@ -2,3 +2,5 @@ pettingzoo[butterfly,atari,testing]>=1.24.0
 SuperSuit>=3.9.0
 tensorboard>=2.11.2
 torch>=1.13.1
+imageio
+imageio-ffmpeg


### PR DESCRIPTION
# Description

This PR fixes the broken --capture-video option in the CleanRL Advanced PPO tutorial (tutorials/CleanRL/cleanrl_advanced.py). The original implementation attempted to use Gymnasium’s RecordVideo wrapper, which does not support PettingZoo’s parallel environments or SuperSuit’s vectorized wrappers. As a result, enabling --capture-video always produced an exception or silently failed.

This PR replaces the unsupported wrapper with a post-training video recorder that:

- Creates a fresh, non-vectorized Atari environment with render_mode="rgb_array"
- Replays the trained policy for a configurable number of frames
- Captures RGB frames and writes an MP4 using imageio
- Saves the video inside the same TensorBoard run directory for easy experiment tracking

This restores full video-recording functionality for the tutorial and provides a more reliable, backend-agnostic way to generate videos of trained PettingZoo agents.

Additional changes

- Added imageio and imageio-ffmpeg to the tutorial requirements.txt since MP4 writing requires them.
- Added a small message clarifying why RecordVideo is disabled for vectorized multi-agent environments.

Fixes # (issue), Depends on # (pull request)
N/A

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

### Screenshots

N/A

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
