### PR TITLE
Fix CustomEnvironment tutorial failing tutorial-test CI (np.int8 action masks)

### DIFF
--- a/tutorials/CustomEnvironment/tutorial3_action_masking.py
+++ b/tutorials/CustomEnvironment/tutorial3_action_masking.py
@@ -75,8 +75,14 @@ class CustomActionMaskedEnvironment(ParallelEnv):
             self.escape_x + 7 * self.escape_y,
         )
         observations = {
-            "prisoner": {"observation": observation, "action_mask": [0, 1, 0, 1]},
-            "guard": {"observation": observation, "action_mask": [1, 0, 1, 0]},
+            "prisoner": {
+                "observation": observation,
+                "action_mask": np.array([0, 1, 0, 1], dtype=np.int8),
+            },
+            "guard": {
+                "observation": observation,
+                "action_mask": np.array([1, 0, 1, 0], dtype=np.int8),
+            },
         }
 
         # Get dummy infos. Necessary for proper parallel_to_aec conversion


### PR DESCRIPTION
Extension fix for #1312

The `CustomEnvironment` tutorial test (`tutorial-test`) fails on all Python
versions (3.11–3.14). `tutorial3_action_masking.py` builds action masks as
`np.int8` arrays in `step()`, but `reset()` returns them as plain Python lists
(`[0, 1, 0, 1]`). `tutorial4` runs `parallel_api_test`, which samples an action
from the reset observation, and gymnasium's `Discrete.sample(mask=...)` requires
an `np.ndarray` — so the list mask trips an assertion.

This makes `reset()` consistent with `step()` by returning
`np.array([...], dtype=np.int8)`. Verified all four `CustomEnvironment.`
tutorials run cleanly and the full `pre-commit` suite passes.

I tried to recheck the fix and run tests 4 times to make sure this actually works with minimal changes.

Per @jkterry1's request to fix the remaining CI issues on master.
