### PR TITLE
Promote ty/ruff diagnostics from warnings to errors and fix findings

### DIFF
--- a/pettingzoo/utils/agent_selector.py
+++ b/pettingzoo/utils/agent_selector.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Any
 from warnings import warn
 
+from typing_extensions import override
+
 
 class AgentSelector:
     """Outputs an agent in the given order whenever agent_select is called.
@@ -53,7 +55,8 @@ class AgentSelector:
         """Check if the current agent is the first agent in the cycle."""
         return self.selected_agent == self.agent_order[0]
 
-    def __eq__(self, other: AgentSelector) -> bool:
+    @override
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, AgentSelector):
             return NotImplemented
 

--- a/pettingzoo/utils/average_total_reward.py
+++ b/pettingzoo/utils/average_total_reward.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import random
+from typing import Any
 
 import numpy as np
 
@@ -8,7 +9,7 @@ from pettingzoo.utils.env import AECEnv
 
 
 def average_total_reward(
-    env: AECEnv, max_episodes: int = 100, max_steps: int = 10000000000
+    env: AECEnv[Any, Any, Any], max_episodes: int = 100, max_steps: int = 10000000000
 ) -> float:
     """Calculates the average total reward over the episodes for AEC environments.
 

--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -1,14 +1,16 @@
 import copy
 import warnings
 from collections import defaultdict
-from typing import Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, cast
+
+from typing_extensions import override
 
 from pettingzoo.utils import AgentSelector
 from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
 from pettingzoo.utils.wrappers import OrderEnforcingWrapper
 
 
-def parallel_wrapper_fn(env_fn: Callable) -> Callable:
+def parallel_wrapper_fn(env_fn: Callable[..., Any]) -> Callable[..., Any]:
     def par_fn(**kwargs):
         env = env_fn(**kwargs)
         env = aec_to_parallel_wrapper(env)
@@ -17,7 +19,7 @@ def parallel_wrapper_fn(env_fn: Callable) -> Callable:
     return par_fn
 
 
-def aec_wrapper_fn(par_env_fn: Callable) -> Callable:
+def aec_wrapper_fn(par_env_fn: Callable[..., Any]) -> Callable[..., Any]:
     """Converts class(pettingzoo.utils.env.ParallelEnv) -> class(pettingzoo.utils.env.AECEnv).
 
     Args:
@@ -77,7 +79,7 @@ def turn_based_aec_to_parallel(
     aec_env: AECEnv[AgentID, ObsType, Optional[ActionType]]
 ) -> ParallelEnv[AgentID, ObsType, Optional[ActionType]]:
     if isinstance(aec_env, parallel_to_aec_wrapper):
-        return aec_env.env
+        return cast("ParallelEnv[AgentID, ObsType, Optional[ActionType]]", aec_env.env)
     else:
         par_env = turn_based_aec_to_parallel_wrapper(aec_env)
         return par_env
@@ -124,7 +126,7 @@ class aec_to_parallel_wrapper(ParallelEnv[AgentID, ObsType, ActionType]):
         self.metadata = aec_env.metadata
 
         try:
-            self.render_mode = self.aec_env.render_mode  # type: ignore
+            self.render_mode = self.aec_env.render_mode
         except AttributeError:
             warnings.warn(
                 f"The base environment `{aec_env}` does not have a `render_mode` defined."
@@ -137,6 +139,7 @@ class aec_to_parallel_wrapper(ParallelEnv[AgentID, ObsType, ActionType]):
             pass
 
     @property
+    @override
     def observation_spaces(self):
         warnings.warn(
             "The `observation_spaces` dictionary is deprecated. Use the `observation_space` function instead."
@@ -151,6 +154,7 @@ class aec_to_parallel_wrapper(ParallelEnv[AgentID, ObsType, ActionType]):
             ) from e
 
     @property
+    @override
     def action_spaces(self):
         warnings.warn(
             "The `action_spaces` dictionary is deprecated. Use the `action_space` function instead."
@@ -162,16 +166,20 @@ class aec_to_parallel_wrapper(ParallelEnv[AgentID, ObsType, ActionType]):
                 "The base environment does not have an action_spaces dict attribute. Use the environments `action_space` method instead"
             ) from e
 
+    @override
     def observation_space(self, agent):
         return self.aec_env.observation_space(agent)
 
+    @override
     def action_space(self, agent):
         return self.aec_env.action_space(agent)
 
     @property
+    @override
     def unwrapped(self):
         return self.aec_env.unwrapped
 
+    @override
     def reset(self, seed=None, options=None):
         self.aec_env.reset(seed=seed, options=options)
         self.agents = self.aec_env.agents[:]
@@ -184,6 +192,7 @@ class aec_to_parallel_wrapper(ParallelEnv[AgentID, ObsType, ActionType]):
         infos = dict(**self.aec_env.infos)
         return observations, infos
 
+    @override
     def step(self, actions):
         rewards = defaultdict(int)
         terminations = {}
@@ -220,12 +229,15 @@ class aec_to_parallel_wrapper(ParallelEnv[AgentID, ObsType, ActionType]):
         self.agents = self.aec_env.agents
         return observations, rewards, terminations, truncations, infos
 
+    @override
     def render(self):
         return self.aec_env.render()
 
+    @override
     def state(self):
         return self.aec_env.state()
 
+    @override
     def close(self):
         return self.aec_env.close()
 
@@ -260,10 +272,12 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
             pass
 
     @property
+    @override
     def unwrapped(self):
         return self.env.unwrapped
 
     @property
+    @override
     def observation_spaces(self):
         warnings.warn(
             "The `observation_spaces` dictionary is deprecated. Use the `observation_space` function instead."
@@ -278,6 +292,7 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
             ) from e
 
     @property
+    @override
     def action_spaces(self):
         warnings.warn(
             "The `action_spaces` dictionary is deprecated. Use the `action_space` function instead."
@@ -289,12 +304,15 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
                 "The base environment does not have an action_spaces dict attribute. Use the environments `action_space` method instead"
             ) from e
 
+    @override
     def observation_space(self, agent):
         return self.env.observation_space(agent)
 
+    @override
     def action_space(self, agent):
         return self.env.action_space(agent)
 
+    @override
     def reset(self, seed=None, options=None):
         self._observations, self.infos = self.env.reset(seed=seed, options=options)
         self.agents = self.env.agents[:]
@@ -315,7 +333,8 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
             )
             self.infos = {agent: {} for agent in self.agents}
         elif set(self.infos.keys()) != set(self.agents):
-            self.infos = {agent: {self.infos.copy()} for agent in self.agents}
+            current_info = cast("dict[str, Any]", self.infos)
+            self.infos = {agent: current_info.copy() for agent in self.agents}
             warnings.warn(
                 f"The `infos` dictionary returned by `env.reset()` is not valid: must contain keys for each agent defined in self.agents: {self.agents}. Overwriting with current info duplicated for each agent: {self.infos}"
             )
@@ -324,9 +343,11 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
         self.new_agents = []
         self.new_values = {}
 
+    @override
     def observe(self, agent):
         return self._observations[agent]
 
+    @override
     def state(self):
         return self.env.state()
 
@@ -341,6 +362,7 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
         self.rewards[new_agent] = 0
         self._cumulative_rewards[new_agent] = 0
 
+    @override
     def step(self, action: Optional[ActionType]):
         if (
             self.terminations[self.agent_selection]
@@ -380,6 +402,7 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
 
             self.agent_selection = self._agent_selector.next()
 
+    @override
     def last(self, observe=True):
         agent = self.agent_selection
         observation = self.observe(agent) if observe else None
@@ -391,12 +414,15 @@ class parallel_to_aec_wrapper(AECEnv[AgentID, ObsType, Optional[ActionType]]):
             self.infos[agent],
         )
 
+    @override
     def render(self):
         return self.env.render()
 
+    @override
     def close(self):
         self.env.close()
 
+    @override
     def __str__(self):
         return str(self.env)
 
@@ -428,10 +454,12 @@ class turn_based_aec_to_parallel_wrapper(
             )
 
     @property
+    @override
     def unwrapped(self):
         return self.aec_env.unwrapped
 
     @property
+    @override
     def observation_spaces(self):
         warnings.warn(
             "The `observation_spaces` dictionary is deprecated. Use the `observation_space` function instead."
@@ -446,6 +474,7 @@ class turn_based_aec_to_parallel_wrapper(
             ) from e
 
     @property
+    @override
     def action_spaces(self):
         warnings.warn(
             "The `action_spaces` dictionary is deprecated. Use the `action_space` function instead."
@@ -457,12 +486,15 @@ class turn_based_aec_to_parallel_wrapper(
                 "The base environment does not have an action_spaces dict attribute. Use the environments `action_space` method instead"
             ) from e
 
+    @override
     def observation_space(self, agent):
         return self.aec_env.observation_space(agent)
 
+    @override
     def action_space(self, agent):
         return self.aec_env.action_space(agent)
 
+    @override
     def reset(self, seed=None, options=None):
         self.aec_env.reset(seed=seed, options=options)
         self.agents = self.aec_env.agents[:]
@@ -475,6 +507,7 @@ class turn_based_aec_to_parallel_wrapper(
         infos = {**self.aec_env.infos}
         return observations, infos
 
+    @override
     def step(self, actions):
         if not self.agents:
             return {}, {}, {}, {}
@@ -502,11 +535,14 @@ class turn_based_aec_to_parallel_wrapper(
         self.agents = self.aec_env.agents
         return observations, rewards, terminations, truncations, infos
 
+    @override
     def render(self):
         return self.aec_env.render()
 
+    @override
     def state(self):
         return self.aec_env.state()
 
+    @override
     def close(self):
         return self.aec_env.close()

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Generic, Iterable, Iterator, TypeVar
 
 import gymnasium.spaces
 import numpy as np
+from typing_extensions import override
 
 ObsType = TypeVar("ObsType")
 ActionType = TypeVar("ActionType")
@@ -68,7 +69,7 @@ class AECEnv(Generic[AgentID, ObsType, ActionType]):
     def reset(
         self,
         seed: int | None = None,
-        options: dict | None = None,
+        options: dict[str, Any] | None = None,
     ) -> None:
         """Resets the environment to a starting state."""
         raise NotImplementedError
@@ -81,7 +82,7 @@ class AECEnv(Generic[AgentID, ObsType, ActionType]):
         """
         raise NotImplementedError
 
-    def render(self) -> None | np.ndarray | str | list:
+    def render(self) -> None | np.ndarray | str | list[Any]:
         """Renders the environment as specified by self.render_mode.
 
         Render mode can be `human` to display a window.
@@ -244,6 +245,7 @@ class AECEnv(Generic[AgentID, ObsType, ActionType]):
             self._skip_agent_selection = None
         self._clear_rewards()
 
+    @override
     def __str__(self) -> str:
         """Returns a name which looks like: `space_invaders_v1`."""
         if hasattr(self, "metadata"):
@@ -261,6 +263,7 @@ class AECIterable(Iterable[AgentID], Generic[AgentID, ObsType, ActionType]):
         self.env = env
         self.max_iter = max_iter
 
+    @override
     def __iter__(self) -> AECIterator[AgentID, ObsType, ActionType]:
         return AECIterator(self.env, self.max_iter)
 
@@ -270,12 +273,14 @@ class AECIterator(Iterator[AgentID], Generic[AgentID, ObsType, ActionType]):
         self.env = env
         self.iters_til_term = max_iter
 
+    @override
     def __next__(self) -> AgentID:
         if not self.env.agents or self.iters_til_term <= 0:
             raise StopIteration
         self.iters_til_term -= 1
         return self.env.agent_selection
 
+    @override
     def __iter__(self) -> AECIterator[AgentID, ObsType, ActionType]:
         return self
 
@@ -300,8 +305,8 @@ class ParallelEnv(Generic[AgentID, ObsType, ActionType]):
     def reset(
         self,
         seed: int | None = None,
-        options: dict | None = None,
-    ) -> tuple[dict[AgentID, ObsType], dict[AgentID, dict]]:
+        options: dict[str, Any] | None = None,
+    ) -> tuple[dict[AgentID, ObsType], dict[AgentID, dict[str, Any]]]:
         """Resets the environment.
 
         And returns a dictionary of observations (keyed by the agent name)
@@ -315,7 +320,7 @@ class ParallelEnv(Generic[AgentID, ObsType, ActionType]):
         dict[AgentID, float],
         dict[AgentID, bool],
         dict[AgentID, bool],
-        dict[AgentID, dict],
+        dict[AgentID, dict[str, Any]],
     ]:
         """Receives a dictionary of actions keyed by the agent name.
 
@@ -324,7 +329,7 @@ class ParallelEnv(Generic[AgentID, ObsType, ActionType]):
         """
         raise NotImplementedError
 
-    def render(self) -> None | np.ndarray | str | list:
+    def render(self) -> None | np.ndarray | str | list[Any]:
         """Displays a rendered frame from the environment, if supported.
 
         Alternate render modes in the default environments are `'rgb_array'`
@@ -382,6 +387,7 @@ class ParallelEnv(Generic[AgentID, ObsType, ActionType]):
     def max_num_agents(self) -> int:
         return len(self.possible_agents)
 
+    @override
     def __str__(self) -> str:
         """Returns the name.
 
@@ -393,5 +399,5 @@ class ParallelEnv(Generic[AgentID, ObsType, ActionType]):
             return self.__class__.__name__
 
     @property
-    def unwrapped(self) -> ParallelEnv:
+    def unwrapped(self) -> ParallelEnv[AgentID, ObsType, ActionType]:
         return self

--- a/pettingzoo/utils/env_logger.py
+++ b/pettingzoo/utils/env_logger.py
@@ -5,6 +5,7 @@ from logging import Logger
 from typing import Any
 
 import gymnasium.spaces
+from typing_extensions import override
 
 
 class EnvLogger:
@@ -111,6 +112,7 @@ class EnvWarningHandler(logging.Handler):
         logging.Handler.__init__(self, *args, **kwargs)
         self.mqueue = mqueue
 
+    @override
     def emit(self, record: logging.LogRecord):
         m = self.format(record).rstrip("\n")
         self.mqueue.append(m)

--- a/pettingzoo/utils/random_demo.py
+++ b/pettingzoo/utils/random_demo.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import random
+from typing import Any
 
 import numpy as np
 
 from pettingzoo.utils.env import AECEnv
 
 
-def random_demo(env: AECEnv, render: bool = True, episodes: int = 1) -> float:
+def random_demo(
+    env: AECEnv[Any, Any, Any], render: bool = True, episodes: int = 1
+) -> float:
     """Runs an env object with random actions."""
     total_reward = 0
     completed_episodes = 0

--- a/pettingzoo/utils/wrappers/assert_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/assert_out_of_bounds.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing_extensions import override
+
 from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType
 from pettingzoo.utils.wrappers.base import BaseWrapper
 
@@ -13,6 +15,7 @@ class AssertOutOfBoundsWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
         ), "AssertOutOfBoundsWrapper is only compatible with AEC environments"
         super().__init__(env)
 
+    @override
     def step(self, action: ActionType) -> None:
         assert (
             action is None
@@ -25,5 +28,6 @@ class AssertOutOfBoundsWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
         ), "action is not in action space"
         super().step(action)
 
+    @override
     def __str__(self) -> str:
         return str(self.env)

--- a/pettingzoo/utils/wrappers/base.py
+++ b/pettingzoo/utils/wrappers/base.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import gymnasium.spaces
 import numpy as np
+from typing_extensions import override
 
 from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType
 
@@ -25,33 +26,43 @@ class BaseWrapper(AECEnv[AgentID, ObsType, ActionType]):
         return getattr(self.env, name)
 
     @property
-    def unwrapped(self) -> AECEnv:
+    @override
+    def unwrapped(self) -> AECEnv[AgentID, ObsType, ActionType]:
         return self.env.unwrapped
 
+    @override
     def close(self) -> None:
         self.env.close()
 
-    def render(self) -> None | np.ndarray | str | list:
+    @override
+    def render(self) -> None | np.ndarray | str | list[Any]:
         return self.env.render()
 
-    def reset(self, seed: int | None = None, options: dict | None = None):
+    @override
+    def reset(self, seed: int | None = None, options: dict[str, Any] | None = None):
         self.env.reset(seed=seed, options=options)
 
+    @override
     def observe(self, agent: AgentID) -> ObsType | None:
         return self.env.observe(agent)
 
+    @override
     def state(self) -> np.ndarray:
         return self.env.state()
 
+    @override
     def step(self, action: ActionType) -> None:
         self.env.step(action)
 
+    @override
     def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space:
         return self.env.observation_space(agent)
 
+    @override
     def action_space(self, agent: AgentID) -> gymnasium.spaces.Space:
         return self.env.action_space(agent)
 
+    @override
     def __str__(self) -> str:
         """Returns a name which looks like: "max_observation<space_invaders_v1>"."""
         return f"{type(self).__name__}<{str(self.env)}>"

--- a/pettingzoo/utils/wrappers/base_parallel.py
+++ b/pettingzoo/utils/wrappers/base_parallel.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from typing import Any
+
 import gymnasium.spaces
 import numpy as np
+from typing_extensions import override
 
 from pettingzoo.utils.env import ActionType, AgentID, ObsType, ParallelEnv
 
@@ -17,11 +20,13 @@ class BaseParallelWrapper(ParallelEnv[AgentID, ObsType, ActionType]):
             raise AttributeError(f"accessing private attribute '{name}' is prohibited")
         return getattr(self.env, name)
 
+    @override
     def reset(
-        self, seed: int | None = None, options: dict | None = None
-    ) -> tuple[dict[AgentID, ObsType], dict[AgentID, dict]]:
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[dict[AgentID, ObsType], dict[AgentID, dict[str, Any]]]:
         return self.env.reset(seed=seed, options=options)
 
+    @override
     def step(
         self, actions: dict[AgentID, ActionType]
     ) -> tuple[
@@ -29,25 +34,31 @@ class BaseParallelWrapper(ParallelEnv[AgentID, ObsType, ActionType]):
         dict[AgentID, float],
         dict[AgentID, bool],
         dict[AgentID, bool],
-        dict[AgentID, dict],
+        dict[AgentID, dict[str, Any]],
     ]:
         return self.env.step(actions)
 
-    def render(self) -> None | np.ndarray | str | list:
+    @override
+    def render(self) -> None | np.ndarray | str | list[Any]:
         return self.env.render()
 
+    @override
     def close(self) -> None:
         return self.env.close()
 
     @property
-    def unwrapped(self) -> ParallelEnv:
+    @override
+    def unwrapped(self) -> ParallelEnv[AgentID, ObsType, ActionType]:
         return self.env.unwrapped
 
+    @override
     def state(self) -> np.ndarray:
         return self.env.state()
 
+    @override
     def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space:
         return self.env.observation_space(agent)
 
+    @override
     def action_space(self, agent: AgentID) -> gymnasium.spaces.Space:
         return self.env.action_space(agent)

--- a/pettingzoo/utils/wrappers/capture_stdout.py
+++ b/pettingzoo/utils/wrappers/capture_stdout.py
@@ -1,28 +1,32 @@
+from typing_extensions import override
+
 from pettingzoo.utils.capture_stdout import capture_stdout
-from pettingzoo.utils.env import AECEnv
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType
 from pettingzoo.utils.wrappers.base import BaseWrapper
 
 
-class CaptureStdoutWrapper(BaseWrapper):
+class CaptureStdoutWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
     """Takes an environment which prints to terminal, and gives it an `ansi` render mode where it captures the terminal output and returns it as a string instead."""
 
-    def __init__(self, env: AECEnv):
+    def __init__(self, env: AECEnv[AgentID, ObsType, ActionType]):
         assert isinstance(
             env, AECEnv
         ), "CaptureStdoutWrapper is only compatible with AEC environments"
         assert hasattr(env, "render_mode"), f"Environment {env} has no render_mode."
         assert (
-            env.render_mode == "human"  # type: ignore
-        ), f"CaptureStdoutWrapper works only with human rendering mode, but found {env.render_mode} instead."  # type: ignore
+            env.render_mode == "human"
+        ), f"CaptureStdoutWrapper works only with human rendering mode, but found {env.render_mode} instead."
         super().__init__(env)
         self.metadata["render_modes"].append("ansi")
         self.render_mode = "ansi"
 
+    @override
     def render(self) -> str:
         with capture_stdout() as stdout:
             super().render()
             val = stdout.getvalue()
         return val
 
+    @override
     def __str__(self) -> str:
         return str(self.env)

--- a/pettingzoo/utils/wrappers/clip_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/clip_out_of_bounds.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 from gymnasium.spaces import Box
+from typing_extensions import override
 
 from pettingzoo.utils.env import AECEnv
 from pettingzoo.utils.env_logger import EnvLogger
 from pettingzoo.utils.wrappers.base import BaseWrapper
 
 
-class ClipOutOfBoundsWrapper(BaseWrapper):
+class ClipOutOfBoundsWrapper(BaseWrapper[Any, Any, Any]):
     """Clips the input action to fit in the continuous action space (emitting a warning if it does so).
 
     Applied to continuous environments in pettingzoo.
     """
 
-    def __init__(self, env: AECEnv):
+    def __init__(self, env: AECEnv[Any, Any, Any]):
         super().__init__(env)
         assert isinstance(
             env, AECEnv
@@ -24,6 +27,7 @@ class ClipOutOfBoundsWrapper(BaseWrapper):
             for agent in getattr(self, "possible_agents", [])
         ), "should only use ClipOutOfBoundsWrapper for Box spaces"
 
+    @override
     def step(self, action: np.ndarray | None) -> None:
         space = self.action_space(self.agent_selection)
         if not (
@@ -43,12 +47,13 @@ class ClipOutOfBoundsWrapper(BaseWrapper):
                 action=action, action_space=space, backup_policy="clipping to space"
             )
             action = np.clip(
-                action,  # type: ignore
-                space.low,  # type: ignore
-                space.high,  # type: ignore
+                action,
+                space.low,
+                space.high,
             )
 
         super().step(action)
 
+    @override
     def __str__(self) -> str:
         return str(self.env)

--- a/pettingzoo/utils/wrappers/multi_episode_env.py
+++ b/pettingzoo/utils/wrappers/multi_episode_env.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import copy
+from typing import Any
 
-from pettingzoo.utils.env import ActionType, AECEnv
+from typing_extensions import override
+
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType
 from pettingzoo.utils.wrappers.base import BaseWrapper
 
 
-class MultiEpisodeEnv(BaseWrapper):
+class MultiEpisodeEnv(BaseWrapper[AgentID, ObsType, ActionType]):
     """Creates a new environment using the base environment that runs for `num_episodes` before truncating.
 
     This is useful for creating evaluation environments.
@@ -15,7 +18,7 @@ class MultiEpisodeEnv(BaseWrapper):
     The result of this wrapper is that the environment is no longer Markovian around the environment reset.
     """
 
-    def __init__(self, env: AECEnv, num_episodes: int):
+    def __init__(self, env: AECEnv[AgentID, ObsType, ActionType], num_episodes: int):
         """__init__.
 
         Args:
@@ -29,7 +32,10 @@ class MultiEpisodeEnv(BaseWrapper):
 
         self._num_episodes = num_episodes
 
-    def reset(self, seed: int | None = None, options: dict | None = None) -> None:
+    @override
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> None:
         """reset.
 
         Args:
@@ -44,6 +50,7 @@ class MultiEpisodeEnv(BaseWrapper):
         self._options = copy.deepcopy(options)
         super().reset(seed=seed, options=options)
 
+    @override
     def step(self, action: ActionType) -> None:
         """Steps the underlying environment for `num_episodes`.
 
@@ -74,6 +81,7 @@ class MultiEpisodeEnv(BaseWrapper):
         self._seed = self._seed + 1 if self._seed else None
         super().reset(seed=self._seed, options=self._options)
 
+    @override
     def __str__(self) -> str:
         """__str__.
 

--- a/pettingzoo/utils/wrappers/multi_episode_parallel_env.py
+++ b/pettingzoo/utils/wrappers/multi_episode_parallel_env.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import copy
+from typing import Any
+
+from typing_extensions import override
 
 from pettingzoo.utils.env import ActionType, AgentID, ObsType, ParallelEnv
 from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
 
 
-class MultiEpisodeParallelEnv(BaseParallelWrapper):
+class MultiEpisodeParallelEnv(BaseParallelWrapper[AgentID, ObsType, ActionType]):
     """Creates a new environment using the base environment that runs for `num_episodes` before truncating.
 
     This is useful for creating evaluation environments.
@@ -15,7 +18,9 @@ class MultiEpisodeParallelEnv(BaseParallelWrapper):
     The result of this wrapper is that the environment is no longer Markovian around the environment reset.
     """
 
-    def __init__(self, env: ParallelEnv, num_episodes: int):
+    def __init__(
+        self, env: ParallelEnv[AgentID, ObsType, ActionType], num_episodes: int
+    ):
         """__init__.
 
         Args:
@@ -29,9 +34,10 @@ class MultiEpisodeParallelEnv(BaseParallelWrapper):
 
         self._num_episodes = num_episodes
 
+    @override
     def reset(
-        self, seed: int | None = None, options: dict | None = None
-    ) -> tuple[dict[AgentID, ObsType], dict[AgentID, dict]]:
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[dict[AgentID, ObsType], dict[AgentID, dict[str, Any]]]:
         """reset.
 
         Args:
@@ -49,6 +55,7 @@ class MultiEpisodeParallelEnv(BaseParallelWrapper):
 
         return obs, info
 
+    @override
     def step(
         self, actions: dict[AgentID, ActionType]
     ) -> tuple[
@@ -56,7 +63,7 @@ class MultiEpisodeParallelEnv(BaseParallelWrapper):
         dict[AgentID, float],
         dict[AgentID, bool],
         dict[AgentID, bool],
-        dict[AgentID, dict],
+        dict[AgentID, dict[str, Any]],
     ]:
         """Steps the environment.
 

--- a/pettingzoo/utils/wrappers/order_enforcing.py
+++ b/pettingzoo/utils/wrappers/order_enforcing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+from typing_extensions import override
 
 from pettingzoo.utils.env import (
     ActionType,
@@ -36,10 +37,11 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
         self._has_updated = False
         super().__init__(env)
 
-    def __getattr__(self, value: str) -> Any:
+    @override
+    def __getattr__(self, name: str) -> Any:
         """Raises an error if certain data is accessed before reset."""
         if (
-            value
+            name
             in {
                 "rewards",
                 "terminations",
@@ -51,14 +53,16 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
             }
             and not self._has_reset
         ):
-            raise AttributeError(f"{value} cannot be accessed before reset")
-        return super().__getattr__(value)
+            raise AttributeError(f"{name} cannot be accessed before reset")
+        return super().__getattr__(name)
 
-    def render(self) -> None | np.ndarray | str | list:
+    @override
+    def render(self) -> None | np.ndarray | str | list[Any]:
         if not self._has_reset:
             EnvLogger.error_render_before_reset()
         return super().render()
 
+    @override
     def step(self, action: ActionType) -> None:
         if not self._has_reset:
             EnvLogger.error_step_before_reset()
@@ -69,16 +73,19 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
             self._has_updated = True
             super().step(action)
 
+    @override
     def observe(self, agent: AgentID) -> ObsType | None:
         if not self._has_reset:
             EnvLogger.error_observe_before_reset()
         return super().observe(agent)
 
+    @override
     def state(self) -> np.ndarray:
         if not self._has_reset:
             EnvLogger.error_state_before_reset()
         return super().state()
 
+    @override
     def agent_iter(
         self, max_iter: int = 2**63
     ) -> AECOrderEnforcingIterable[AgentID, ObsType, ActionType]:
@@ -86,11 +93,15 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
             EnvLogger.error_agent_iter_before_reset()
         return AECOrderEnforcingIterable(self, max_iter)
 
-    def reset(self, seed: int | None = None, options: dict | None = None) -> None:
+    @override
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> None:
         self._has_reset = True
         self._has_updated = True
         super().reset(seed=seed, options=options)
 
+    @override
     def __str__(self) -> str:
         if hasattr(self, "metadata"):
             return (
@@ -102,6 +113,7 @@ class OrderEnforcingWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
 
 
 class AECOrderEnforcingIterable(AECIterable[AgentID, ObsType, ActionType]):
+    @override
     def __iter__(self) -> AECOrderEnforcingIterator[AgentID, ObsType, ActionType]:
         return AECOrderEnforcingIterator(self.env, self.max_iter)
 
@@ -115,6 +127,7 @@ class AECOrderEnforcingIterator(AECIterator[AgentID, ObsType, ActionType]):
         ), "env must be wrapped by OrderEnforcingWrapper"
         super().__init__(env, max_iter)
 
+    @override
     def __next__(self) -> AgentID:
         agent = super().__next__()
         assert (

--- a/pettingzoo/utils/wrappers/terminate_illegal.py
+++ b/pettingzoo/utils/wrappers/terminate_illegal.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
+from typing_extensions import override
+
 from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType
 from pettingzoo.utils.env_logger import EnvLogger
 from pettingzoo.utils.wrappers.base import BaseWrapper
@@ -17,16 +21,20 @@ class TerminateIllegalWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
     ):
         super().__init__(env)
         self._illegal_value = illegal_reward
-        self._prev_obs = None
-        self._prev_info = None
+        self._prev_obs: Any = None
+        self._prev_info: Any = None
         self._terminated = False  # terminated by an illegal move
 
-    def reset(self, seed: int | None = None, options: dict | None = None) -> None:
+    @override
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> None:
         self._terminated = False
         self._prev_obs = None
         self._prev_info = None
         super().reset(seed=seed, options=options)
 
+    @override
     def observe(self, agent: AgentID) -> ObsType | None:
         obs = super().observe(agent)
         if agent == self.agent_selection:
@@ -37,6 +45,7 @@ class TerminateIllegalWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
                 self._prev_info = {}
         return obs
 
+    @override
     def step(self, action: ActionType) -> None:
         current_agent = self.agent_selection
         if self._prev_obs is None:
@@ -77,5 +86,6 @@ class TerminateIllegalWrapper(BaseWrapper[AgentID, ObsType, ActionType]):
         else:
             super().step(action)
 
+    @override
     def __str__(self) -> str:
         return str(self.env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.21.0",
     "gymnasium>=1.0.0",
-    "typing-extensions >=4.0.0",
+    "typing-extensions >=4.4.0",
 ]
 dynamic = ["version"]
 
@@ -118,15 +118,16 @@ exclude = [
 ]
 
 [tool.ty.rules]
-# Forgiving baseline: downgrade every rule to a warning so type checking does
-# not fail CI. Ratchet individual rules back up to "error" over time.
-all = "warn"
+# Every enabled rule is an error so type-checking failures fail CI. The set of
+# enabled rules is unchanged from the forgiving baseline (no new strictness);
+# we only promoted the existing diagnostics from "warn" to "error".
+all = "error"
 # Missing imports are not reported (third-party deps lack stubs).
 unresolved-import = "ignore"
 
 [tool.ty.terminal]
-# Don't fail (exit non-zero) on warning-level diagnostics for now.
-error-on-warning = false
+# Fail (exit non-zero) on warning-level diagnostics too.
+error-on-warning = true
 
 [tool.pytest.ini_options]
 addopts = [ "--ignore-glob=*/__init__.py", "-n=auto", "--ignore=tutorials", "--ignore=docs/_scripts", "--ignore=conf.py"]


### PR DESCRIPTION
Following #1345 and #1344 this PR changes ty and ruff from emitting warning to emit errors on CI and locally when running them. And simultaneously fixed all previous existing PRs. Next step is increasing how strict they are in a follow up PR.

<details>
<summary>Claude Code summary</summary>

## Description

Now that `ty` and `ruff` are configured, this slightly tightens enforcement: it turns the **existing** type-checker diagnostics into hard CI failures **without enabling any new rules** (no strictness-level increase) and fixes everything that surfaced.

### Config (`pyproject.toml`)
- `[tool.ty.rules]`: `all = "warn"` → `all = "error"` (same rule set, kept `unresolved-import = "ignore"`).
- `[tool.ty.terminal]`: `error-on-warning = false` → `true`.
- Bump `typing-extensions` `>=4.0.0` → `>=4.4.0` (needed for `@override` on Python 3.9).
- `ruff` already errors on its default rule set and was passing — no rule changes there.

### Fixes for the 131 surfaced diagnostics (all in `pettingzoo/utils/`)
- Add `@override` (from `typing_extensions`) to overriding methods.
- Parameterize bare generics: `dict` → `dict[str, Any]`, `list` → `list[Any]`, `Callable` → `Callable[..., Any]`, and explicit `AECEnv`/`ParallelEnv`/`BaseWrapper` type args; make a few wrappers generic to match their siblings.
- Remove dead `# type: ignore` directives flagged as unused (kept the ones still needed).
- `AgentSelector.__eq__` parameter `AgentSelector` → `object` (Liskov), and `OrderEnforcingWrapper.__getattr__` parameter `value` → `name` to match its base.
- Annotate dynamic `_prev_obs`/`_prev_info` as `Any` in `TerminateIllegalWrapper`.
- `cast(...)` for two generic-narrowing returns `ty` can't track in `conversions.py`.

### Incidental bug fix
`parallel_to_aec_wrapper.reset` had a latent crash in its malformed-infos recovery path: `{agent: {self.infos.copy()} for agent in self.agents}` built a **set** containing a dict (unhashable → `TypeError` at runtime). It now duplicates the info dict per agent, exactly as the adjacent warning message already documents.

## Verification
- `ty check` → **All checks passed!**
- `ruff check .` → **All checks passed!**
- `black --check` and `isort --check` → clean.
- Import smoke test + AEC↔Parallel conversion round-trip exercised at runtime.

## Notes for reviewers
- The change is type/annotation hardening plus one genuine bug fix; no intended behavior changes elsewhere.
- The wrappers that narrow their action type (e.g. `ClipOutOfBoundsWrapper`) intentionally use `[Any, Any, Any]` rather than the `ActionType` TypeVar, since the narrowed `step()` signature is otherwise incompatible with the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>