### PR TITLE
Fix gin_rummy knock/gin reward reverting to RLCard default on seeded reset (#1312)

### DIFF
--- a/pettingzoo/classic/rlcard_envs/gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/gin_rummy.py
@@ -176,6 +176,15 @@ class raw_env(RLCardBase, EzPickle):
         if self.render_mode == "human":
             self.clock = pygame.time.Clock()
 
+    def _seed(self, seed=None):
+        # RLCardBase._seed() rebuilds self.env via rlcard.make(), which
+        # discards the custom payoff scorer installed in __init__. Without
+        # re-applying it here, the configured knock_reward / gin_reward
+        # silently revert to RLCard's defaults (0.2 / 1.0) on every
+        # reset(seed=...). See issue #1312.
+        super()._seed(seed=seed)
+        self.env.game.judge.scorer.get_payoff = self._get_payoff
+
     def _get_payoff(self, player: GinRummyPlayer, game) -> float:
         going_out_action = game.round.going_out_action
         going_out_player_id = game.round.going_out_player_id

--- a/pettingzoo/classic/rlcard_envs/test_gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/test_gin_rummy.py
@@ -1,0 +1,66 @@
+"""Tests for the gin_rummy environment.
+
+Regression tests for https://github.com/Farama-Foundation/PettingZoo/issues/1312:
+calling ``reset(seed=...)`` rebuilt the underlying RLCard env and discarded the
+custom payoff scorer, silently reverting the configured ``knock_reward`` /
+``gin_reward`` to RLCard's defaults (0.2 / 1.0).
+"""
+
+from __future__ import annotations
+
+import random
+
+import numpy as np
+
+from pettingzoo.classic import gin_rummy_v4
+from pettingzoo.test import seed_test
+
+# Action ids that end a hand (gin, or any of the 52 knock actions).
+GIN_ACTION = 5
+KNOCK_ACTIONS = range(58, 110)
+
+
+def test_payoff_override_survives_seeded_reset():
+    """Ensure the custom payoff scorer survives a seeded reset."""
+    env = gin_rummy_v4.env(knock_reward=0.5, gin_reward=1.0)
+
+    env.reset()  # no seed: override installed in __init__
+    raw = env.unwrapped
+    assert raw.env.game.judge.scorer.get_payoff == raw._get_payoff
+
+    env.reset(seed=42)  # seeded: env is rebuilt, override must be re-applied
+    assert raw.env.game.judge.scorer.get_payoff == raw._get_payoff
+
+
+def test_configured_knock_reward_used_in_seeded_game():
+    """Ensure a seeded knock pays the configured reward, not RLCard's 0.2."""
+    knock_reward = 0.5
+
+    def finisher_policy(mask, rng):
+        legal = np.flatnonzero(mask).tolist()
+        finishers = [a for a in legal if a == GIN_ACTION or a in KNOCK_ACTIONS]
+        return min(finishers) if finishers else rng.choice(legal)
+
+    saw_knock = False
+    for seed in range(50):
+        env = gin_rummy_v4.env(knock_reward=knock_reward, gin_reward=1.0)
+        env.reset(seed=seed)
+        raw = env.unwrapped
+        rng = random.Random(seed)
+        for _ in env.agent_iter(max_iter=10_000):
+            obs, _, term, trunc, _ = env.last()
+            if term or trunc:
+                going_out = raw.env.game.round.going_out_action
+                if type(going_out).__name__ == "KnockAction":
+                    saw_knock = True
+                    assert max(env.rewards.values()) == knock_reward
+                env.step(None)
+                break
+            env.step(finisher_policy(obs["action_mask"], rng))
+
+    assert saw_knock, "test did not exercise a knock ending; cannot validate reward"
+
+
+def test_seeding_is_deterministic():
+    """Run PettingZoo's determinism check for gin_rummy."""
+    seed_test(gin_rummy_v4.env)


### PR DESCRIPTION
Fixes #1312

## Problem

`gin_rummy` ignores the configured `knock_reward` / `gin_reward` whenever the env
is seeded. `reset(seed=...)` silently reverts them to RLCard's defaults
(knock `0.2`, gin `1.0`), breaking reproducible experiments.

## Cause

`__init__` patches the scorer once (`self.env.game.judge.scorer.get_payoff =
self._get_payoff`), but `RLCardBase._seed()` rebuilds `self.env` via
`rlcard.make()`, which restores RLCard's default scorer. Since `reset()` only
calls `_seed()` when a seed is given, the bug appears only on seeded resets.

## Fix

Re-apply the override after reseeding, in a `gin_rummy`-local `_seed`:

```python
def _seed(self, seed=None):
    super()._seed(seed=seed)
    self.env.game.judge.scorer.get_payoff = self._get_payoff
```

I avoided the base-class alternative (reseed in place via `self.env.seed(seed)`):
it breaks `texas_holdem_no_limit_v6`, whose dealer button is randomized only on a
fresh game object, so reusing the env makes seeding non-deterministic there.

## Tests

New `pettingzoo/classic/rlcard_envs/test_gin_rummy.py`:
- configured scorer survives `reset(seed=...)`;
- a seeded knock pays `0.5`, not `0.2` (fails on `master`, passes here);
- `seed_test(gin_rummy_v4.env)` still passes.

`seed_test` + `api_test` pass for all four RLCard envs; `pre-commit` is clean.
