### PR TITLE
Fix isort import ordering to repair CI on main (#1347)

### DIFF
--- a/pettingzoo/butterfly/all_modules.py
+++ b/pettingzoo/butterfly/all_modules.py
@@ -1,6 +1,6 @@
 from pettingzoo.butterfly import (
-    knights_archers_zombies_v11,
     cooperative_pong_v6,
+    knights_archers_zombies_v11,
     pistonball_v6,
 )
 

--- a/test/all_parameter_combs_test.py
+++ b/test/all_parameter_combs_test.py
@@ -29,8 +29,8 @@ from pettingzoo.atari import (
     wizard_of_wor_v3,
 )
 from pettingzoo.butterfly import (
-    knights_archers_zombies_v11,
     cooperative_pong_v6,
+    knights_archers_zombies_v11,
     pistonball_v6,
 )
 from pettingzoo.classic import (


### PR DESCRIPTION
## Description

Fixes #1347.

CI on `main` was broken by the merge of #1297, which introduced imports that violate the project's `isort --profile black` ordering. Two files imported `pettingzoo.butterfly` submodules out of alphabetical order (`cooperative_pong_v6` placed after `knights_archers_zombies_v11`).

This PR reorders the offending imports so the isort pre-commit/CI check passes again.

## Files changed
- `pettingzoo/butterfly/all_modules.py`
- `test/all_parameter_combs_test.py`

## Verification
`isort --profile black --check-only .` now exits 0 across the repo.

## Notes for reviewers
Pure import reordering — no functional changes.