### PR TITLE
fix(registry): normalize env id to use -v[version] & misc improvements to code quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ or with the new Gymnasium-like registry:
 
 ```python
 from pettingzoo import make
-env = make("aec", "butterfly/pistonball_v6")
+env = make("aec", "butterfly/pistonball-v6")
 ```
 
 Environments can be interacted with in a manner very similar to Gymnasium:

--- a/pettingzoo/env_registry/helpers.py
+++ b/pettingzoo/env_registry/helpers.py
@@ -54,7 +54,7 @@ def find_spec(registry: dict[str, "EnvSpec"], env_id: str) -> "EnvSpec":
     )
 
 
-@lru_cache(typed=True)
+@lru_cache
 def _get_env_id(namespace: str | None, name: str, version: int | None) -> str:
     """Reconstruct a full environment ID from its components."""
     env_id = namespace + "/" if namespace else ""

--- a/pettingzoo/env_registry/helpers.py
+++ b/pettingzoo/env_registry/helpers.py
@@ -7,17 +7,18 @@ from pettingzoo.env_registry.exceptions import (
     NamespaceNotFound,
     VersionNotFound,
 )
-from pettingzoo.env_registry.spec import EnvSpec, _parse_env_id
+from pettingzoo.env_registry.spec import EnvSpec, _normalize_env_id, _parse_env_id
 
 
 def find_spec(registry: dict[str, "EnvSpec"], env_id: str) -> "EnvSpec":
     """Look up an EnvSpec in a registry, resolving unversioned IDs to the latest version."""
+    env_id = _normalize_env_id(env_id)
+    if env_id in registry:
+        return registry[env_id]
+
     namespace, name, version = _parse_env_id(env_id)
 
     if version is not None:
-        full_id = _get_env_id(namespace, name, version)
-        if full_id in registry:
-            return registry[full_id]
         # Check if the env name exists at all
         highest = _find_highest_version(registry, namespace, name)
         if highest is not None:
@@ -42,11 +43,6 @@ def find_spec(registry: dict[str, "EnvSpec"], env_id: str) -> "EnvSpec":
     if highest is not None:
         full_id = _get_env_id(namespace, name, highest)
         return registry[full_id]
-
-    # No versioned env found; try unversioned exact match
-    unversioned_id = _get_env_id(namespace, name, None)
-    if unversioned_id in registry:
-        return registry[unversioned_id]
 
     if namespace is not None:
         ns_exists = any(s.namespace == namespace for s in registry.values())

--- a/pettingzoo/env_registry/spec.py
+++ b/pettingzoo/env_registry/spec.py
@@ -10,9 +10,16 @@ from typing import Any
 from pettingzoo.env_registry.exceptions import PettingZooRegistryError
 from pettingzoo.env_registry.types import _AECEnv, _ParallelEnv
 
-ENV_ID_RE = re.compile(
+ENV_ID_PARSING = re.compile(
     r"^(?:(?P<namespace>[\w.-]+)\/)?(?P<name>[\w:.-]+?)(?:-v(?P<version>\d+))?$"
 )
+UNDERSCORE_NORMALIZATION = re.compile(r"_v(?=\d+$)")
+
+
+@lru_cache(typed=True)
+def _normalize_env_id(env_id: str) -> str:
+    """Normalize PettingZoo-style version suffixes to Gymnasium-style IDs."""
+    return UNDERSCORE_NORMALIZATION.sub("-v", env_id.strip(), count=1)
 
 
 @dataclass
@@ -29,6 +36,7 @@ class EnvSpec:
     version: int | None = field(init=False)
 
     def __post_init__(self):
+        self.id = _normalize_env_id(self.id)
         self.namespace, self.name, self.version = _parse_env_id(self.id)
 
     def make(self, **kwargs: Any) -> _AECEnv | _ParallelEnv:
@@ -46,15 +54,17 @@ def _parse_env_id(env_id: str) -> tuple[str | None, str, int | None]:
 
     Format: ``[namespace/]EnvName[-vN]``
     """
-    match = ENV_ID_RE.fullmatch(env_id) if isinstance(env_id, str) else None
-    if not match:
+    env_id_parsed = None
+    if isinstance(env_id, str):
+        env_id_parsed = ENV_ID_PARSING.fullmatch(_normalize_env_id(env_id))
+    if not env_id_parsed:
         raise PettingZooRegistryError(
             f"Malformed environment ID: {env_id!r}. "
             f"Expected a str with format: [namespace/]EnvName[-vN]"
         )
-    namespace = match.group("namespace")
-    name = match.group("name")
-    version_str = match.group("version")
+    namespace = env_id_parsed.group("namespace")
+    name = env_id_parsed.group("name")
+    version_str = env_id_parsed.group("version")
     version = int(version_str) if version_str is not None else None
     return namespace, name, version
 

--- a/pettingzoo/env_registry/spec.py
+++ b/pettingzoo/env_registry/spec.py
@@ -22,9 +22,9 @@ def _normalize_env_id(env_id: str) -> str:
     return UNDERSCORE_NORMALIZATION.sub("-v", env_id.strip(), count=1)
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class EnvSpec:
-    """Specification for a registered environment."""
+    """Specification for a registered environment, immutable after creation."""
 
     id: str
     entry_point: Callable[..., Any] | str | None = None
@@ -36,8 +36,12 @@ class EnvSpec:
     version: int | None = field(init=False)
 
     def __post_init__(self):
-        self.id = _normalize_env_id(self.id)
-        self.namespace, self.name, self.version = _parse_env_id(self.id)
+        force_setattr = object.__setattr__  # we need to overwrite frozen fields
+        force_setattr(self, "id", _normalize_env_id(self.id))
+        ns, name, ver = _parse_env_id(self.id)
+        force_setattr(self, "namespace", ns)
+        force_setattr(self, "name", name)
+        force_setattr(self, "version", ver)
 
     def make(self, **kwargs: Any) -> _AECEnv | _ParallelEnv:
         """Create an environment instance from this spec."""

--- a/pettingzoo/env_registry/spec.py
+++ b/pettingzoo/env_registry/spec.py
@@ -16,7 +16,7 @@ ENV_ID_PARSING = re.compile(
 UNDERSCORE_NORMALIZATION = re.compile(r"_v(?=\d+$)")
 
 
-@lru_cache(typed=True)
+@lru_cache
 def _normalize_env_id(env_id: str) -> str:
     """Normalize PettingZoo-style version suffixes to Gymnasium-style IDs."""
     return UNDERSCORE_NORMALIZATION.sub("-v", env_id.strip(), count=1)
@@ -52,7 +52,7 @@ class EnvSpec:
         return creator(**merged_kwargs)
 
 
-@lru_cache(typed=True)
+@lru_cache
 def _parse_env_id(env_id: str) -> tuple[str | None, str, int | None]:
     """Parse an environment ID into (namespace, name, version).
 
@@ -73,7 +73,7 @@ def _parse_env_id(env_id: str) -> tuple[str | None, str, int | None]:
     return namespace, name, version
 
 
-@lru_cache(typed=True)
+@lru_cache
 def _load_env_creator(
     entry_point: Callable[..., Any] | str | None,
 ) -> Callable[..., Any]:

--- a/pettingzoo/utils/all_modules.py
+++ b/pettingzoo/utils/all_modules.py
@@ -2,6 +2,7 @@ from pettingzoo.atari.all_modules import atari_environments
 from pettingzoo.butterfly.all_modules import butterfly_environments
 from pettingzoo.classic.all_modules import classic_environments
 from pettingzoo.env_registry.registration import aec_registry, parallel_registry
+from pettingzoo.env_registry.spec import _normalize_env_id
 from pettingzoo.sisl.all_modules import sisl_environments
 
 all_prefixes = ["atari", "classic", "butterfly", "sisl"]
@@ -22,7 +23,7 @@ all_environments = {
 }
 
 # Verify that every env declared in all_modules is registered
-_declared_ids = set(all_environments.keys())
+_declared_ids = {_normalize_env_id(env_id) for env_id in all_environments}
 _missing_aec = _declared_ids - set(aec_registry.keys())
 _missing_parallel = _declared_ids - set(parallel_registry.keys())
 assert not _missing_aec, (

--- a/test/test_registry.py
+++ b/test/test_registry.py
@@ -18,7 +18,7 @@ from pettingzoo.env_registry.registration import (
     register,
     spec,
 )
-from pettingzoo.env_registry.spec import _parse_env_id
+from pettingzoo.env_registry.spec import _normalize_env_id, _parse_env_id
 from pettingzoo.utils.env import AECEnv, ParallelEnv
 
 
@@ -47,6 +47,12 @@ class TestParseEnvId:
         assert name == "space_invaders"
         assert version == 2
 
+    def test_pettingzoo_version_suffix_alias(self):
+        ns, name, version = _parse_env_id("atari/space_invaders_v2")
+        assert ns == "atari"
+        assert name == "space_invaders"
+        assert version == 2
+
     def test_no_namespace_no_version(self):
         ns, name, version = _parse_env_id("MyEnv")
         assert ns is None
@@ -63,6 +69,20 @@ class TestGetEnvId:
 
     def test_no_version(self):
         assert _get_env_id("classic", "rps", None) == "classic/rps"
+
+
+class TestNormalizeEnvId:
+    def test_pettingzoo_suffix_to_gymnasium_suffix(self):
+        assert _normalize_env_id("classic/rps_v2") == "classic/rps-v2"
+
+    def test_internal_underscore_in_name_is_preserved(self):
+        assert (
+            _normalize_env_id("classic/texas_holdem_no_limit_v6")
+            == "classic/texas_holdem_no_limit-v6"
+        )
+
+    def test_non_version_suffix_is_preserved(self):
+        assert _normalize_env_id("test_ns/My_v2_CustomEnv") == "test_ns/My_v2_CustomEnv"
 
 
 class TestEnvSpec:
@@ -98,6 +118,16 @@ class TestRegister:
         assert aec_registry["test_ns/KW-v1"].kwargs == {"x": 1}
         del aec_registry["test_ns/KW-v1"]
 
+    def test_register_normalizes_pettingzoo_version_suffix(self):
+        register("aec", "test_ns/NormalizeMe_v2", entry_point="a:b")
+        assert "test_ns/NormalizeMe-v2" in aec_registry
+        assert "test_ns/NormalizeMe_v2" not in aec_registry
+        registered_spec = aec_registry["test_ns/NormalizeMe-v2"]
+        assert registered_spec.id == "test_ns/NormalizeMe-v2"
+        assert registered_spec.name == "NormalizeMe"
+        assert registered_spec.version == 2
+        del aec_registry["test_ns/NormalizeMe-v2"]
+
 
 class TestVersionResolution:
     def setup_method(self):
@@ -115,6 +145,11 @@ class TestVersionResolution:
 
     def test_explicit_version(self):
         s = find_spec(aec_registry, "test_ns/VersionedEnv-v1")
+        assert s.version == 1
+
+    def test_explicit_pettingzoo_version_suffix_alias(self):
+        s = find_spec(aec_registry, "test_ns/VersionedEnv_v1")
+        assert s.id == "test_ns/VersionedEnv-v1"
         assert s.version == 1
 
 
@@ -140,6 +175,26 @@ class TestSpec:
         s = spec("parallel", "test_ns/SpecTest-v0")
         assert s.id == "test_ns/SpecTest-v0"
         del parallel_registry["test_ns/SpecTest-v0"]
+
+
+class TestBuiltInRegistryIds:
+    def test_builtin_canonical_id_uses_gymnasium_suffix(self):
+        s = spec("aec", "butterfly/pistonball-v6")
+        assert s.id == "butterfly/pistonball-v6"
+        assert s.name == "pistonball"
+        assert s.version == 6
+
+    def test_builtin_pettingzoo_suffix_alias_resolves(self):
+        s = spec("aec", "butterfly/pistonball_v6")
+        assert s.id == "butterfly/pistonball-v6"
+        assert s.name == "pistonball"
+        assert s.version == 6
+
+    def test_builtin_unversioned_resolves_latest(self):
+        s = spec("aec", "butterfly/pistonball")
+        assert s.id == "butterfly/pistonball-v6"
+        assert s.name == "pistonball"
+        assert s.version == 6
 
 
 class TestHelperEdgeCases:


### PR DESCRIPTION
# Description

PettingZoo registry implementation in #1388 did not normalize version parsing (since it seems that we only provide one version per environment within PettingZoo), so for example: `atari/basketball_pong_v3` is treated as an environment named `basketball_pong_v3` in the `atari` namespace with no versioning, instead of the `basketball_pong` environment's version `3`.

This PR does these:
- Proper version string normalization (`atari/basketball_pong_v3` to `atari/basketball_pong-v3`) so that the existing env id parsing logic can take advantage of this
- Made `EnvSpec` dataclass `frozen=True, slots=True`, as it should be immutable by design
- Changed a few variable names that are not informative enough
- Made the `@lru_cache` decorators untyped; no user should pass in some custom object mimicking a `str` anyway, and untyped is faster

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
