### PR TITLE
chore: deprecate old env creation API

### DIFF
--- a/pettingzoo/atari/basketball_pong_v3.py
+++ b/pettingzoo/atari/basketball_pong_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.basketball_pong.basketball_pong import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/boxing_v2.py
+++ b/pettingzoo/atari/boxing_v2.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.boxing.boxing import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/combat_plane_v2.py
+++ b/pettingzoo/atari/combat_plane_v2.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.combat_plane.combat_plane import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/combat_tank_v2.py
+++ b/pettingzoo/atari/combat_tank_v2.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.combat_tank.combat_tank import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/double_dunk_v3.py
+++ b/pettingzoo/atari/double_dunk_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.double_dunk.double_dunk import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/entombed_competitive_v3.py
+++ b/pettingzoo/atari/entombed_competitive_v3.py
@@ -1,7 +1,12 @@
+import warnings
+
 from pettingzoo.atari.entombed_competitive.entombed_competitive import (
     env,
     parallel_env,
     raw_env,
 )
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/entombed_cooperative_v3.py
+++ b/pettingzoo/atari/entombed_cooperative_v3.py
@@ -1,7 +1,12 @@
+import warnings
+
 from pettingzoo.atari.entombed_cooperative.entombed_cooperative import (
     env,
     parallel_env,
     raw_env,
 )
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/flag_capture_v2.py
+++ b/pettingzoo/atari/flag_capture_v2.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.flag_capture.flag_capture import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/foozpong_v3.py
+++ b/pettingzoo/atari/foozpong_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.foozpong.foozpong import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/ice_hockey_v2.py
+++ b/pettingzoo/atari/ice_hockey_v2.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.ice_hockey.ice_hockey import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/joust_v3.py
+++ b/pettingzoo/atari/joust_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.joust.joust import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/mario_bros_v3.py
+++ b/pettingzoo/atari/mario_bros_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.mario_bros.mario_bros import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/maze_craze_v3.py
+++ b/pettingzoo/atari/maze_craze_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.maze_craze.maze_craze import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/othello_v3.py
+++ b/pettingzoo/atari/othello_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.othello.othello import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/pong_v3.py
+++ b/pettingzoo/atari/pong_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.pong.pong import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/quadrapong_v4.py
+++ b/pettingzoo/atari/quadrapong_v4.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.quadrapong.quadrapong import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/space_invaders_v2.py
+++ b/pettingzoo/atari/space_invaders_v2.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.space_invaders.space_invaders import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/space_war_v2.py
+++ b/pettingzoo/atari/space_war_v2.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.space_war.space_war import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/surround_v2.py
+++ b/pettingzoo/atari/surround_v2.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.surround.surround import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/tennis_v3.py
+++ b/pettingzoo/atari/tennis_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.tennis.tennis import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/video_checkers_v4.py
+++ b/pettingzoo/atari/video_checkers_v4.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.video_checkers.video_checkers import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/volleyball_pong_v3.py
+++ b/pettingzoo/atari/volleyball_pong_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.volleyball_pong.volleyball_pong import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/warlords_v3.py
+++ b/pettingzoo/atari/warlords_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.warlords.warlords import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/atari/wizard_of_wor_v3.py
+++ b/pettingzoo/atari/wizard_of_wor_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.atari.wizard_of_wor.wizard_of_wor import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/butterfly/cooperative_pong_v6.py
+++ b/pettingzoo/butterfly/cooperative_pong_v6.py
@@ -1,8 +1,13 @@
+import warnings
+
 from pettingzoo.butterfly.cooperative_pong.cooperative_pong import (
     env,
     parallel_env,
     raw_env,
 )
 from pettingzoo.butterfly.cooperative_pong.manual_policy import ManualPolicy
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["ManualPolicy", "env", "parallel_env", "raw_env"]

--- a/pettingzoo/butterfly/knights_archers_zombies_v11.py
+++ b/pettingzoo/butterfly/knights_archers_zombies_v11.py
@@ -1,8 +1,13 @@
+import warnings
+
 from pettingzoo.butterfly.knights_archers_zombies.knights_archers_zombies import (
     env,
     parallel_env,
     raw_env,
 )
 from pettingzoo.butterfly.knights_archers_zombies.manual_policy import ManualPolicy
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["ManualPolicy", "env", "parallel_env", "raw_env"]

--- a/pettingzoo/butterfly/pistonball_v6.py
+++ b/pettingzoo/butterfly/pistonball_v6.py
@@ -1,8 +1,13 @@
+import warnings
+
 from pettingzoo.butterfly.pistonball.pistonball import (
     ManualPolicy,
     env,
     parallel_env,
     raw_env,
 )
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["ManualPolicy", "env", "parallel_env", "raw_env"]

--- a/pettingzoo/classic/chess_v6.py
+++ b/pettingzoo/classic/chess_v6.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.classic.chess.chess import env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "raw_env"]

--- a/pettingzoo/classic/connect_four_v3.py
+++ b/pettingzoo/classic/connect_four_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.classic.connect_four.connect_four import env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "raw_env"]

--- a/pettingzoo/classic/go_v5.py
+++ b/pettingzoo/classic/go_v5.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.classic.go.go import env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "raw_env"]

--- a/pettingzoo/classic/hanabi_v5.py
+++ b/pettingzoo/classic/hanabi_v5.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.classic.hanabi.hanabi import env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "raw_env"]

--- a/pettingzoo/classic/leduc_holdem_v4.py
+++ b/pettingzoo/classic/leduc_holdem_v4.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.classic.rlcard_envs.leduc_holdem import env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "raw_env"]

--- a/pettingzoo/classic/rps_v2.py
+++ b/pettingzoo/classic/rps_v2.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.classic.rps.rps import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/classic/texas_holdem_no_limit_v6.py
+++ b/pettingzoo/classic/texas_holdem_no_limit_v6.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.classic.rlcard_envs.texas_holdem_no_limit import env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "raw_env"]

--- a/pettingzoo/classic/texas_holdem_v4.py
+++ b/pettingzoo/classic/texas_holdem_v4.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.classic.rlcard_envs.texas_holdem import env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "raw_env"]

--- a/pettingzoo/classic/tictactoe_v3.py
+++ b/pettingzoo/classic/tictactoe_v3.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.classic.tictactoe.tictactoe import env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "raw_env"]

--- a/pettingzoo/env_registry/__init__.py
+++ b/pettingzoo/env_registry/__init__.py
@@ -5,47 +5,73 @@ Importing this module populates the AEC and parallel registries with all
 built-in environments. This mimics Gymnasium's API design.
 """
 
+import re
+from pathlib import Path
+
 from pettingzoo.env_registry.registration import register
+
+# Internal helpers for checking whether an environment provides parallel API
+
+_PACKAGE_ROOT = Path(__file__).parent.parent.resolve()
+_SOURCE_CACHE: dict[str, str] = {}
+
+
+def _module_source(module: str) -> str:
+    """Return source text for ``module`` without importing it."""
+    if module not in _SOURCE_CACHE:
+        parts = module.split(".")
+        path = _PACKAGE_ROOT.joinpath(*parts[1:]).with_suffix(".py")
+        _SOURCE_CACHE[module] = path.read_text(encoding="utf-8")
+    return _SOURCE_CACHE[module]
+
+
+def _maybe_register_parallel(
+    _id: str,
+    _module: str,
+    *,
+    keyword: str = "parallel_env",
+) -> None:
+    """Register a parallel entry point only if it is defined in the source code."""
+    src = _module_source(_module)
+    if re.search(r"^" + keyword + " =", src, re.MULTILINE) or re.search(
+        r"def " + keyword, src
+    ):
+        register("parallel", _id, entry_point=f"{_module}:{keyword}")
+
 
 # Atari environments
 
 _atari_envs = [
-    "basketball_pong_v3",
-    "boxing_v2",
-    "combat_plane_v2",
-    "combat_tank_v2",
-    "double_dunk_v3",
-    "entombed_competitive_v3",
-    "entombed_cooperative_v3",
-    "flag_capture_v2",
-    "foozpong_v3",
-    "ice_hockey_v2",
-    "joust_v3",
-    "mario_bros_v3",
-    "maze_craze_v3",
-    "othello_v3",
-    "pong_v3",
-    "quadrapong_v4",
-    "space_invaders_v2",
-    "space_war_v2",
-    "surround_v2",
-    "tennis_v3",
-    "video_checkers_v4",
-    "volleyball_pong_v3",
-    "warlords_v3",
-    "wizard_of_wor_v3",
+    ("basketball_pong_v3", "basketball_pong"),
+    ("boxing_v2", "boxing"),
+    ("combat_plane_v2", "combat_plane"),
+    ("combat_tank_v2", "combat_tank"),
+    ("double_dunk_v3", "double_dunk"),
+    ("entombed_competitive_v3", "entombed_competitive"),
+    ("entombed_cooperative_v3", "entombed_cooperative"),
+    ("flag_capture_v2", "flag_capture"),
+    ("foozpong_v3", "foozpong"),
+    ("ice_hockey_v2", "ice_hockey"),
+    ("joust_v3", "joust"),
+    ("mario_bros_v3", "mario_bros"),
+    ("maze_craze_v3", "maze_craze"),
+    ("othello_v3", "othello"),
+    ("pong_v3", "pong"),
+    ("quadrapong_v4", "quadrapong"),
+    ("space_invaders_v2", "space_invaders"),
+    ("space_war_v2", "space_war"),
+    ("surround_v2", "surround"),
+    ("tennis_v3", "tennis"),
+    ("video_checkers_v4", "video_checkers"),
+    ("volleyball_pong_v3", "volleyball_pong"),
+    ("warlords_v3", "warlords"),
+    ("wizard_of_wor_v3", "wizard_of_wor"),
 ]
 
-for _name in _atari_envs:
-    _base = _name.rsplit("_v", 1)[0]
-    register(
-        "aec", f"atari/{_name}", entry_point=f"pettingzoo.atari.{_base}.{_base}:env"
-    )
-    register(
-        "parallel",
-        f"atari/{_name}",
-        entry_point=f"pettingzoo.atari.{_base}.{_base}:parallel_env",
-    )
+for _id, _base in _atari_envs:
+    _module = f"pettingzoo.atari.{_base}.{_base}"
+    register("aec", f"atari/{_id}", entry_point=f"{_module}:env")
+    _maybe_register_parallel(f"atari/{_id}", _module)
 
 # Butterfly environments
 
@@ -56,40 +82,30 @@ _butterfly_envs = [
 ]
 
 for _id, _base in _butterfly_envs:
-    register(
-        "aec",
-        f"butterfly/{_id}",
-        entry_point=f"pettingzoo.butterfly.{_base}.{_base}:env",
-    )
-    register(
-        "parallel",
-        f"butterfly/{_id}",
-        entry_point=f"pettingzoo.butterfly.{_base}.{_base}:parallel_env",
-    )
+    _module = f"pettingzoo.butterfly.{_base}.{_base}"
+    register("aec", f"butterfly/{_id}", entry_point=f"{_module}:env")
+    _maybe_register_parallel(f"butterfly/{_id}", _module)
 
 # Classic environments
 
 _classic_envs = [
-    ("chess_v6", "chess"),
-    ("rps_v2", "rps"),
-    ("connect_four_v3", "connect_four"),
-    ("tictactoe_v3", "tictactoe"),
-    ("leduc_holdem_v4", "leduc_holdem"),
-    ("texas_holdem_v4", "texas_holdem"),
-    ("texas_holdem_no_limit_v6", "texas_holdem_no_limit"),
-    ("go_v5", "go"),
-    ("hanabi_v5", "hanabi"),
+    ("chess_v6", "pettingzoo.classic.chess.chess"),
+    ("rps_v2", "pettingzoo.classic.rps.rps"),
+    ("connect_four_v3", "pettingzoo.classic.connect_four.connect_four"),
+    ("tictactoe_v3", "pettingzoo.classic.tictactoe.tictactoe"),
+    ("leduc_holdem_v4", "pettingzoo.classic.rlcard_envs.leduc_holdem"),
+    ("texas_holdem_v4", "pettingzoo.classic.rlcard_envs.texas_holdem"),
+    (
+        "texas_holdem_no_limit_v6",
+        "pettingzoo.classic.rlcard_envs.texas_holdem_no_limit",
+    ),
+    ("go_v5", "pettingzoo.classic.go.go"),
+    ("hanabi_v5", "pettingzoo.classic.hanabi.hanabi"),
 ]
 
-for _id, _base in _classic_envs:
-    register(
-        "aec", f"classic/{_id}", entry_point=f"pettingzoo.classic.{_base}.{_base}:env"
-    )
-    register(
-        "parallel",
-        f"classic/{_id}",
-        entry_point=f"pettingzoo.classic.{_base}.{_base}:parallel_env",
-    )
+for _id, _module in _classic_envs:
+    register("aec", f"classic/{_id}", entry_point=f"{_module}:env")
+    _maybe_register_parallel(f"classic/{_id}", _module)
 
 # SISL environments
 
@@ -99,9 +115,8 @@ _sisl_envs = [
 ]
 
 for _id, _base in _sisl_envs:
-    register("aec", f"sisl/{_id}", entry_point=f"pettingzoo.sisl.{_base}.{_base}:env")
-    register(
-        "parallel",
-        f"sisl/{_id}",
-        entry_point=f"pettingzoo.sisl.{_base}.{_base}:parallel_env",
-    )
+    _module = f"pettingzoo.sisl.{_base}.{_base}"
+    register("aec", f"sisl/{_id}", entry_point=f"{_module}:env")
+    _maybe_register_parallel(f"sisl/{_id}", _module)
+
+_SOURCE_CACHE.clear()

--- a/pettingzoo/sisl/multiwalker_v9.py
+++ b/pettingzoo/sisl/multiwalker_v9.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.sisl.multiwalker.multiwalker import env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["env", "parallel_env", "raw_env"]

--- a/pettingzoo/sisl/pursuit_v5.py
+++ b/pettingzoo/sisl/pursuit_v5.py
@@ -1,3 +1,8 @@
+import warnings
+
 from pettingzoo.sisl.pursuit.pursuit import ManualPolicy, env, parallel_env, raw_env
+from pettingzoo.utils.deprecated_module import CREATE_ENV_WITHOUT_REGISTRY
+
+warnings.warn(CREATE_ENV_WITHOUT_REGISTRY, DeprecationWarning, stacklevel=2)
 
 __all__ = ["ManualPolicy", "env", "parallel_env", "raw_env"]

--- a/pettingzoo/utils/all_modules.py
+++ b/pettingzoo/utils/all_modules.py
@@ -1,7 +1,7 @@
 from pettingzoo.atari.all_modules import atari_environments
 from pettingzoo.butterfly.all_modules import butterfly_environments
 from pettingzoo.classic.all_modules import classic_environments
-from pettingzoo.env_registry.registration import aec_registry, parallel_registry
+from pettingzoo.env_registry.registration import aec_registry
 from pettingzoo.env_registry.spec import _normalize_env_id
 from pettingzoo.sisl.all_modules import sisl_environments
 
@@ -22,13 +22,9 @@ all_environments = {
     **sisl_environments,
 }
 
-# Verify that every env declared in all_modules is registered
+# Verify that every env declared in all_modules is registered for AEC
 _declared_ids = {_normalize_env_id(env_id) for env_id in all_environments}
 _missing_aec = _declared_ids - set(aec_registry.keys())
-_missing_parallel = _declared_ids - set(parallel_registry.keys())
 assert not _missing_aec, (
     f"Environments missing from AEC registry: {sorted(_missing_aec)}"
-)
-assert not _missing_parallel, (
-    f"Environments missing from Parallel registry: {sorted(_missing_parallel)}"
 )

--- a/pettingzoo/utils/deprecated_module.py
+++ b/pettingzoo/utils/deprecated_module.py
@@ -11,6 +11,12 @@ class DeprecatedEnv(ImportError):
     pass
 
 
+CREATE_ENV_WITHOUT_REGISTRY = (
+    "The old environment creation API has been deprecated in favor of a Gymnasium-like"
+    " registry implementation, please use the make function instead.\nThe old API will"
+    " eventually be removed in a future release."
+)
+
 # Environments removed from PettingZoo entirely, mapped to the reason why. These
 # raise on attribute access rather than falling through as a missing module, so
 # that users upgrading from an older release get an actionable message.


### PR DESCRIPTION
# Description

As announced in #1392, we are deprecating the old environment creation API.
This PR also fixed issues with the `parallel_env` registry containing non-existent entries.

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
