### PR TITLE
Bump version from 1.26.1 to 1.27.0

### DIFF
--- a/pettingzoo/__init__.py
+++ b/pettingzoo/__init__.py
@@ -33,7 +33,7 @@ if sys.platform.startswith("linux"):
 
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
 
-__version__ = "1.27.0.dev0"
+__version__ = "1.27.0"
 
 try:
     import sys


### PR DESCRIPTION
# Description

Prepares PettingZoo for the 1.27.0 release by updating the package version from `1.26.1` to `1.27.0`.

No new dependencies are required.

## Type of change

Release preparation / version update.

### Screenshots

Not applicable.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas — Not applicable
- [x] I have made corresponding changes to the documentation — Not applicable
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge — Not applicable
- [x] I have added tests that prove my fix is effective or that my feature works — Not applicable
- [ ] New and existing unit tests pass locally with my changes