### PR TITLE
feat: add gymnasium-like registry feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ from pettingzoo.butterfly import pistonball_v6
 env = pistonball_v6.env()
 ```
 
+or with the new Gymnasium-like registry:
+
+```python
+from pettingzoo import make
+env = make("aec", "butterfly/pistonball_v6")
+```
+
 Environments can be interacted with in a manner very similar to Gymnasium:
 
 ```python

--- a/pettingzoo/__init__.py
+++ b/pettingzoo/__init__.py
@@ -1,11 +1,28 @@
 import os
 import sys
 
+# This import also populate registries with built-in environments
+from pettingzoo.env_registry.registration import (
+    EnvSpec,
+    aec_registry,
+    make,
+    parallel_registry,
+    pprint_registry,
+    register,
+    spec,
+)
 from pettingzoo.utils import AECEnv, ParallelEnv
 
 __all__ = [
     "AECEnv",
+    "EnvSpec",
     "ParallelEnv",
+    "aec_registry",
+    "make",
+    "parallel_registry",
+    "pprint_registry",
+    "register",
+    "spec",
 ]
 # Initializing pygame initializes audio connections through SDL. SDL uses alsa by default on all Linux systems
 # SDL connecting to alsa frequently create these giant lists of warnings every time you import an environment using pygame

--- a/pettingzoo/env_registry/__init__.py
+++ b/pettingzoo/env_registry/__init__.py
@@ -1,0 +1,108 @@
+"""
+Built-in environment registration for PettingZoo.
+
+Importing this module populates the AEC and parallel registries with all
+built-in environments. This mimics Gymnasium's API design.
+"""
+
+from pettingzoo.env_registry.registration import register
+
+# Atari environments
+
+_atari_envs = [
+    "basketball_pong_v3",
+    "boxing_v2",
+    "combat_plane_v2",
+    "combat_tank_v2",
+    "double_dunk_v3",
+    "entombed_competitive_v3",
+    "entombed_cooperative_v3",
+    "flag_capture_v2",
+    "foozpong_v3",
+    "ice_hockey_v2",
+    "joust_v3",
+    "mario_bros_v3",
+    "maze_craze_v3",
+    "othello_v3",
+    "pong_v3",
+    "quadrapong_v4",
+    "space_invaders_v2",
+    "space_war_v2",
+    "surround_v2",
+    "tennis_v3",
+    "video_checkers_v4",
+    "volleyball_pong_v3",
+    "warlords_v3",
+    "wizard_of_wor_v3",
+]
+
+for _name in _atari_envs:
+    _base = _name.rsplit("_v", 1)[0]
+    register(
+        "aec", f"atari/{_name}", entry_point=f"pettingzoo.atari.{_base}.{_base}:env"
+    )
+    register(
+        "parallel",
+        f"atari/{_name}",
+        entry_point=f"pettingzoo.atari.{_base}.{_base}:parallel_env",
+    )
+
+# Butterfly environments
+
+_butterfly_envs = [
+    ("knights_archers_zombies_v11", "knights_archers_zombies"),
+    ("pistonball_v6", "pistonball"),
+    ("cooperative_pong_v6", "cooperative_pong"),
+]
+
+for _id, _base in _butterfly_envs:
+    register(
+        "aec",
+        f"butterfly/{_id}",
+        entry_point=f"pettingzoo.butterfly.{_base}.{_base}:env",
+    )
+    register(
+        "parallel",
+        f"butterfly/{_id}",
+        entry_point=f"pettingzoo.butterfly.{_base}.{_base}:parallel_env",
+    )
+
+# Classic environments
+
+_classic_envs = [
+    ("chess_v6", "chess"),
+    ("rps_v2", "rps"),
+    ("connect_four_v3", "connect_four"),
+    ("tictactoe_v3", "tictactoe"),
+    ("leduc_holdem_v4", "leduc_holdem"),
+    ("texas_holdem_v4", "texas_holdem"),
+    ("texas_holdem_no_limit_v6", "texas_holdem_no_limit"),
+    ("gin_rummy_v5", "gin_rummy"),
+    ("go_v5", "go"),
+    ("hanabi_v5", "hanabi"),
+]
+
+for _id, _base in _classic_envs:
+    register(
+        "aec", f"classic/{_id}", entry_point=f"pettingzoo.classic.{_base}.{_base}:env"
+    )
+    register(
+        "parallel",
+        f"classic/{_id}",
+        entry_point=f"pettingzoo.classic.{_base}.{_base}:parallel_env",
+    )
+
+# SISL environments
+
+_sisl_envs = [
+    ("multiwalker_v9", "multiwalker"),
+    ("pursuit_v5", "pursuit"),
+]
+
+for _id, _base in _sisl_envs:
+    register("aec", f"sisl/{_id}", entry_point=f"pettingzoo.sisl.{_base}.{_base}:env")
+    register(
+        "parallel",
+        f"sisl/{_id}",
+        entry_point=f"pettingzoo.sisl.{_base}.{_base}:parallel_env",
+    )

--- a/pettingzoo/env_registry/exceptions.py
+++ b/pettingzoo/env_registry/exceptions.py
@@ -1,0 +1,21 @@
+"""Custom exceptions for the PettingZoo registry."""
+
+
+class PettingZooRegistryError(Exception):
+    """Base exception for PettingZoo registry."""
+
+
+class NamespaceNotFound(PettingZooRegistryError):
+    """Raised when an environment namespace is not found in the registry."""
+
+
+class NameNotFound(PettingZooRegistryError):
+    """Raised when an environment name is not found in the registry."""
+
+
+class VersionNotFound(PettingZooRegistryError):
+    """Raised when an environment version is not found in the registry."""
+
+
+class FailedToImport(PettingZooRegistryError):
+    """Raised when an environment fails to import."""

--- a/pettingzoo/env_registry/helpers.py
+++ b/pettingzoo/env_registry/helpers.py
@@ -1,0 +1,84 @@
+"""Registry lookup and version resolution helpers."""
+
+from functools import lru_cache
+
+from pettingzoo.env_registry.exceptions import (
+    NameNotFound,
+    NamespaceNotFound,
+    VersionNotFound,
+)
+from pettingzoo.env_registry.spec import EnvSpec, _parse_env_id
+
+
+def find_spec(registry: dict[str, "EnvSpec"], env_id: str) -> "EnvSpec":
+    """Look up an EnvSpec in a registry, resolving unversioned IDs to the latest version."""
+    namespace, name, version = _parse_env_id(env_id)
+
+    if version is not None:
+        full_id = _get_env_id(namespace, name, version)
+        if full_id in registry:
+            return registry[full_id]
+        # Check if the env name exists at all
+        highest = _find_highest_version(registry, namespace, name)
+        if highest is not None:
+            raise VersionNotFound(
+                f"Environment version v{version} for {_get_env_id(namespace, name, None)!r} "
+                f"not found. Available version: v{highest}"
+            )
+        # Check namespace
+        if namespace is not None:
+            ns_exists = any(s.namespace == namespace for s in registry.values())
+            if not ns_exists:
+                raise NamespaceNotFound(
+                    f"Namespace {namespace!r} not found in registry."
+                )
+        raise NameNotFound(
+            f"Environment {env_id!r} not found in registry. "
+            f"Available environments: {list(registry.keys())}"
+        )
+
+    # No version specified — resolve to highest
+    highest = _find_highest_version(registry, namespace, name)
+    if highest is not None:
+        full_id = _get_env_id(namespace, name, highest)
+        return registry[full_id]
+
+    # No versioned env found; try unversioned exact match
+    unversioned_id = _get_env_id(namespace, name, None)
+    if unversioned_id in registry:
+        return registry[unversioned_id]
+
+    if namespace is not None:
+        ns_exists = any(s.namespace == namespace for s in registry.values())
+        if not ns_exists:
+            raise NamespaceNotFound(f"Namespace {namespace!r} not found in registry.")
+    raise NameNotFound(
+        f"Environment {env_id!r} not found in registry. "
+        f"Available environments: {list(registry.keys())}"
+    )
+
+
+@lru_cache(typed=True)
+def _get_env_id(namespace: str | None, name: str, version: int | None) -> str:
+    """Reconstruct a full environment ID from its components."""
+    env_id = namespace + "/" if namespace else ""
+    env_id += name
+    if version is not None:
+        env_id += f"-v{version}"
+    return env_id
+
+
+def _find_highest_version(
+    registry: dict[str, "EnvSpec"], namespace: str | None, name: str
+) -> int | None:
+    """Find the highest registered version for a given env name in a registry."""
+    highest: int | None = None
+    for spec in registry.values():
+        if (
+            spec.namespace == namespace
+            and spec.name == name
+            and spec.version is not None
+        ):
+            if highest is None or spec.version > highest:
+                highest = spec.version
+    return highest

--- a/pettingzoo/env_registry/registration.py
+++ b/pettingzoo/env_registry/registration.py
@@ -3,6 +3,7 @@
 import warnings
 from collections.abc import Callable
 from copy import deepcopy
+from functools import lru_cache
 from typing import Any, Literal, overload
 
 from pettingzoo.env_registry.exceptions import FailedToImport
@@ -14,14 +15,6 @@ from pettingzoo.utils.env import AECEnv, ParallelEnv
 # Two separate registries for AEC and Parallel
 aec_registry: dict[str, EnvSpec] = {}
 parallel_registry: dict[str, EnvSpec] = {}
-
-
-def _get_registry(env_type: EnvType) -> dict[str, EnvSpec]:
-    if env_type == "aec":
-        return aec_registry
-    if env_type == "parallel":
-        return parallel_registry
-    raise ValueError(f"Invalid env_type: {env_type!r}. Must be 'aec' or 'parallel'.")
 
 
 @overload
@@ -179,3 +172,12 @@ def pprint_registry() -> None:
     print("\nParallel environments:")
     for env_id in sorted(parallel_registry.keys()):
         print(f"  {env_id}")
+
+
+@lru_cache(maxsize=2)
+def _get_registry(env_type: EnvType) -> dict[str, EnvSpec]:
+    if env_type == "aec":
+        return aec_registry
+    if env_type == "parallel":
+        return parallel_registry
+    raise ValueError(f"Invalid env_type: {env_type!r}. Must be 'aec' or 'parallel'.")

--- a/pettingzoo/env_registry/registration.py
+++ b/pettingzoo/env_registry/registration.py
@@ -1,0 +1,181 @@
+"""Functions for registering environments within PettingZoo: ``make``, ``register`` and ``spec``."""
+
+import warnings
+from collections.abc import Callable
+from copy import deepcopy
+from typing import Any, Literal, overload
+
+from pettingzoo.env_registry.exceptions import FailedToImport
+from pettingzoo.env_registry.helpers import find_spec
+from pettingzoo.env_registry.spec import EnvSpec, _load_env_creator
+from pettingzoo.env_registry.types import EnvType, _AECEnv, _ParallelEnv
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+
+# Two separate registries for AEC and Parallel
+aec_registry: dict[str, EnvSpec] = {}
+parallel_registry: dict[str, EnvSpec] = {}
+
+
+def _get_registry(env_type: EnvType) -> dict[str, EnvSpec]:
+    if env_type == "aec":
+        return aec_registry
+    if env_type == "parallel":
+        return parallel_registry
+    raise ValueError(f"Invalid env_type: {env_type!r}. Must be 'aec' or 'parallel'.")
+
+
+@overload
+def register(
+    env_type: Literal["aec"],
+    id: str,
+    entry_point: Callable[..., _AECEnv] | str | None = ...,
+    *,
+    max_cycles: int | None = ...,
+    kwargs: dict[str, Any] | None = ...,
+) -> None: ...
+
+
+@overload
+def register(
+    env_type: Literal["parallel"],
+    id: str,
+    entry_point: Callable[..., _ParallelEnv] | str | None = ...,
+    *,
+    max_cycles: int | None = ...,
+    kwargs: dict[str, Any] | None = ...,
+) -> None: ...
+
+
+def register(
+    env_type: EnvType,
+    id: str,
+    entry_point: Callable[..., Any] | str | None = None,
+    *,
+    max_cycles: int | None = None,
+    kwargs: dict[str, Any] | None = None,
+) -> None:
+    """Register an environment in the appropriate registry.
+
+    Args:
+        env_type: Either ``"aec"`` or ``"parallel"``.
+        id: The environment ID in format ``[namespace/]EnvName[-vN]``.
+        entry_point: A callable or ``"module:attr"`` string that creates the env.
+        max_cycles: Default maximum number of cycles before the environment truncates.
+            Passed as ``max_cycles`` kwarg to the entry point if the environment
+            supports it.
+        kwargs: Default keyword arguments passed to the entry point.
+    """
+    registry = _get_registry(env_type)
+    new_spec = EnvSpec(
+        id=id,
+        entry_point=entry_point,
+        kwargs=kwargs if kwargs is not None else {},
+        max_cycles=max_cycles,
+    )
+    if new_spec.id in registry:
+        warnings.warn(
+            f"Overriding environment {new_spec.id!r} in the {env_type} registry.",
+            stacklevel=2,
+        )
+    registry[new_spec.id] = new_spec
+
+
+@overload
+def make(
+    env_type: Literal["aec"],
+    id: str | EnvSpec,
+    *,
+    max_cycles: int | None = ...,
+    **kwargs: Any,
+) -> _AECEnv: ...
+
+
+@overload
+def make(
+    env_type: Literal["parallel"],
+    id: str | EnvSpec,
+    *,
+    max_cycles: int | None = ...,
+    **kwargs: Any,
+) -> _ParallelEnv: ...
+
+
+def make(
+    env_type: EnvType,
+    id: str | EnvSpec,
+    *,
+    max_cycles: int | None = None,
+    **kwargs: Any,
+) -> _AECEnv | _ParallelEnv:
+    """Create an environment from the registry.
+
+    Args:
+        env_type: Either ``"aec"`` or ``"parallel"``.
+        id: The environment ID string or an ``EnvSpec`` instance.
+        max_cycles: Maximum number of cycles before truncation. Overrides the
+            value stored in the ``EnvSpec``. Pass ``-1`` to disable.
+        **kwargs: Additional keyword arguments passed to the entry point
+            (overrides defaults in the spec).
+
+    Returns:
+        An environment instance (``AECEnv`` for ``"aec"``, ``ParallelEnv`` for ``"parallel"``).
+    """
+    if isinstance(id, EnvSpec):
+        env_spec = id
+    else:
+        registry = _get_registry(env_type)
+        env_spec = find_spec(registry, id)
+
+    merged_kwargs = deepcopy(env_spec.kwargs)
+    merged_kwargs.update(kwargs)
+
+    # Resolve max_cycles: explicit arg > spec default; -1 means don't pass it
+    effective_max_cycles = max_cycles if max_cycles is not None else env_spec.max_cycles
+    if effective_max_cycles is not None and effective_max_cycles != -1:
+        merged_kwargs.setdefault("max_cycles", effective_max_cycles)
+
+    # Entry point import may fail if optional dependencies are missing
+    try:
+        creator = _load_env_creator(env_spec.entry_point)
+    except ImportError as import_error:
+        raise FailedToImport(
+            f"Failed to import entry point {env_spec.entry_point!r} for "
+            f"environment {env_spec.id!r}. You may need to install additional "
+            f"dependencies (e.g. pip install 'pettingzoo[{env_spec.namespace}]')."
+        ) from import_error
+
+    env = creator(**merged_kwargs)
+
+    expected_type = AECEnv if env_type == "aec" else ParallelEnv
+    if not isinstance(env, expected_type):
+        warnings.warn(
+            f"Environment {env_spec.id!r} was expected to be an instance of "
+            f"{expected_type.__name__}, but got {type(env).__name__}.",
+            stacklevel=2,
+        )
+
+    return env
+
+
+def spec(env_type: EnvType, id: str) -> EnvSpec:
+    """Look up the EnvSpec for a registered environment.
+
+    Args:
+        env_type: Either ``"aec"`` or ``"parallel"``.
+        id: The environment ID string.
+
+    Returns:
+        The ``EnvSpec`` for the environment.
+    """
+    registry = _get_registry(env_type)
+    return find_spec(registry, id)
+
+
+def pprint_registry() -> None:
+    """Pretty-print all registered environments."""
+    print("AEC environments:")
+    for env_id in sorted(aec_registry.keys()):
+        print(f"  {env_id}")
+    print("\nParallel environments:")
+    for env_id in sorted(parallel_registry.keys()):
+        print(f"  {env_id}")

--- a/pettingzoo/env_registry/spec.py
+++ b/pettingzoo/env_registry/spec.py
@@ -1,0 +1,80 @@
+"""EnvSpec dataclass and environment ID parsing utilities."""
+
+import importlib
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any
+
+from pettingzoo.env_registry.exceptions import PettingZooRegistryError
+from pettingzoo.env_registry.types import _AECEnv, _ParallelEnv
+
+ENV_ID_RE = re.compile(
+    r"^(?:(?P<namespace>[\w.-]+)\/)?(?P<name>[\w:.-]+?)(?:-v(?P<version>\d+))?$"
+)
+
+
+@dataclass
+class EnvSpec:
+    """Specification for a registered environment."""
+
+    id: str
+    entry_point: Callable[..., Any] | str | None = None
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    max_cycles: int | None = field(default=None)
+
+    namespace: str | None = field(init=False)
+    name: str = field(init=False)
+    version: int | None = field(init=False)
+
+    def __post_init__(self):
+        self.namespace, self.name, self.version = _parse_env_id(self.id)
+
+    def make(self, **kwargs: Any) -> _AECEnv | _ParallelEnv:
+        """Create an environment instance from this spec."""
+        merged_kwargs = {**self.kwargs, **kwargs}
+        if self.max_cycles is not None and "max_cycles" not in merged_kwargs:
+            merged_kwargs["max_cycles"] = self.max_cycles
+        creator = _load_env_creator(self.entry_point)
+        return creator(**merged_kwargs)
+
+
+@lru_cache(typed=True)
+def _parse_env_id(env_id: str) -> tuple[str | None, str, int | None]:
+    """Parse an environment ID into (namespace, name, version).
+
+    Format: ``[namespace/]EnvName[-vN]``
+    """
+    match = ENV_ID_RE.fullmatch(env_id) if isinstance(env_id, str) else None
+    if not match:
+        raise PettingZooRegistryError(
+            f"Malformed environment ID: {env_id!r}. "
+            f"Expected a str with format: [namespace/]EnvName[-vN]"
+        )
+    namespace = match.group("namespace")
+    name = match.group("name")
+    version_str = match.group("version")
+    version = int(version_str) if version_str is not None else None
+    return namespace, name, version
+
+
+@lru_cache(typed=True)
+def _load_env_creator(
+    entry_point: Callable[..., Any] | str | None,
+) -> Callable[..., Any]:
+    """Load an environment creator from a string or callable entry point."""
+    if entry_point is None:
+        raise PettingZooRegistryError(
+            "entry_point must not be None when creating an environment."
+        )
+    if callable(entry_point):
+        return entry_point
+    mod_name, attr_name = entry_point.split(":")
+    module = importlib.import_module(mod_name)
+    creator = getattr(module, attr_name)
+    if not callable(creator):
+        raise PettingZooRegistryError(
+            f"Entry point {entry_point!r} resolved to a non-callable: {type(creator)}"
+        )
+    return creator

--- a/pettingzoo/env_registry/types.py
+++ b/pettingzoo/env_registry/types.py
@@ -1,0 +1,10 @@
+"""Type aliases for generic environment base classes."""
+
+from typing import Any, Literal, TypeAlias
+
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+
+_AECEnv: TypeAlias = AECEnv[Any, Any, Any]
+_ParallelEnv: TypeAlias = ParallelEnv[Any, Any, Any]
+
+EnvType = Literal["aec", "parallel"]

--- a/pettingzoo/utils/all_modules.py
+++ b/pettingzoo/utils/all_modules.py
@@ -1,6 +1,7 @@
 from pettingzoo.atari.all_modules import atari_environments
 from pettingzoo.butterfly.all_modules import butterfly_environments
 from pettingzoo.classic.all_modules import classic_environments
+from pettingzoo.env_registry.registration import aec_registry, parallel_registry
 from pettingzoo.sisl.all_modules import sisl_environments
 
 all_prefixes = ["atari", "classic", "butterfly", "sisl"]
@@ -19,3 +20,14 @@ all_environments = {
     **classic_environments,
     **sisl_environments,
 }
+
+# Verify that every env declared in all_modules is registered
+_declared_ids = set(all_environments.keys())
+_missing_aec = _declared_ids - set(aec_registry.keys())
+_missing_parallel = _declared_ids - set(parallel_registry.keys())
+assert not _missing_aec, (
+    f"Environments missing from AEC registry: {sorted(_missing_aec)}"
+)
+assert not _missing_parallel, (
+    f"Environments missing from Parallel registry: {sorted(_missing_parallel)}"
+)

--- a/test/test_registry.py
+++ b/test/test_registry.py
@@ -3,21 +3,22 @@
 import pytest
 
 from pettingzoo.env_registry.exceptions import (
+    FailedToImport,
     NameNotFound,
     NamespaceNotFound,
+    PettingZooRegistryError,
     VersionNotFound,
 )
+from pettingzoo.env_registry.helpers import _get_env_id, find_spec
 from pettingzoo.env_registry.registration import (
     EnvSpec,
-    _get_env_id,
-    _parse_env_id,
     aec_registry,
-    find_spec,
     make,
     parallel_registry,
     register,
     spec,
 )
+from pettingzoo.env_registry.spec import _parse_env_id
 from pettingzoo.utils.env import AECEnv, ParallelEnv
 
 
@@ -139,6 +140,229 @@ class TestSpec:
         s = spec("parallel", "test_ns/SpecTest-v0")
         assert s.id == "test_ns/SpecTest-v0"
         del parallel_registry["test_ns/SpecTest-v0"]
+
+
+class TestHelperEdgeCases:
+    def test_unversioned_exact_match(self):
+        register("aec", "test_ns/Unversioned", entry_point="a:b")
+        s = find_spec(aec_registry, "test_ns/Unversioned")
+        assert s.id == "test_ns/Unversioned"
+        assert s.version is None
+        del aec_registry["test_ns/Unversioned"]
+
+    def test_unversioned_namespace_not_found(self):
+        with pytest.raises(NamespaceNotFound):
+            find_spec(aec_registry, "totally_bogus_ns/SomeEnv")
+
+    def test_unversioned_name_not_found_no_namespace(self):
+        with pytest.raises(NameNotFound):
+            find_spec(aec_registry, "CompletelyUnknownEnv")
+
+
+class TestSpecModule:
+    def test_malformed_env_id(self):
+        with pytest.raises(PettingZooRegistryError):
+            _parse_env_id("")  # type: ignore[arg-type]
+
+    def test_load_env_creator_none(self):
+        from pettingzoo.env_registry.spec import _load_env_creator
+
+        with pytest.raises(PettingZooRegistryError, match="must not be None"):
+            _load_env_creator(None)
+
+    def test_load_env_creator_string_success(self):
+        from pettingzoo.env_registry.spec import _load_env_creator
+
+        creator = _load_env_creator("pettingzoo.env_registry.spec:_parse_env_id")
+        assert callable(creator)
+
+    def test_load_env_creator_non_callable(self):
+        from pettingzoo.env_registry.spec import _load_env_creator
+
+        with pytest.raises(PettingZooRegistryError, match="non-callable"):
+            _load_env_creator("pettingzoo.env_registry:_atari_envs")
+
+    def test_envspec_make_method(self):
+        class FakeAEC(AECEnv):
+            metadata = {"name": "fake"}
+
+            def __init__(self, val=0):
+                self.val = val
+
+            def step(self, action):
+                pass
+
+            def reset(self, seed=None, options=None):
+                pass
+
+            def observe(self, agent):
+                pass
+
+            def render(self):
+                pass
+
+            def close(self):
+                pass
+
+        s = EnvSpec(id="test_ns/Direct-v0", entry_point=FakeAEC, kwargs={"val": 7})
+        env = s.make()
+        assert isinstance(env, AECEnv)
+        assert env.val == 7
+
+    def test_envspec_make_with_max_cycles(self):
+        class FakeAEC(AECEnv):
+            metadata = {"name": "fake"}
+
+            def __init__(self, max_cycles=10):
+                self.max_cycles = max_cycles
+
+            def step(self, action):
+                pass
+
+            def reset(self, seed=None, options=None):
+                pass
+
+            def observe(self, agent):
+                pass
+
+            def render(self):
+                pass
+
+            def close(self):
+                pass
+
+        s = EnvSpec(id="test_ns/MC-v0", entry_point=FakeAEC, max_cycles=42)
+        env = s.make()
+        assert env.max_cycles == 42
+
+
+class TestRegistrationEdgeCases:
+    def test_invalid_env_type(self):
+        from pettingzoo.env_registry.registration import _get_registry
+
+        with pytest.raises(ValueError, match="Invalid env_type"):
+            _get_registry("invalid")  # type: ignore[arg-type]
+
+    def test_make_with_envspec_directly(self):
+        class FakeAEC(AECEnv):
+            metadata = {"name": "fake"}
+
+            def __init__(self):
+                pass
+
+            def step(self, action):
+                pass
+
+            def reset(self, seed=None, options=None):
+                pass
+
+            def observe(self, agent):
+                pass
+
+            def render(self):
+                pass
+
+            def close(self):
+                pass
+
+        s = EnvSpec(id="test_ns/DirectMake-v0", entry_point=FakeAEC)
+        env = make("aec", s)
+        assert isinstance(env, AECEnv)
+
+    def test_make_max_cycles_override(self):
+        class FakeAEC(AECEnv):
+            metadata = {"name": "fake"}
+
+            def __init__(self, max_cycles=10):
+                self.max_cycles = max_cycles
+
+            def step(self, action):
+                pass
+
+            def reset(self, seed=None, options=None):
+                pass
+
+            def observe(self, agent):
+                pass
+
+            def render(self):
+                pass
+
+            def close(self):
+                pass
+
+        register("aec", "test_ns/MCOverride-v0", entry_point=FakeAEC, max_cycles=20)
+        env = make("aec", "test_ns/MCOverride-v0", max_cycles=5)
+        assert env.max_cycles == 5
+        del aec_registry["test_ns/MCOverride-v0"]
+
+    def test_make_max_cycles_disable(self):
+        class FakeAEC(AECEnv):
+            metadata = {"name": "fake"}
+
+            def __init__(self, max_cycles=None):
+                self.max_cycles = max_cycles
+
+            def step(self, action):
+                pass
+
+            def reset(self, seed=None, options=None):
+                pass
+
+            def observe(self, agent):
+                pass
+
+            def render(self):
+                pass
+
+            def close(self):
+                pass
+
+        register("aec", "test_ns/MCDisable-v0", entry_point=FakeAEC, max_cycles=20)
+        env = make("aec", "test_ns/MCDisable-v0", max_cycles=-1)
+        assert env.max_cycles is None
+        del aec_registry["test_ns/MCDisable-v0"]
+
+    def test_make_failed_import(self):
+        register("aec", "test_ns/BadImport-v0", entry_point="nonexistent.module:func")
+        with pytest.raises(FailedToImport):
+            make("aec", "test_ns/BadImport-v0")
+        del aec_registry["test_ns/BadImport-v0"]
+
+    def test_make_type_mismatch_warns(self):
+        class FakeAEC(AECEnv):
+            metadata = {"name": "fake"}
+
+            def __init__(self):
+                pass
+
+            def step(self, action):
+                pass
+
+            def reset(self, seed=None, options=None):
+                pass
+
+            def observe(self, agent):
+                pass
+
+            def render(self):
+                pass
+
+            def close(self):
+                pass
+
+        register("parallel", "test_ns/Mismatch-v0", entry_point=FakeAEC)
+        with pytest.warns(UserWarning, match="expected to be an instance of"):
+            make("parallel", "test_ns/Mismatch-v0")
+        del parallel_registry["test_ns/Mismatch-v0"]
+
+    def test_pprint_registry(self, capsys):
+        from pettingzoo.env_registry.registration import pprint_registry
+
+        pprint_registry()
+        captured = capsys.readouterr()
+        assert "AEC environments:" in captured.out
+        assert "Parallel environments:" in captured.out
 
 
 class TestMake:

--- a/test/test_registry.py
+++ b/test/test_registry.py
@@ -1,0 +1,198 @@
+"""Tests for the PettingZoo registry (register/make/spec)."""
+
+import pytest
+
+from pettingzoo.env_registry.exceptions import (
+    NameNotFound,
+    NamespaceNotFound,
+    VersionNotFound,
+)
+from pettingzoo.env_registry.registration import (
+    EnvSpec,
+    _get_env_id,
+    _parse_env_id,
+    aec_registry,
+    find_spec,
+    make,
+    parallel_registry,
+    register,
+    spec,
+)
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+
+
+class TestParseEnvId:
+    def test_simple_name_with_version(self):
+        ns, name, version = _parse_env_id("CartPole-v1")
+        assert ns is None
+        assert name == "CartPole"
+        assert version == 1
+
+    def test_namespaced_with_version(self):
+        ns, name, version = _parse_env_id("classic/rps-v2")
+        assert ns == "classic"
+        assert name == "rps"
+        assert version == 2
+
+    def test_no_version(self):
+        ns, name, version = _parse_env_id("classic/rps")
+        assert ns == "classic"
+        assert name == "rps"
+        assert version is None
+
+    def test_underscore_in_name(self):
+        ns, name, version = _parse_env_id("atari/space_invaders-v2")
+        assert ns == "atari"
+        assert name == "space_invaders"
+        assert version == 2
+
+    def test_no_namespace_no_version(self):
+        ns, name, version = _parse_env_id("MyEnv")
+        assert ns is None
+        assert name == "MyEnv"
+        assert version is None
+
+
+class TestGetEnvId:
+    def test_full(self):
+        assert _get_env_id("classic", "rps", 2) == "classic/rps-v2"
+
+    def test_no_namespace(self):
+        assert _get_env_id(None, "rps", 2) == "rps-v2"
+
+    def test_no_version(self):
+        assert _get_env_id("classic", "rps", None) == "classic/rps"
+
+
+class TestEnvSpec:
+    def test_post_init_parsing(self):
+        s = EnvSpec(id="classic/rps-v2", entry_point="some.module:func")
+        assert s.namespace == "classic"
+        assert s.name == "rps"
+        assert s.version == 2
+
+
+class TestRegister:
+    def test_register_aec(self):
+        register("aec", "test_ns/TestEnv-v0", entry_point="fake.module:env")
+        assert "test_ns/TestEnv-v0" in aec_registry
+        # cleanup
+        del aec_registry["test_ns/TestEnv-v0"]
+
+    def test_register_parallel(self):
+        register(
+            "parallel", "test_ns/TestEnv-v0", entry_point="fake.module:parallel_env"
+        )
+        assert "test_ns/TestEnv-v0" in parallel_registry
+        del parallel_registry["test_ns/TestEnv-v0"]
+
+    def test_register_warns_on_override(self):
+        register("aec", "test_ns/Override-v0", entry_point="a:b")
+        with pytest.warns(UserWarning, match="Overriding"):
+            register("aec", "test_ns/Override-v0", entry_point="c:d")
+        del aec_registry["test_ns/Override-v0"]
+
+    def test_register_with_kwargs(self):
+        register("aec", "test_ns/KW-v1", entry_point="a:b", kwargs={"x": 1})
+        assert aec_registry["test_ns/KW-v1"].kwargs == {"x": 1}
+        del aec_registry["test_ns/KW-v1"]
+
+
+class TestVersionResolution:
+    def setup_method(self):
+        register("aec", "test_ns/VersionedEnv-v1", entry_point="a:b")
+        register("aec", "test_ns/VersionedEnv-v3", entry_point="a:b")
+        register("aec", "test_ns/VersionedEnv-v2", entry_point="a:b")
+
+    def teardown_method(self):
+        for v in (1, 2, 3):
+            aec_registry.pop(f"test_ns/VersionedEnv-v{v}", None)
+
+    def test_resolves_to_highest(self):
+        s = find_spec(aec_registry, "test_ns/VersionedEnv")
+        assert s.version == 3
+
+    def test_explicit_version(self):
+        s = find_spec(aec_registry, "test_ns/VersionedEnv-v1")
+        assert s.version == 1
+
+
+class TestErrors:
+    def test_name_not_found(self):
+        with pytest.raises(NameNotFound):
+            find_spec(aec_registry, "classic/NonexistentEnv-v0")
+
+    def test_namespace_not_found(self):
+        with pytest.raises(NamespaceNotFound):
+            find_spec(aec_registry, "bogus_ns_xyz/SomeEnv-v1")
+
+    def test_version_not_found(self):
+        register("aec", "test_ns/VerErr-v1", entry_point="a:b")
+        with pytest.raises(VersionNotFound):
+            find_spec(aec_registry, "test_ns/VerErr-v99")
+        del aec_registry["test_ns/VerErr-v1"]
+
+
+class TestSpec:
+    def test_spec_lookup(self):
+        register("parallel", "test_ns/SpecTest-v0", entry_point="a:b")
+        s = spec("parallel", "test_ns/SpecTest-v0")
+        assert s.id == "test_ns/SpecTest-v0"
+        del parallel_registry["test_ns/SpecTest-v0"]
+
+
+class TestMake:
+    def test_make_with_callable(self):
+        class FakeAEC(AECEnv):
+            metadata = {"name": "fake"}
+
+            def __init__(self, x=1):
+                self.x = x
+
+            def step(self, action):
+                pass
+
+            def reset(self, seed=None, options=None):
+                pass
+
+            def observe(self, agent):
+                pass
+
+            def render(self):
+                pass
+
+            def close(self):
+                pass
+
+        register("aec", "test_ns/FakeAEC-v0", entry_point=FakeAEC, kwargs={"x": 42})
+        env = make("aec", "test_ns/FakeAEC-v0")
+        assert isinstance(env, AECEnv)
+        assert env.x == 42
+        del aec_registry["test_ns/FakeAEC-v0"]
+
+    def test_make_kwargs_override(self):
+        class FakeParallel(ParallelEnv):
+            metadata = {"name": "fake"}
+
+            def __init__(self, y=0):
+                self.y = y
+
+            def step(self, actions):
+                pass
+
+            def reset(self, seed=None, options=None):
+                pass
+
+            def render(self):
+                pass
+
+            def close(self):
+                pass
+
+        register(
+            "parallel", "test_ns/FakePar-v0", entry_point=FakeParallel, kwargs={"y": 10}
+        )
+        env = make("parallel", "test_ns/FakePar-v0", y=99)
+        assert isinstance(env, ParallelEnv)
+        assert env.y == 99
+        del parallel_registry["test_ns/FakePar-v0"]


### PR DESCRIPTION
# Description

Implementation for a small part of https://github.com/Farama-Foundation/PettingZoo/issues/803: a Gymnasium-like registry for PettingZoo.

This is only the implementation part. A documentation update is also needed but belongs to a separate PR.

I have made sure to add unit tests for relevant parts:
```
python -m pytest test/test_registry.py -o "addopts=" --noconftest --cov=pettingzoo.env_registry --cov-report=term-missing
============================= test session starts ==============================
platform darwin -- Python 3.12.7, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/Sushi/Documents/PettingZoo-Contrib
configfile: pyproject.toml
plugins: mock-3.15.1, cov-7.1.0, langsmith-0.4.4, asyncio-1.3.0, anyio-4.13.0, typeguard-4.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 37 items                                                             

test/test_registry.py .....................................              [100%]

=============================== warnings summary ===============================
pettingzoo/utils/average_total_reward.py:6
  /Users/Sushi/Documents/PettingZoo-Contrib/pettingzoo/utils/average_total_reward.py:6: UserWarning: The NumPy module was reloaded (imported a second time). This can in some cases result in small but subtle issues and is discouraged.
    import numpy as np

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.12.7-final-0 _______________

Name                                      Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------
pettingzoo/env_registry/__init__.py          18      0   100%
pettingzoo/env_registry/exceptions.py         5      0   100%
pettingzoo/env_registry/helpers.py           43      0   100%
pettingzoo/env_registry/registration.py      54      0   100%
pettingzoo/env_registry/spec.py              48      0   100%
pettingzoo/env_registry/types.py              5      0   100%
-----------------------------------------------------------------------
TOTAL                                       173      0   100%
======================== 37 passed, 1 warning in 0.13s =========================
```

Fixes #1387

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
