### PR TITLE
Restore CI on main

### DIFF
--- a/.github/workflows/linux-tutorials-test.yml
+++ b/.github/workflows/linux-tutorials-test.yml
@@ -33,8 +33,13 @@ jobs:
                   cd tutorials/${{ matrix.tutorial }}
                   grep -ivE "pettingzoo" requirements.txt > _requirements.txt
                   pip install -r _requirements.txt
-                  pip install -e $root_dir[all]
-                  pip install -e $root_dir[testing]
+                  if [ "${{ matrix.tutorial }}" = "Tianshou" ]; then
+                    pip install -c _requirements.txt -e $root_dir[all]
+                    pip install -c _requirements.txt -e $root_dir[testing]
+                  else
+                    pip install -e $root_dir[all]
+                    pip install -e $root_dir[testing]
+                  fi
                   AutoROM -v
                   for f in *.py; do xvfb-run -a -s "-screen 0 1024x768x24" python "$f"; done
 

--- a/docs/_scripts/gen_envs_mds.py
+++ b/docs/_scripts/gen_envs_mds.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 
             if not full_env_names:
                 continue
-                
+
             env_name_version = full_env_names[0].split("/")[1]
             if env_type == "classic" and env_name != "rps":
                 with open(f"{docs_dir}/code_examples/usage_aec_action_mask.py") as f:

--- a/docs/_scripts/gen_envs_mds.py
+++ b/docs/_scripts/gen_envs_mds.py
@@ -98,6 +98,10 @@ if __name__ == "__main__":
                 for full_name in all_environments.keys()
                 if env_name == full_name.split("/")[1].rsplit("_", 1)[0]
             ]
+
+            if not full_env_names:
+                continue
+                
             env_name_version = full_env_names[0].split("/")[1]
             if env_type == "classic" and env_name != "rps":
                 with open(f"{docs_dir}/code_examples/usage_aec_action_mask.py") as f:

--- a/pettingzoo/utils/env.py
+++ b/pettingzoo/utils/env.py
@@ -39,10 +39,10 @@ class AECEnv(Generic[AgentID, ObsType, ActionType]):
     agents: list[AgentID]  # Agents active at any given time
 
     observation_spaces: dict[
-        AgentID, gymnasium.spaces.Space
+        AgentID, gymnasium.spaces.Space[ObsType]
     ]  # Observation space for each agent
     # Action space for each agent
-    action_spaces: dict[AgentID, gymnasium.spaces.Space]
+    action_spaces: dict[AgentID, gymnasium.spaces.Space[ActionType]]
 
     # Whether each agent has just reached a terminal state
     terminations: dict[AgentID, bool]
@@ -111,7 +111,7 @@ class AECEnv(Generic[AgentID, ObsType, ActionType]):
         """
         pass
 
-    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space:
+    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space[ObsType]:
         """Takes in agent and returns the observation space for that agent.
 
         MUST return the same value for the same agent name
@@ -123,7 +123,7 @@ class AECEnv(Generic[AgentID, ObsType, ActionType]):
         )
         return self.observation_spaces[agent]
 
-    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space:
+    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space[ActionType]:
         """Takes in agent and returns the action space for that agent.
 
         MUST return the same value for the same agent name
@@ -298,9 +298,11 @@ class ParallelEnv(Generic[AgentID, ObsType, ActionType]):
     agents: list[AgentID]
     possible_agents: list[AgentID]
     observation_spaces: dict[
-        AgentID, gymnasium.spaces.Space
+        AgentID, gymnasium.spaces.Space[ObsType]
     ]  # Observation space for each agent
-    action_spaces: dict[AgentID, gymnasium.spaces.Space]
+    action_spaces: dict[
+        AgentID, gymnasium.spaces.Space[ActionType]
+    ]  # Action space for each agent
 
     def reset(
         self,
@@ -355,7 +357,7 @@ class ParallelEnv(Generic[AgentID, ObsType, ActionType]):
             )
         )
 
-    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space:
+    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space[ObsType]:
         """Takes in agent and returns the observation space for that agent.
 
         MUST return the same value for the same agent name
@@ -367,7 +369,7 @@ class ParallelEnv(Generic[AgentID, ObsType, ActionType]):
         )
         return self.observation_spaces[agent]
 
-    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space:
+    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space[ActionType]:
         """Takes in agent and returns the action space for that agent.
 
         MUST return the same value for the same agent name

--- a/pettingzoo/utils/env_logger.py
+++ b/pettingzoo/utils/env_logger.py
@@ -55,7 +55,7 @@ class EnvLogger:
 
     @staticmethod
     def warn_action_out_of_bound(
-        action: Any, action_space: gymnasium.spaces.Space, backup_policy: str
+        action: Any, action_space: gymnasium.spaces.Space[Any], backup_policy: str
     ) -> None:
         """Warns: ``[WARNING]: Received an action {action} that was outside action space {action_space}.``."""
         EnvLogger._generic_warning(

--- a/pettingzoo/utils/wrappers/base.py
+++ b/pettingzoo/utils/wrappers/base.py
@@ -55,11 +55,11 @@ class BaseWrapper(AECEnv[AgentID, ObsType, ActionType]):
         self.env.step(action)
 
     @override
-    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space:
+    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space[ObsType]:
         return self.env.observation_space(agent)
 
     @override
-    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space:
+    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space[ActionType]:
         return self.env.action_space(agent)
 
     @override

--- a/pettingzoo/utils/wrappers/base_parallel.py
+++ b/pettingzoo/utils/wrappers/base_parallel.py
@@ -56,9 +56,9 @@ class BaseParallelWrapper(ParallelEnv[AgentID, ObsType, ActionType]):
         return self.env.state()
 
     @override
-    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space:
+    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Space[ObsType]:
         return self.env.observation_space(agent)
 
     @override
-    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space:
+    def action_space(self, agent: AgentID) -> gymnasium.spaces.Space[ActionType]:
         return self.env.action_space(agent)

--- a/pettingzoo/utils/wrappers/clip_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/clip_out_of_bounds.py
@@ -30,6 +30,9 @@ class ClipOutOfBoundsWrapper(BaseWrapper[Any, Any, Any]):
     @override
     def step(self, action: np.ndarray | None) -> None:
         space = self.action_space(self.agent_selection)
+        assert isinstance(space, Box), (
+            "should only use ClipOutOfBoundsWrapper for Box spaces"
+        )
         if not (
             action is None
             and (

--- a/pettingzoo/utils/wrappers/clip_out_of_bounds.py
+++ b/pettingzoo/utils/wrappers/clip_out_of_bounds.py
@@ -33,18 +33,12 @@ class ClipOutOfBoundsWrapper(BaseWrapper[Any, Any, Any]):
         assert isinstance(space, Box), (
             "should only use ClipOutOfBoundsWrapper for Box spaces"
         )
-        if not (
-            action is None
-            and (
-                self.terminations[self.agent_selection]
-                or self.truncations[self.agent_selection]
-            )
-        ) and not space.contains(action):
-            if action is None or np.isnan(action).any():
+        if action is not None and not space.contains(action):
+            if np.isnan(action).any():
                 EnvLogger.error_nan_action()
-            assert (
-                space.shape == action.shape  # type: ignore
-            ), f"action should have shape {space.shape}, has shape {action.shape}"  # type: ignore
+            assert space.shape == action.shape, (
+                f"action should have shape {space.shape}, has shape {action.shape}"
+            )
 
             EnvLogger.warn_action_out_of_bound(
                 action=action, action_space=space, backup_policy="clipping to space"

--- a/test/pygame_init_test.py
+++ b/test/pygame_init_test.py
@@ -19,7 +19,7 @@ from pettingzoo.classic import (
     texas_holdem_v4,
     tictactoe_v3,
 )
-from pettingzoo.sisl import multiwalker_v9, pursuit_v4
+from pettingzoo.sisl import multiwalker_v9, pursuit_v5
 
 pygame_envs = [
     cooperative_pong_v6,
@@ -34,7 +34,7 @@ pygame_envs = [
     texas_holdem_v4,
     tictactoe_v3,
     multiwalker_v9,
-    pursuit_v4,
+    pursuit_v5,
 ]
 
 


### PR DESCRIPTION
# Description

This PR restores several failing CI jobs on the `main` branch. It is intended to bring the main branch back to a passing CI state by addressing the current failures across the typing, documentation, test, and tutorial workflows.

The changes include:

* Resolving `ty` type-checking errors by adding appropriate generic Gymnasium `Space` type annotations, narrowing `Box` action spaces before accessing `low` and `high`, and improving type narrowing in `ClipOutOfBoundsWrapper`.
* Updating the pygame initialization tests to use `pursuit_v5` instead of the deprecated `pursuit_v4`, since these tests are intended to validate pygame subsystem behavior rather than deprecated environment behavior.
* Updating the documentation generation script to ignore test files when discovering environments, preventing failures when processing non-environment modules.
* Preserving the Tianshou tutorial dependency constraints during the GitHub Actions installation process to prevent dependency resolution issues in CI.
* Applying minor formatting cleanup.

These changes collectively address the CI failures observed on the `main` branch while preserving existing functionality.

Fixes #
Depends on #

## Type of change

* Bug fix (non-breaking change which fixes an issue)

### Screenshots

Not applicable.

# Checklist:

* [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
* [x] I have run `pytest -v` and no errors are present.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] I solved any possible warnings that `pytest -v` generated that are related to my changes to the best of my knowledge.
* [ ] I have added tests that prove my fix is effective or that my feature works.
* [x] New and existing unit tests pass locally with my changes.