### PR TITLE
Remove Python 3.9 support

### DIFF
--- a/.github/workflows/docs-versioning.yml
+++ b/.github/workflows/docs-versioning.yml
@@ -16,7 +16,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-python@v4
               with:
-                  python-version: '3.9'
+                  python-version: '3.11'
             - name: Get tag
               id: tag
               uses: dawidd6/action-get-tag@v1

--- a/.github/workflows/linux-test.yml
+++ b/.github/workflows/linux-test.yml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+                python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
 
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+                python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
                 tutorial: [Tianshou, CustomEnvironment, CleanRL, SB3/connect_four, SB3/kaz, SB3/test]  # TODO: fix tutorials and add back Ray.
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -15,7 +15,7 @@ jobs:
             matrix:
             # Big Sur, Monterey
                 os: [macos-11, macos-12]
-                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+                python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -11,7 +11,7 @@ This does not include dependencies for all families of environments (some enviro
 
 To install the dependencies for one family, use `pip install 'pettingzoo[atari]'`, or use `pip install 'pettingzoo[all]'` to install all dependencies.
 
-We support and maintain PettingZoo for Python 3.9, 3.10, 3.11, and 3.12 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+We support and maintain PettingZoo for Python 3.10, 3.11, 3.12, 3.13, and 3.14 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 
 ## Initializing Environments
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "pettingzoo"
 description = "Gymnasium for multi-agent reinforcement learning."
 readme = "README.md"
-requires-python = ">= 3.9, <3.15"
+requires-python = ">= 3.10, <3.15"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "game", "RL", "AI", "gymnasium"]
@@ -16,7 +16,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -86,7 +85,7 @@ include = ["pettingzoo", "pettingzoo.*"]
 # historical black formatting. Linting uses only the default rule set
 # (pyflakes `F` and a subset of pycodestyle `E`); E501 is not enabled.
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 # Default ruff rules (E4, E7, E9, F) plus `I` for import sorting (replaces


### PR DESCRIPTION
Closes #1358

Removes Python 3.9 from the supported versions.

## What changed
- **`pyproject.toml`**: `requires-python` → `>= 3.10, <3.15`, dropped the `Python :: 3.9` classifier, ruff `target-version` → `py310`
- **CI test matrices** (`linux-test.yml`, `macos-test.yml`, `linux-tutorials-test.yml`): removed `'3.9'`
- **`docs-versioning.yml`**: bumped its pinned `3.9` build to `3.11`
- **`docs/content/basic_usage.md`**: updated the supported-versions line to `3.10, 3.11, 3.12, 3.13, and 3.14` (the old text was also stale, capping at 3.12)

## Notes
- No runtime code referenced 3.9 (no `sys.version_info` guards or `python_requires` in `pettingzoo/`/`setup.py`), so only metadata/CI/docs changed.
- The `open_spiel ... python_version >= '3.11'` dependency marker is unaffected.