### PR TITLE
Report one error when RecordVideo cannot be constructed, not three

### DIFF
--- a/pettingzoo/utils/wrappers/record_video.py
+++ b/pettingzoo/utils/wrappers/record_video.py
@@ -60,8 +60,8 @@ class RecordVideo(BaseWrapper[AgentID, ObsType, ActionType]):
 
         if env.render_mode in {None, "human", "ansi"}:  # type: ignore
             raise ValueError(
-                f"Render mode is {env.render_mode}, which is incompatible with RecordVideo.",  # type: ignore
-                "Initialize your environment with a render_mode that returns an image, such as rgb_array.",
+                f"Render mode is {env.render_mode}, which is incompatible with RecordVideo. "  # type: ignore
+                "Initialize your environment with a render_mode that returns an image, such as rgb_array."
             )
 
         if episode_trigger is None and step_trigger is None:
@@ -215,5 +215,9 @@ class RecordVideo(BaseWrapper[AgentID, ObsType, ActionType]):
 
     def __del__(self) -> None:
         """Warn the user in case last video wasn't saved."""
-        if len(self.recorded_frames) > 0:
+        # `__init__` can raise before `recorded_frames` is assigned, and `__del__`
+        # still runs on the half-built wrapper. Reading the attribute directly
+        # raised an AttributeError that Python reports as "Exception ignored in",
+        # on top of the error that actually stopped construction.
+        if getattr(self, "recorded_frames", None):
             gymnasium.logger.warn("Unable to save last video! Did you call close()?")

--- a/pettingzoo/utils/wrappers/record_video_parallel.py
+++ b/pettingzoo/utils/wrappers/record_video_parallel.py
@@ -60,8 +60,8 @@ class RecordVideoParallel(BaseParallelWrapper[AgentID, ObsType, ActionType]):
 
         if env.render_mode in {None, "human", "ansi"}:  # type: ignore
             raise ValueError(
-                f"Render mode is {env.render_mode}, which is incompatible with RecordVideo.",  # type: ignore
-                "Initialize your environment with a render_mode that returns an image, such as rgb_array.",
+                f"Render mode is {env.render_mode}, which is incompatible with RecordVideo. "  # type: ignore
+                "Initialize your environment with a render_mode that returns an image, such as rgb_array."
             )
 
         if episode_trigger is None and step_trigger is None:
@@ -227,5 +227,9 @@ class RecordVideoParallel(BaseParallelWrapper[AgentID, ObsType, ActionType]):
 
     def __del__(self) -> None:
         """Warn the user in case last video wasn't saved."""
-        if len(self.recorded_frames) > 0:
+        # `__init__` can raise before `recorded_frames` is assigned, and `__del__`
+        # still runs on the half-built wrapper. Reading the attribute directly
+        # raised an AttributeError that Python reports as "Exception ignored in",
+        # on top of the error that actually stopped construction.
+        if getattr(self, "recorded_frames", None):
             gymnasium.logger.warn("Unable to save last video! Did you call close()?")

--- a/test/wrapper_record_video_test.py
+++ b/test/wrapper_record_video_test.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 import shutil
 
+import pytest
+
 from pettingzoo.butterfly import pistonball_v6
 from pettingzoo.utils import parallel_to_aec
 from pettingzoo.utils.wrappers import RecordVideo, RecordVideoParallel
@@ -74,3 +76,35 @@ def test_video_folder_and_filenames_parallel(
         "video-prefix-episode-1.mp4",  # episode triggers
         "video-prefix-episode-4.mp4",
     }
+
+
+@pytest.mark.parametrize(
+    "wrapper,env_fn",
+    [
+        (RecordVideo, lambda: parallel_to_aec(pistonball_v6.parallel_env())),
+        (RecordVideoParallel, lambda: pistonball_v6.parallel_env()),
+    ],
+)
+def test_incompatible_render_mode(wrapper, env_fn):
+    """Construction with a render mode that yields no image fails cleanly.
+
+    The message used to be split across two arguments of `ValueError`, so
+    `str(e)` printed a tuple and the sentence telling the user what to do
+    arrived quoted inside it. `__del__` then ran on the half-built wrapper and
+    raised an AttributeError of its own, which Python reports as an ignored
+    exception on top of the real one.
+    """
+    env = env_fn()  # render_mode is None
+
+    with pytest.raises(ValueError) as exc_info:
+        wrapper(env, video_folder="videos")
+
+    assert len(exc_info.value.args) == 1
+    assert "such as rgb_array" in str(exc_info.value)
+
+    # `__del__` runs on the object the failed `__init__` left behind. At the
+    # point of the raise, `super().__init__(env)` had assigned `env` and nothing
+    # else, so that is the whole state to reproduce.
+    half_built = wrapper.__new__(wrapper)
+    half_built.env = env
+    half_built.__del__()


### PR DESCRIPTION
## Description

Constructing `RecordVideo` on an environment whose render mode yields no image
reports three errors where one was intended:

```python
>>> env = parallel_to_aec(pistonball_v6.parallel_env())   # render_mode is None
>>> RecordVideo(env, video_folder="videos")
ValueError: ('Render mode is None, which is incompatible with RecordVideo.', 'Initialize your environment with a render_mode that returns an image, such as rgb_array.')
Exception ignored in: <function RecordVideo.__del__ at 0x...>
AttributeError: 'RecordVideo' object has no attribute 'recorded_frames'
```

Two separate causes.

The message is split across two arguments of `ValueError` rather than
concatenated, so `str(e)` renders a tuple and the sentence that tells the
caller what to do arrives quoted inside it. The comma was meant to be string
concatenation.

`recorded_frames` is assigned further down `__init__`, after this check, so
`__del__` runs on the object the failed constructor left behind and raises an
`AttributeError` of its own. Python reports that as an ignored exception, and
`recorded_frames` has nothing to do with what the caller got wrong.

`__del__` now tolerates a partially initialised wrapper. That covers every
failure path in `__init__` rather than this one alone.

`RecordVideo` and `RecordVideoParallel` carry the same two lines, so both are
fixed here. The same pair exists in Gymnasium's `RecordVideo`, which these
files were adapted from; that one is
[Farama-Foundation/Gymnasium#1671](https://github.com/Farama-Foundation/Gymnasium/pull/1671).

## Tests

`test/wrapper_record_video_test.py`, parametrised over both wrappers: the
exception carries a single argument, the guidance is in the message, and
`__del__` on the state the failed `__init__` leaves behind does not raise.
Both cases fail on `main` and pass with this change; the file goes from 2 to 4
passing.

`pre-commit run` is clean on the three files.

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
