### PR TITLE
Improve typing on AECEnv.agent_iter

### DIFF
--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -170,7 +170,9 @@ class AECEnv(Generic[AgentID, ObsType, ActionType]):
         for agent, reward in self.rewards.items():
             self._cumulative_rewards[agent] += reward
 
-    def agent_iter(self, max_iter: int = 2**63) -> AECIterable:
+    def agent_iter(
+        self, max_iter: int = 2**63
+    ) -> AECIterable[AgentID, ObsType, ActionType]:
         """Yields the current agent (self.agent_selection).
 
         Needs to be used in a loop where you step() each iteration.


### PR DESCRIPTION
# Description

Minor typing improvement.

```python=
for agent in env.agent_iter(): ...
```

Now `agent` will be properly typed as `AgentId`. Address my main (initial) motivation for proposing #1318 

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

Before & After
<img width="279" height="117" alt="Screenshot 2025-11-26 at 23 21 47" src="https://github.com/user-attachments/assets/20fa8955-0881-4053-a619-b73239a94130" />
<img width="281" height="117" alt="Screenshot 2025-11-26 at 23 22 14" src="https://github.com/user-attachments/assets/a2e69b1b-98ac-4aef-b0a2-3d569b6ecbfe" />

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present. (only the same tests that fail on CI, fail locally)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works (See screenshots)
- [ ] New and existing unit tests pass locally with my changes
