### PR TITLE
Migrate type checking from pyright to ty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# uv
+uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,17 +65,10 @@ repos:
                 - --add-ignore=D100,D107,D101,D102,D103,D105
             exclude: __init__.py$|^pettingzoo.test|^docs
             additional_dependencies: [tomli]
-    - repo: local
+    - repo: https://github.com/astral-sh/ty-pre-commit
+      rev: v0.0.52
       hooks:
-          - id: pyright
-            name: pyright
-            entry: pyright
-            language: node
-            pass_filenames: false
-            types: [python]
-            additional_dependencies: [pyright@1.1.347]
-            args:
-                - --project=pyproject.toml
+          - id: ty
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
       rev: 0.2.3
       hooks:

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -1,4 +1,3 @@
-# pyright: reportGeneralTypeIssues=false
 import copy
 import warnings
 from collections import defaultdict
@@ -126,7 +125,7 @@ class aec_to_parallel_wrapper(ParallelEnv[AgentID, ObsType, ActionType]):
 
         try:
             self.render_mode = (
-                self.aec_env.render_mode  # pyright: ignore[reportGeneralTypeIssues]
+                self.aec_env.render_mode  # type: ignore
             )
         except AttributeError:
             warnings.warn(
@@ -246,7 +245,7 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
 
         try:
             self.render_mode = (
-                self.env.render_mode  # pyright: ignore[reportGeneralTypeIssues]
+                self.env.render_mode  # type: ignore
             )
         except AttributeError:
             warnings.warn(
@@ -261,7 +260,7 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
         # Not every environment has the .state_space attribute implemented
         try:
             self.state_space = (
-                self.env.state_space  # pyright: ignore[reportGeneralTypeIssues]
+                self.env.state_space  # type: ignore
             )
         except AttributeError:
             pass
@@ -424,14 +423,14 @@ class turn_based_aec_to_parallel_wrapper(
         # Not every environment has the .state_space attribute implemented
         try:
             self.state_space = (
-                self.aec_env.state_space  # pyright: ignore[reportGeneralTypeIssues]
+                self.aec_env.state_space  # type: ignore
             )
         except AttributeError:
             pass
 
         try:
             self.render_mode = (
-                self.aec_env.render_mode  # pyright: ignore[reportGeneralTypeIssues]
+                self.aec_env.render_mode  # type: ignore
             )
         except AttributeError:
             warnings.warn(

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -124,9 +124,7 @@ class aec_to_parallel_wrapper(ParallelEnv[AgentID, ObsType, ActionType]):
         self.metadata = aec_env.metadata
 
         try:
-            self.render_mode = (
-                self.aec_env.render_mode  # type: ignore
-            )
+            self.render_mode = self.aec_env.render_mode  # type: ignore
         except AttributeError:
             warnings.warn(
                 f"The base environment `{aec_env}` does not have a `render_mode` defined."
@@ -244,9 +242,7 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
         self.metadata["is_parallelizable"] = True
 
         try:
-            self.render_mode = (
-                self.env.render_mode  # type: ignore
-            )
+            self.render_mode = self.env.render_mode  # type: ignore
         except AttributeError:
             warnings.warn(
                 f"The base environment `{parallel_env}` does not have a `render_mode` defined."
@@ -259,9 +255,7 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
 
         # Not every environment has the .state_space attribute implemented
         try:
-            self.state_space = (
-                self.env.state_space  # type: ignore
-            )
+            self.state_space = self.env.state_space  # type: ignore
         except AttributeError:
             pass
 
@@ -422,16 +416,12 @@ class turn_based_aec_to_parallel_wrapper(
 
         # Not every environment has the .state_space attribute implemented
         try:
-            self.state_space = (
-                self.aec_env.state_space  # type: ignore
-            )
+            self.state_space = self.aec_env.state_space  # type: ignore
         except AttributeError:
             pass
 
         try:
-            self.render_mode = (
-                self.aec_env.render_mode  # type: ignore
-            )
+            self.render_mode = self.aec_env.render_mode  # type: ignore
         except AttributeError:
             warnings.warn(
                 f"The base environment `{aec_env}` does not have a `render_mode` defined."

--- a/pettingzoo/utils/wrappers/capture_stdout.py
+++ b/pettingzoo/utils/wrappers/capture_stdout.py
@@ -12,8 +12,8 @@ class CaptureStdoutWrapper(BaseWrapper):
         ), "CaptureStdoutWrapper is only compatible with AEC environments"
         assert hasattr(env, "render_mode"), f"Environment {env} has no render_mode."
         assert (
-            env.render_mode == "human"  # pyright: ignore[reportGeneralTypeIssues]
-        ), f"CaptureStdoutWrapper works only with human rendering mode, but found {env.render_mode} instead."  # pyright: ignore[reportGeneralTypeIssues]
+            env.render_mode == "human"  # type: ignore
+        ), f"CaptureStdoutWrapper works only with human rendering mode, but found {env.render_mode} instead."  # type: ignore
         super().__init__(env)
         self.metadata["render_modes"].append("ansi")
         self.render_mode = "ansi"

--- a/pettingzoo/utils/wrappers/clip_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/clip_out_of_bounds.py
@@ -37,16 +37,16 @@ class ClipOutOfBoundsWrapper(BaseWrapper):
                 EnvLogger.error_nan_action()
             assert (
                 space.shape
-                == action.shape  # pyright: ignore[reportOptionalMemberAccess]
-            ), f"action should have shape {space.shape}, has shape {action.shape}"  # pyright: ignore[reportOptionalMemberAccess]
+                == action.shape  # type: ignore
+            ), f"action should have shape {space.shape}, has shape {action.shape}"  # type: ignore
 
             EnvLogger.warn_action_out_of_bound(
                 action=action, action_space=space, backup_policy="clipping to space"
             )
             action = np.clip(
-                action,  # pyright: ignore[reportGeneralTypeIssues]
-                space.low,  # pyright: ignore[reportGeneralTypeIssues]
-                space.high,  # pyright: ignore[reportGeneralTypeIssues]
+                action,  # type: ignore
+                space.low,  # type: ignore
+                space.high,  # type: ignore
             )
 
         super().step(action)

--- a/pettingzoo/utils/wrappers/clip_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/clip_out_of_bounds.py
@@ -36,8 +36,7 @@ class ClipOutOfBoundsWrapper(BaseWrapper):
             if action is None or np.isnan(action).any():
                 EnvLogger.error_nan_action()
             assert (
-                space.shape
-                == action.shape  # type: ignore
+                space.shape == action.shape  # type: ignore
             ), f"action should have shape {space.shape}, has shape {action.shape}"  # type: ignore
 
             EnvLogger.warn_action_out_of_bound(

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -118,7 +118,7 @@ class AECOrderEnforcingIterator(AECIterator[AgentID, ObsType, ActionType]):
     def __next__(self) -> AgentID:
         agent = super().__next__()
         assert (
-            self.env._has_updated  # pyright: ignore[reportGeneralTypeIssues]
+            self.env._has_updated  # type: ignore
         ), "need to call step() or reset() in a loop over `agent_iter`"
-        self.env._has_updated = False  # pyright: ignore[reportGeneralTypeIssues]
+        self.env._has_updated = False  # type: ignore
         return agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ atomic = true
 profile = "black"
 src_paths = ["pettingzoo", "test"]
 
-[tool.pyright]
+[tool.ty.src]
 # add any files/directories with type declaration to include
 include = [
     "pettingzoo/",
@@ -98,11 +98,17 @@ exclude = [
     "pettingzoo/sisl/",
     "pettingzoo/test/",
 ]
-strict = [
-]
-verboseOutput = true
-typeCheckingMode = "basic"
-reportMissingImports = false
+
+[tool.ty.rules]
+# Forgiving baseline: downgrade every rule to a warning so type checking does
+# not fail CI. Ratchet individual rules back up to "error" over time.
+all = "warn"
+# Missing imports are not reported (third-party deps lack stubs).
+unresolved-import = "ignore"
+
+[tool.ty.terminal]
+# Don't fail (exit non-zero) on warning-level diagnostics for now.
+error-on-warning = false
 
 [tool.pytest.ini_options]
 addopts = [ "--ignore-glob=*/__init__.py", "-n=auto", "--ignore=tutorials", "--ignore=docs/_scripts", "--ignore=conf.py"]


### PR DESCRIPTION
This is a follow up to https://github.com/Farama-Foundation/PettingZoo/issues/1318

This is intentional non-invasive, to avoid large code changes hard to review, once we have `ty` and `ruff` in the project and in the CI, it should be an easy migration.

Even though the code was generated using Claude Code, I reviewed the output. Leaving Claude comment below in case you find them useful

---


## What

Migrates the project's type checker from **pyright** to **[ty](https://docs.astral.sh/ty/)** (Astral's type checker), using a deliberately forgiving initial configuration so the migration does not break CI.

## Changes

- **`pyproject.toml`**: replaced `[tool.pyright]` with `[tool.ty]` config.
  - `[tool.ty.src]` preserves the same `include`/`exclude` scope as before — only `pettingzoo/`, excluding `atari/`, `butterfly/`, `classic/`, `mpe/`, `sisl/`, `test/`.
  - `[tool.ty.rules]` sets `all = "warn"` (downgrade every rule to a warning) and `unresolved-import = "ignore"` to match the old `reportMissingImports = false`.
  - `[tool.ty.terminal]` sets `error-on-warning = false` so `ty check` exits `0` on warnings.
- **`.pre-commit-config.yaml`**: replaced the local `pyright@1.1.347` node hook with the official [`astral-sh/ty-pre-commit`](https://github.com/astral-sh/ty-pre-commit) hook (`rev: v0.0.52`).
- **Inline suppressions**: converted all `# pyright: ignore[...]` comments to PEP 484 `# type: ignore` (respected by ty) and dropped the file-level `# pyright: reportGeneralTypeIssues=false` directive — in `conversions.py`, `capture_stdout.py`, `clip_out_of_bounds.py`, `order_enforcing.py`.
- **`.gitignore`**: ignore `uv.lock`.

## Why forgiving

This is intended as a low-risk first step. With `all = "warn"` + `error-on-warning = false`, ty surfaces issues without failing CI. Individual rules can be ratcheted back up to `"error"` over time.

## Notes for reviewers

- No dedicated pyright GitHub Action existed — pyright ran via pre-commit, and CI invokes it through the generic `.github/workflows/pre-commit.yml` (`pre-commit run --all-files`). Swapping the hook is sufficient; that workflow needs no edits.
- Validated locally with `uvx ty check`: **132 diagnostics, all `warning`-level, exit code 0**. The excludes were confirmed to be respected.
- `rev: v0.0.52` was the latest `ty-pre-commit` tag at authoring time; ty is pre-1.0, so `pre-commit autoupdate` can bump it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)