### PR TITLE
Add v9 version history entry for multiwalker

### DIFF
--- a/pettingzoo/sisl/multiwalker/multiwalker.py
+++ b/pettingzoo/sisl/multiwalker/multiwalker.py
@@ -107,6 +107,7 @@ terminate_on_fall=True, remove_on_fall=True, terrain_length=200, max_cycles=500)
 
 
 ### Version History
+* v9: Fixed reward sharing and termination logic, refactored rendering to use pygame (1.18.0)
 * v8: Replaced local_ratio, fixed rewards, terrain length as an argument and documentation (1.15.0)
 * v7: Fixed problem with walker collisions (1.8.2)
 * v6: Fixed observation space and made large improvements to code quality (1.5.0)


### PR DESCRIPTION
## Description

Fixes #1349.

The `multiwalker` module is `multiwalker_v9`, but its version history (in the module docstring, which the documentation site is generated from) stopped at `v8`. As a result the v9 entry was missing both in the file and on the docs site.

This adds the missing entry:

```
* v9: Fixed reward sharing and termination logic, refactored rendering to use pygame (1.18.0)
```

The v9 bump (commit `132f101f`) first shipped in PettingZoo 1.18.0, following the reward/termination-logic fix (`c8b00735`) and the pyglet→pygame rendering refactor (`194d4439`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)