### PR TITLE
Hanabi: finish OpenSpiel/Shimmy migration cleanup

### DIFF
--- a/pettingzoo/classic/hanabi/hanabi.py
+++ b/pettingzoo/classic/hanabi/hanabi.py
@@ -161,7 +161,7 @@ If an illegal action is taken, the game terminates and the one player that took 
 
 """
 
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import gymnasium
 import numpy as np
@@ -243,9 +243,8 @@ class raw_env(AECEnv, EzPickle):
                 "players": 2,
                 "max_information_tokens": 8,
                 "max_life_tokens": 3,
-                "hand_size": (4 if players >= 4 else 5)
+                "hand_size": 5,
                 "observation_type": "card_knowledge",
-                "hand_size": 2,
                 }
 
             Hanabi-Small : {
@@ -282,7 +281,6 @@ class raw_env(AECEnv, EzPickle):
             render_mode=render_mode,
         )
 
-        # ToDo: Starts
         # Check if all possible dictionary values are within a certain ranges.
         self._raise_error_if_config_values_out_of_range(
             colors,
@@ -404,13 +402,12 @@ class raw_env(AECEnv, EzPickle):
         mask = self.hanabi_env.infos[self.agent_selection]["action_mask"]
         return [i for i in range(len(mask))]
 
-    # ToDo: Fix Return value
     def reset(self, seed=None, options=None):
-        """Resets the environment for a new game and returns observations of current player as List of ints.
+        """Resets the environment for a new game.
 
-        Returns:
-            observation: Optional list of integers of length self.observation_vector_dim, describing observations of
-            current agent (agent_selection).
+        Resets the underlying OpenSpiel (Shimmy) environment and re-initializes the
+        agent iteration order. Follows the AEC API and returns nothing; the current
+        agent's observation is available via `observe`/`last`.
         """
         self.agents = self.possible_agents[:]
 
@@ -436,7 +433,6 @@ class raw_env(AECEnv, EzPickle):
         self.rewards = self.hanabi_env.rewards
         self._cumulative_rewards = self.hanabi_env._cumulative_rewards
         self.agent_selection = self.hanabi_env.agent_selection
-        self.rewards = self.hanabi_env.rewards
         self.terminations = self.hanabi_env.terminations
         self.truncations = self.hanabi_env.truncations
         self.infos = self.hanabi_env.infos
@@ -444,15 +440,12 @@ class raw_env(AECEnv, EzPickle):
         self._agent_selector = AgentSelector(self.agents)
         self.agent_selection = self._agent_selector.reset()
 
-    def step(
-        self, action: int, observe: bool = True, as_vector: bool = True
-    ) -> Optional[Union[np.ndarray, List[List[dict]]]]:
-        """Advances the environment by one step. Action must be within self.legal_moves, otherwise throws error.
+    def step(self, action: int) -> None:
+        """Advances the environment by one step.
 
-        Returns:
-            observation: Optional List of new observations of agent at turn after the action step is performed.
-            By default, a list of integers, describing the logic state of the game from the view of the agent.
-            Can be a returned as a descriptive dictionary, if as_vector=False.
+        Action must be within `self.legal_moves`; illegal moves are handled by the
+        surrounding wrappers. Follows the AEC API and returns nothing; the next
+        agent's observation is available via `observe`/`last`.
         """
         if (
             self.terminations[self.agent_selection]
@@ -471,9 +464,9 @@ class raw_env(AECEnv, EzPickle):
         if self.render_mode is not None:
             self.render()
 
-    def observe(self, agent_name: str):
-        observation = self.hanabi_env.observe(agent_name)
-        mask = self.infos[agent_name]["action_mask"]
+    def observe(self, agent: str):
+        observation = self.hanabi_env.observe(agent)
+        mask = self.infos[agent]["action_mask"]
         return {"observation": observation, "action_mask": mask}
 
     def render(self):


### PR DESCRIPTION
# Description

The Hanabi environment was migrated off the unmaintained [`hanabi-learning-environment`](https://github.com/Farama-Foundation/hanabi-learning-environment) fork onto OpenSpiel (via the Shimmy `OpenSpielCompatibilityV0` wrapper) in #948, which introduced `hanabi_v5`. That migration left behind dead code and docstrings that still describe the old backend's behavior. This PR finishes that cleanup — no change to game dynamics.

Changes in `pettingzoo/classic/hanabi/hanabi.py`:

- **`step()`**: removed the non-functional `observe=True, as_vector=True` parameters (silently ignored ever since the OpenSpiel switch) and the bogus `Optional[Union[np.ndarray, List[List[dict]]]]` return annotation. `step` now matches the AEC API — `step(self, action) -> None` — which also fixes an incompatible-override type mismatch against `AECEnv.step`.
- **`observe()`**: renamed `agent_name` → `agent` to match `AECEnv.observe(self, agent)` (was another override mismatch).
- Removed stale `# ToDo: Starts` and `# ToDo: Fix Return value` comments.
- Removed a duplicate `self.rewards = self.hanabi_env.rewards` assignment in `reset()`.
- Rewrote the `reset()`/`step()` docstrings, which described return values the methods no longer produce.
- Fixed the `Hanabi-Full` docstring config example, which had contradictory duplicate `hand_size` keys (`(4 if players >= 4 else 5)` plus a stray `"hand_size": 2`).
- Dropped the now-unused `Union` import.

Fixes #1333

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (the env docs page is generated from the module docstring, so the docstring fixes propagate automatically)

> Note: `step()` and `observe()` signatures changed. The removed `step` kwargs were already inert (ignored since the v5 backend swap), so this is not a behavioral break, but a caller passing `step(action, observe=..., as_vector=...)` by keyword would now raise `TypeError`.

# Checklist:

- [x] I have run the `pre-commit` checks (black, isort, ruff, pydocstyle all pass on the changed file)
- [x] I have run `pytest -v` and no errors are present (verified via `api_test` and `seed_test` across default, 3/4/5-player, seer, minimal, and small-game configs)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (docstring is the docs source)
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works (existing `hanabi_v5` tests cover the change; no new behavior added)
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)