### PR TITLE
Security: Path Traversal in Image Loading via get_image()

### DIFF
--- a/pettingzoo/butterfly/knights_archers_zombies/src/img.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/src/img.py
@@ -1,11 +1,15 @@
-from os import path as os_path
+import os
 
 import pygame
 
 
 def get_image(path):
-    cwd = os_path.dirname(os_path.dirname(__file__))
-    image = pygame.image.load(cwd + "/" + path)
+    cwd = os.path.dirname(os.path.dirname(__file__))
+    full_path = os.path.join(cwd, path)
+    full_path = os.path.abspath(full_path)
+    if os.path.commonpath([full_path, cwd]) != cwd:
+        raise ValueError("Invalid path: path must be within the assets directory")
+    image = pygame.image.load(full_path)
     sfc = pygame.Surface(image.get_size(), flags=pygame.SRCALPHA)
     sfc.blit(image, (0, 0))
     return sfc


### PR DESCRIPTION
## Summary

Security: Path Traversal in Image Loading via get_image()

## Problem

**Severity**: `Medium` | **File**: `pettingzoo/butterfly/knights_archers_zombies/src/img.py:L8`

The `get_image()` function in `pettingzoo/butterfly/knights_archers_zombies/src/img.py` and similar pattern in `pettingzoo/classic/rlcard_envs/rlcard_utils.py` constructs file paths using string concatenation with user-influenced input. While the current usage appears to use hardcoded paths, the function signature accepts arbitrary paths that could lead to directory traversal if ever called with untrusted input. The `pygame.image.load()` will load files from any accessible path on the filesystem.

## Solution

Validate and sanitize the `path` parameter using `os.path.abspath()` and `os.path.commonpath()` to ensure it resolves within the expected assets directory. Consider using pathlib for safer path handling.

## Changes

- `pettingzoo/butterfly/knights_archers_zombies/src/img.py` (modified)