### PR TITLE
Direct MAgent and MPE users to MAgent2 and MPE2 on the doc site

### DIFF
--- a/docs/environments/magent.md
+++ b/docs/environments/magent.md
@@ -1,0 +1,55 @@
+---
+title: MAgent Environments
+firstpage:
+---
+
+# MAgent (moved to MAgent2)
+
+```{warning}
+The MAgent environments are no longer part of PettingZoo. They now live in their own
+Farama project, **[MAgent2](https://magent2.farama.org/)**, where they continue to be maintained.
+
+Importing `pettingzoo.magent` raises an `ImportError` pointing here.
+```
+
+## Migration Guide
+
+Install the new package:
+
+````bash
+pip install magent2
+````
+
+Then update your imports. The environment names and versions are unchanged, so in most
+cases swapping the import is the only edit required:
+
+```python
+# Before (PettingZoo <= 1.23)
+from pettingzoo.magent import battle_v4
+
+# After
+from magent2.environments import battle_v4
+
+env = battle_v4.env(render_mode="human")
+```
+
+MAgent2 still implements the PettingZoo [AEC](/api/aec/) and [Parallel](/api/parallel/) APIs,
+so the rest of your code, along with any PettingZoo wrappers and utilities, continues to work.
+
+## Environments
+
+The environments that used to be documented on this site are now documented at
+[magent2.farama.org](https://magent2.farama.org/):
+
+- [Adversarial Pursuit](https://magent2.farama.org/environments/adversarial_pursuit/)
+- [Battle](https://magent2.farama.org/environments/battle/)
+- [Battlefield](https://magent2.farama.org/environments/battlefield/)
+- [Combined Arms](https://magent2.farama.org/environments/combined_arms/)
+- [Gather](https://magent2.farama.org/environments/gather/)
+- [Tiger Deer](https://magent2.farama.org/environments/tiger_deer/)
+
+## Links
+
+- Documentation: [https://magent2.farama.org/](https://magent2.farama.org/)
+- GitHub: [https://github.com/Farama-Foundation/MAgent2](https://github.com/Farama-Foundation/MAgent2)
+- PyPI: [https://pypi.org/project/magent2/](https://pypi.org/project/magent2/)

--- a/docs/environments/magent.md
+++ b/docs/environments/magent.md
@@ -23,7 +23,7 @@ pip install magent2
 Then update your imports. The environment names and versions are unchanged, so in most
 cases swapping the import is the only edit required:
 
-```python
+```python notest
 # Before (PettingZoo <= 1.23)
 from pettingzoo.magent import battle_v4
 

--- a/docs/environments/mpe.md
+++ b/docs/environments/mpe.md
@@ -1,0 +1,63 @@
+---
+title: MPE Environments
+firstpage:
+---
+
+# MPE (moved to MPE2)
+
+```{warning}
+The MPE environments are no longer part of PettingZoo. They now live in their own
+Farama project, **[MPE2](https://mpe2.farama.org/)**, where they continue to be maintained.
+
+Importing `pettingzoo.mpe` raises an `ImportError` pointing here.
+```
+
+## Migration Guide
+
+Install the new package:
+
+````bash
+pip install mpe2
+````
+
+Then update your imports. The environment names and versions are unchanged, so in most
+cases swapping the import is the only edit required:
+
+```python
+# Before (PettingZoo <= 1.24)
+from pettingzoo.mpe import simple_spread_v3
+
+# After
+from mpe2 import simple_spread_v3
+
+env = simple_spread_v3.env(render_mode="human")
+```
+
+MPE2 still implements the PettingZoo [AEC](/api/aec/) and [Parallel](/api/parallel/) APIs,
+so the rest of your code, along with any PettingZoo wrappers and utilities, continues to work.
+
+## Environments
+
+The environments that used to be documented on this site are now documented at
+[mpe2.farama.org](https://mpe2.farama.org/):
+
+- [Simple](https://mpe2.farama.org/environments/simple/)
+- [Simple Adversary](https://mpe2.farama.org/environments/simple_adversary/)
+- [Simple Crypto](https://mpe2.farama.org/environments/simple_crypto/)
+- [Simple Push](https://mpe2.farama.org/environments/simple_push/)
+- [Simple Reference](https://mpe2.farama.org/environments/simple_reference/)
+- [Simple Speaker Listener](https://mpe2.farama.org/environments/simple_speaker_listener/)
+- [Simple Spread](https://mpe2.farama.org/environments/simple_spread/)
+- [Simple Tag](https://mpe2.farama.org/environments/simple_tag/)
+- [Simple World Comm](https://mpe2.farama.org/environments/simple_world_comm/)
+
+MPE2 also adds environments that were never part of PettingZoo, including
+[Simple Formation](https://mpe2.farama.org/environments/simple_formation/),
+[Simple Line](https://mpe2.farama.org/environments/simple_line/), and
+[Collect Treasure](https://mpe2.farama.org/environments/collect_treasure/).
+
+## Links
+
+- Documentation: [https://mpe2.farama.org/](https://mpe2.farama.org/)
+- GitHub: [https://github.com/Farama-Foundation/MPE2](https://github.com/Farama-Foundation/MPE2)
+- PyPI: [https://pypi.org/project/mpe2/](https://pypi.org/project/mpe2/)

--- a/docs/environments/mpe.md
+++ b/docs/environments/mpe.md
@@ -23,7 +23,7 @@ pip install mpe2
 Then update your imports. The environment names and versions are unchanged, so in most
 cases swapping the import is the only edit required:
 
-```python
+```python notest
 # Before (PettingZoo <= 1.24)
 from pettingzoo.mpe import simple_spread_v3
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ environments/atari
 environments/butterfly
 environments/classic
 environments/sisl
+environments/magent
+environments/mpe
 environments/third_party_envs
 ```
 


### PR DESCRIPTION
# Description

The MAgent and MPE environments moved out of PettingZoo into their own Farama projects, [MAgent2](https://magent2.farama.org/) and [MPE2](https://mpe2.farama.org/). Their documentation pages were deleted at the time (#823 for MAgent, #1327 for MPE), so `pettingzoo.farama.org/environments/magent/` and `/environments/mpe/` now 404.

The Python packages already handle this well — `pettingzoo/magent/__init__.py` and `pettingzoo/mpe/__init__.py` raise an `ImportError` naming the new package and doc site. But that only helps people who reach the move via an import. Anyone arriving from a search result, an old bookmark, a paper, or a tutorial link lands on a dead page with no indication that the environments still exist and are still maintained.

This PR restores both pages at their original URLs as migration pages:

- the move stated up front in a warning admonition, with a link to the new project
- the `pip install` command for the new package
- a before/after import example — the environment names and versions are unchanged, so for most users swapping the import is the only edit (note the two packages differ in import shape: `from mpe2 import simple_spread_v3` vs `from magent2.environments import battle_v4`)
- a note that both projects still implement the PettingZoo AEC and Parallel APIs, so existing code, wrappers, and utilities keep working
- direct links to every environment's page on the new doc site, so old per-environment URLs are recoverable in one click

MPE2 also ships environments that were never in PettingZoo (Simple Formation, Simple Line, Collect Treasure); those are mentioned on the MPE page.

Both pages are added to the Environments toctree, so the sidebar reads "MAgent (moved to MAgent2)" and "MPE (moved to MPE2)" alongside Atari, Butterfly, Classic and SISL — the moves are visible without having to search for them.

Note that `docs/.gitignore` ignores `environments/**/*.md` to keep the per-environment pages generated by `gen_envs_mds.py` out of the repo. That pattern also matches the hand-written family landing pages, so these two needed `git add -f`, exactly as the existing tracked `atari.md` / `butterfly.md` / `classic.md` / `sisl.md` are.

Docs only — no library code is touched.

## Type of change

- This change requires a documentation update

### Screenshots

Sidebar under **Environments** now lists the two moved families:

```
Atari
Butterfly
Classic
SISL
MAgent (moved to MAgent2)
MPE (moved to MPE2)
Third-Party Environments
```

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Notes on the checklist: `pre-commit` was run against the changed files and passes. The test-suite boxes are left unchecked because this PR adds no code and no tests — verification was a local `sphinx-build`, which succeeds and emits no warnings attributable to either new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)