### PR TITLE
Add import error redirecting MPE users to the MPE2 package

### DIFF
--- a/pettingzoo/mpe/README.md
+++ b/pettingzoo/mpe/README.md
@@ -1,0 +1,1 @@
+MPE has been moved into its own package: MPE2. Install with `pip install mpe2`. For more information on the MPE2 package, see https://mpe2.farama.org/.

--- a/pettingzoo/mpe/__init__.py
+++ b/pettingzoo/mpe/__init__.py
@@ -1,0 +1,3 @@
+raise ImportError(
+    "MPE has been moved into its own package: MPE2. Install with `pip install mpe2`. For more information on the MPE2 package, see https://mpe2.farama.org/."
+)


### PR DESCRIPTION
# Description

MPE was fully removed from PettingZoo and now lives in its own [`mpe2`](https://mpe2.farama.org/) package. Previously, `import pettingzoo.mpe` (or `from pettingzoo.mpe import ...`) produced a bare `ModuleNotFoundError` with no guidance.

This adds a `pettingzoo/mpe` package whose import raises an `ImportError` pointing users to `pip install mpe2` and https://mpe2.farama.org/, mirroring the existing MAgent → MAgent2 redirect in `pettingzoo/magent/__init__.py`.

This is the approach the maintainers planned for: the last pre-removal `pettingzoo/mpe/__init__.py` carried a `TODO` to "raise a warning instead of importing the environments" once the envs were removed, and the completed MAgent migration uses the same `raise ImportError` pattern. A soft `DeprecationWarning` is not viable here because the code is gone — the import fails regardless, so a hard error with a helpful message is the only meaningful behavior.

Fixes #1357

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes