### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -43,6 +43,8 @@ jobs:
         runs-on: ubuntu-latest
         environment: pypi
         if: github.event_name == 'release' && github.event.action == 'published'
+        permissions:
+            contents: read
         steps:
             - name: Download dist
               uses: actions/download-artifact@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/PettingZoo/security/code-scanning/1](https://github.com/Farama-Foundation/PettingZoo/security/code-scanning/1)

Add an explicit `permissions` block to the `publish` job in `.github/workflows/build-publish.yml`, matching the minimum required access.  
Best fix without changing functionality: set `contents: read` for `publish` (same conservative level used by `build`). This ensures the job does not inherit broader defaults while preserving behavior.

Edit location:
- File: `.github/workflows/build-publish.yml`
- Region: under `jobs.publish` (after `if:` and before `steps:` is a clean placement)

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
