### PR TITLE
Add Ludo environment to third-party registry

### DIFF
--- a/docs/environments/third_party_envs.md
+++ b/docs/environments/third_party_envs.md
@@ -119,6 +119,13 @@ A multi-agent traffic scenario environment for CARLA that supports [ScenarioRunn
 
 Implementation of the board game *Fanorona*.
 
+### [Ludo](https://github.com/Sim43/PettingZoo-Ludo)
+[![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.24.0-blue)]()
+[![GitHub stars](https://img.shields.io/github/stars/Sim43/PettingZoo-Ludo)]()
+
+PettingZoo implementation of the [Ludo](https://en.wikipedia.org/wiki/Ludo) board game, with optional Pygame rendering. Supports both single-player and team modes (2v2).
+* [Variant Rules](https://github.com/Sim43/PettingZoo-Ludo/blob/main/LUDO_RULES.md)
+
 ### [Gobblet-RL](https://github.com/elliottower/gobblet-rl)
 
 [![PettingZoo version dependency](https://img.shields.io/badge/PettingZoo-v1.22.3-blue)]()


### PR DESCRIPTION
# Description

This PR adds **[[PettingZoo-Ludo](https://github.com/Sim43/PettingZoo-Ludo)]** to the third-party environments registry.

PettingZoo-Ludo is a turn-based implementation of the classic Ludo board game using the PettingZoo AEC API. The environment supports legal action masking, optional rendering, and both single-player and 2v2 team-based gameplay.

No existing functionality is modified.

Fixes: N/A
Depends on: N/A

## Type of change

* New feature (non-breaking change which adds functionality)
* This change requires a documentation update

### Screenshots

Not applicable (documentation-only change).

# Checklist:

* [x] I have run the `pre-commit` checks with `pre-commit run --all-files`
* [x] I have run `pytest -v` and no errors are present
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes