### PR TITLE
Fix broken pygame init test on main (knights_archers_zombies)

### DIFF
--- a/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
+++ b/pettingzoo/butterfly/knights_archers_zombies/knights_archers_zombies.py
@@ -773,9 +773,8 @@ class raw_env(AECEnv[AgentID, ObsType, ActionType], EzPickle):
 
     def _get_screen(self) -> pygame.Surface:
         """Return a newly created pygame surface as the display screen."""
-        pygame.init()
-
         if self.render_mode == "human":
+            pygame.display.init()
             screen = pygame.display.set_mode(self.screen_dims)
             pygame.display.set_caption("Knights, Archers, Zombies")
             return screen

--- a/test/pygame_init_test.py
+++ b/test/pygame_init_test.py
@@ -6,7 +6,7 @@ import pytest
 
 from pettingzoo.butterfly import (
     cooperative_pong_v6,
-    knights_archers_zombies_v10,
+    knights_archers_zombies_v11,
     pistonball_v6,
 )
 from pettingzoo.classic import (
@@ -23,7 +23,7 @@ from pettingzoo.sisl import multiwalker_v9, pursuit_v4
 
 pygame_envs = [
     cooperative_pong_v6,
-    knights_archers_zombies_v10,
+    knights_archers_zombies_v11,
     pistonball_v6,
     chess_v6,
     connect_four_v3,


### PR DESCRIPTION
# Description

Fixes the broken CI on `main` reported in https://github.com/Farama-Foundation/PettingZoo/pull/1336#issuecomment-4790432566 (maintainer suggested a small separate PR).

Two related problems:

1. **Stale env version in the test.** `test/pygame_init_test.py` imported and parametrized over the deprecated `knights_archers_zombies_v10`. Since #1297 bumped KAZ to v11, collection raised `DeprecatedEnv` and the test never ran. Updated both references to `knights_archers_zombies_v11`.

2. **KAZ initialized pygame subsystems without rendering.** Once the version was fixed, `test_no_pygame_subsystem_init_without_rendering` and `test_rgb_array_render_does_not_init_audio` failed for KAZ:

   - `_get_screen()` called full `pygame.init()` on every `reinit()` (i.e. every `reset()`), starting the display, audio mixer, font and joystick subsystems regardless of `render_mode`.
   - PR #1343 applied the per-subsystem init fix to `render()` but missed `_get_screen()`.

   Replaced the unconditional `pygame.init()` with `pygame.display.init()` only in the `human` render path, matching `render()` and the other butterfly envs. The `rgb_array`/`None` paths only need a plain `pygame.Surface` — KAZ sprites are built with `SRCALPHA` surfaces (see `src/img.py`), not `convert`/`convert_alpha`, so no display is required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run `pytest -v` and no errors are present.
- [x] New and existing unit tests pass locally with my changes

`test/pygame_init_test.py` (26 cases) and the KAZ test suite (`test_kaz.py`, 26 cases) pass locally, and `rgb_array`/`human` rendering still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)