### PR TITLE
Add Python versions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Python](https://img.shields.io/pypi/pyversions/pettingzoo.svg)](https://badge.fury.io/py/pettingzoo) [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 <p align="center">
     <a href = "https://pettingzoo.farama.org/" target = "_blank"><img src="https://raw.githubusercontent.com/Farama-Foundation/PettingZoo/master/pettingzoo-text.png" width="500px"/> </a>


### PR DESCRIPTION
## Description

Adds a shields.io PyPI `pyversions` badge to the top of the README, so the supported Python versions are displayed automatically and stay current without manual maintenance. This matches the widget Gymnasium uses.

```markdown
[![Python](https://img.shields.io/pypi/pyversions/pettingzoo.svg)](https://badge.fury.io/py/pettingzoo)
```

The badge pulls version metadata from PyPI (currently 3.9–3.14, per `pyproject.toml`) and is placed alongside the existing pre-commit and black badges.

Closes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)