### PR TITLE
Speed up env startup by replacing pygame.init() with per-subsystem init

### DIFF
--- a/pettingzoo/atari/base_atari_env.py
+++ b/pettingzoo/atari/base_atari_env.py
@@ -287,7 +287,7 @@ class ParallelAtariEnv(ParallelEnv[AgentID, ObsType, ActionType], EzPickle):
         if self.render_mode == "human":
             zoom_factor = 4
             if self._screen is None:
-                pygame.init()
+                pygame.display.init()
                 self._screen = pygame.display.set_mode(
                     (screen_width * zoom_factor, screen_height * zoom_factor)
                 )

--- a/pettingzoo/butterfly/cooperative_pong/cooperative_pong.py
+++ b/pettingzoo/butterfly/cooperative_pong/cooperative_pong.py
@@ -205,7 +205,6 @@ class CooperativePong:
         """
         super().__init__()
 
-        pygame.init()
         self.num_agents = 2
 
         self.render_ratio = render_ratio
@@ -331,6 +330,7 @@ class CooperativePong:
 
         if self.screen is None:
             if self.render_mode == "human":
+                pygame.display.init()
                 self.screen = pygame.display.set_mode((self.s_width, self.s_height))
                 pygame.display.set_caption("Cooperative Pong")
         assert self.screen is not None

--- a/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
@@ -803,9 +803,8 @@ class raw_env(AECEnv, EzPickle):
             return
 
         if self.screen is None:
-            pygame.init()
-
             if self.render_mode == "human":
+                pygame.display.init()
                 self.screen = pygame.display.set_mode(
                     [const.SCREEN_WIDTH, const.SCREEN_HEIGHT]
                 )

--- a/pettingzoo/butterfly/pistonball/pistonball.py
+++ b/pettingzoo/butterfly/pistonball/pistonball.py
@@ -215,7 +215,6 @@ class raw_env(AECEnv, EzPickle):
             dtype=np.uint8,
         )
 
-        pygame.init()
         pymunk.pygame_util.positive_y_is_up = False
 
         self.render_mode = render_mode
@@ -302,6 +301,7 @@ class raw_env(AECEnv, EzPickle):
         return state
 
     def enable_render(self):
+        pygame.display.init()
         self.screen = pygame.display.set_mode((self.screen_width, self.screen_height))
         pygame.display.set_caption("Pistonball")
 

--- a/pettingzoo/classic/chess/chess.py
+++ b/pettingzoo/classic/chess/chess.py
@@ -320,9 +320,8 @@ class raw_env(AECEnv, EzPickle):
 
     def _render_gui(self):
         if self.screen is None:
-            pygame.init()
-
             if self.render_mode == "human":
+                pygame.display.init()
                 pygame.display.set_caption("Chess")
                 self.screen = pygame.display.set_mode(self.BOARD_SIZE)
             elif self.render_mode == "rgb_array":

--- a/pettingzoo/classic/connect_four/connect_four.py
+++ b/pettingzoo/classic/connect_four/connect_four.py
@@ -235,9 +235,8 @@ class raw_env(AECEnv, EzPickle):
         screen_height = 86 / 99 * screen_width
 
         if self.screen is None:
-            pygame.init()
-
             if self.render_mode == "human":
+                pygame.display.init()
                 pygame.display.set_caption("Connect Four")
                 self.screen = pygame.display.set_mode((screen_width, screen_height))
             elif self.render_mode == "rgb_array":

--- a/pettingzoo/classic/go/go.py
+++ b/pettingzoo/classic/go/go.py
@@ -342,9 +342,8 @@ class raw_env(AECEnv, EzPickle):
             return
 
         if self.screen is None:
-            pygame.init()
-
             if self.render_mode == "human":
+                pygame.display.init()
                 self.screen = pygame.display.set_mode(
                     (self.screen_width, self.screen_height)
                 )

--- a/pettingzoo/classic/rlcard_envs/gin_rummy.py
+++ b/pettingzoo/classic/rlcard_envs/gin_rummy.py
@@ -249,9 +249,10 @@ class raw_env(RLCardBase, EzPickle):
         screen_width = int(screen_height * (1 / 20) + 3.5 * (screen_height * 1 / 2))
 
         if self.screen is None:
-            pygame.init()
+            pygame.font.init()
 
             if self.render_mode == "human":
+                pygame.display.init()
                 self.screen = pygame.display.set_mode((screen_width, screen_height))
                 pygame.display.set_caption("Gin Rummy")
             else:

--- a/pettingzoo/classic/rlcard_envs/leduc_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/leduc_holdem.py
@@ -137,9 +137,10 @@ class raw_env(RLCardBase, EzPickle):
         )
 
         if self.screen is None:
-            pygame.init()
+            pygame.font.init()
 
             if self.render_mode == "human":
+                pygame.display.init()
                 self.screen = pygame.display.set_mode((screen_width, screen_height))
                 pygame.display.set_caption("Leduc Hold'em")
             else:

--- a/pettingzoo/classic/rlcard_envs/texas_holdem.py
+++ b/pettingzoo/classic/rlcard_envs/texas_holdem.py
@@ -146,9 +146,10 @@ class raw_env(RLCardBase, EzPickle):
         )
 
         if self.screen is None:
-            pygame.init()
+            pygame.font.init()
 
             if self.render_mode == "human":
+                pygame.display.init()
                 self.screen = pygame.display.set_mode((screen_width, screen_height))
                 pygame.display.set_caption(self.caption)
             else:

--- a/pettingzoo/classic/rps/rps.py
+++ b/pettingzoo/classic/rps/rps.py
@@ -437,10 +437,11 @@ class raw_env(AECEnv, EzPickle):
         screen_height = self.screen_height
         screen_width = int(screen_height * 5 / 14)
 
-        if self.screen is None:
-            pygame.init()
+        if self.render_mode is not None and self.screen is None:
+            pygame.font.init()
 
         if self.render_mode == "human":
+            pygame.display.init()
             self.screen = pygame.display.set_mode((screen_width, screen_height))
             pygame.display.set_caption("Rock Paper Scissors")
         else:

--- a/pettingzoo/classic/tictactoe/tictactoe.py
+++ b/pettingzoo/classic/tictactoe/tictactoe.py
@@ -230,9 +230,10 @@ class raw_env(AECEnv, EzPickle):
         self.agent_selection = self._agent_selector.reset()
 
         if self.render_mode is not None and self.screen is None:
-            pygame.init()
+            pygame.font.init()
 
         if self.render_mode == "human":
+            pygame.display.init()
             self.screen = pygame.display.set_mode(
                 (self.screen_height, self.screen_height)
             )

--- a/pettingzoo/sisl/multiwalker/multiwalker_base.py
+++ b/pettingzoo/sisl/multiwalker/multiwalker_base.py
@@ -575,7 +575,7 @@ class MultiWalkerEnv:
         offset = 200  # compensates for the negative coordinates
         render_scale = SCALE / self.package_scale / 0.75
         if self.screen is None:
-            pygame.init()
+            pygame.display.init()
             self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
             pygame.display.set_caption("Multiwalker")
 

--- a/pettingzoo/sisl/pursuit/pursuit.py
+++ b/pettingzoo/sisl/pursuit/pursuit.py
@@ -79,7 +79,6 @@ catch_reward=5.0, urgency_reward=-0.1, surround=True, constraint_window=1.0)
 """
 
 import numpy as np
-import pygame
 from gymnasium.utils import EzPickle
 
 from pettingzoo import AECEnv
@@ -114,7 +113,6 @@ class raw_env(AECEnv, EzPickle):
         EzPickle.__init__(self, *args, **kwargs)
         self.env = _env(*args, **kwargs)
         self.render_mode = kwargs.get("render_mode")
-        pygame.init()
         self.agents = ["pursuer_" + str(a) for a in range(self.env.num_agents)]
         self.possible_agents = self.agents[:]
         self.agent_name_mapping = dict(zip(self.agents, list(range(self.num_agents))))

--- a/pettingzoo/sisl/pursuit/pursuit_base.py
+++ b/pettingzoo/sisl/pursuit/pursuit_base.py
@@ -394,6 +394,7 @@ class Pursuit:
             return
 
         if self.screen is None:
+            pygame.font.init()
             if self.render_mode == "human":
                 pygame.display.init()
                 self.screen = pygame.display.set_mode(

--- a/test/pygame_init_test.py
+++ b/test/pygame_init_test.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import numpy as np
+import pygame
+import pytest
+
+from pettingzoo.butterfly import (
+    cooperative_pong_v6,
+    knights_archers_zombies_v10,
+    pistonball_v6,
+)
+from pettingzoo.classic import (
+    chess_v6,
+    connect_four_v3,
+    gin_rummy_v4,
+    go_v5,
+    leduc_holdem_v4,
+    rps_v2,
+    texas_holdem_v4,
+    tictactoe_v3,
+)
+from pettingzoo.sisl import multiwalker_v9, pursuit_v4
+
+pygame_envs = [
+    cooperative_pong_v6,
+    knights_archers_zombies_v10,
+    pistonball_v6,
+    chess_v6,
+    connect_four_v3,
+    gin_rummy_v4,
+    go_v5,
+    leduc_holdem_v4,
+    rps_v2,
+    texas_holdem_v4,
+    tictactoe_v3,
+    multiwalker_v9,
+    pursuit_v4,
+]
+
+
+@pytest.mark.parametrize("env_module", pygame_envs)
+def test_no_pygame_subsystem_init_without_rendering(env_module):
+    # Constructing and stepping an environment that is not being rendered
+    # should not initialize any pygame subsystem: full pygame.init() starts
+    # the audio/joystick subsystems, and enumerating audio devices can take
+    # several seconds on some platforms (https://github.com/Farama-Foundation/PettingZoo/issues/1252).
+    pygame.quit()
+    env = env_module.env(render_mode=None)
+    env.reset(seed=42)
+    for agent in env.agent_iter(max_iter=4):
+        obs, reward, termination, truncation, info = env.last()
+        action = (
+            None
+            if termination or truncation
+            else env.action_space(agent).sample(
+                obs["action_mask"] if isinstance(obs, dict) else None
+            )
+        )
+        env.step(action)
+    assert pygame.display.get_init() is False
+    assert pygame.mixer.get_init() is None
+    assert pygame.font.get_init() is False
+    env.close()
+
+
+@pytest.mark.parametrize("env_module", pygame_envs)
+def test_rgb_array_render_does_not_init_audio(env_module):
+    # Rendering only needs the display (and font) subsystems, never audio.
+    pygame.quit()
+    env = env_module.env(render_mode="rgb_array")
+    env.reset(seed=42)
+    frame = env.render()
+    assert isinstance(frame, np.ndarray) and frame.size > 0
+    assert pygame.mixer.get_init() is None
+    env.close()


### PR DESCRIPTION
# Description

Fixes #1252.

The slow part of `pygame.init()` is not pygame itself but the audio and joystick subsystems
it also starts: no PettingZoo environment plays sound, and audio-device enumeration is what
takes the seconds (it is also why `pettingzoo/__init__.py` carries the `SDL_AUDIODRIVER=dsp`
workaround). On my machine `pygame.init()` takes ~0.39s vs ~0.008s for
`pygame.display.init()` + `pygame.font.init()`.

There were 14 `pygame.init()` call sites, three of them unconditional in `__init__`
(pistonball, cooperative_pong, pursuit), so even `render_mode=None` training paid the cost
on every construction. This applies the change Gymnasium merged in
Farama-Foundation/Gymnasium#1586: `pygame.display.init()` right before
`pygame.display.set_mode()` on the human render path (the pattern pursuit's `render()`
already used), `pygame.font.init()` in the envs that draw text (rps, tictactoe, the rlcard
envs, pursuit), and the unconditional constructor calls removed entirely.

One subtlety: `pygame.display.init()` raises when no video device is available, while
`pygame.init()` silently swallowed the failure. Display init is therefore kept off the
`rgb_array` path (plain `pygame.Surface` rendering needs no display) and out of
constructors, so headless training keeps working.

Testing: new `test/pygame_init_test.py` asserts that constructing/stepping without rendering
initializes no pygame subsystem and that `rgb_array` rendering never initializes the mixer
(17 of its 26 cases fail before this change). Existing `test/all_parameter_combs_test.py`
(api/seed/render/max_cycles/state), `pickle_test.py`, and `specific_env_test.py` pass for
all touched envs.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

This PR was prepared with the assistance of Claude Code.
