### PR TITLE
Add DtypeObservationV1 wrappers, ported from SuperSuit dtype_v0

### DIFF
--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -129,5 +129,7 @@ while parallel_env.agents:
 .. autoclass:: AssertOutOfBoundsWrapper
 .. autoclass:: ClipOutOfBoundsWrapper
 .. autoclass:: OrderEnforcingWrapper
+.. autoclass:: DtypeObservation
+.. autoclass:: DtypeObservationParallel
 
 ```

--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -129,7 +129,7 @@ while parallel_env.agents:
 .. autoclass:: AssertOutOfBoundsWrapper
 .. autoclass:: ClipOutOfBoundsWrapper
 .. autoclass:: OrderEnforcingWrapper
-.. autoclass:: DtypeObservation
-.. autoclass:: DtypeObservationParallel
+.. autoclass:: DtypeObservationV1
+.. autoclass:: DtypeObservationParallelV1
 
 ```

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -3,7 +3,7 @@ from pettingzoo.utils.wrappers.base import BaseWrapper
 from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
 from pettingzoo.utils.wrappers.capture_stdout import CaptureStdoutWrapper
 from pettingzoo.utils.wrappers.clip_out_of_bounds import ClipOutOfBoundsWrapper
-from pettingzoo.utils.wrappers.dtype import DtypeObservation, DtypeObservationParallel
+from pettingzoo.utils.wrappers.dtype import DtypeObservationV1, DtypeObservationParallelV1
 from pettingzoo.utils.wrappers.multi_episode_env import MultiEpisodeEnv
 from pettingzoo.utils.wrappers.multi_episode_parallel_env import MultiEpisodeParallelEnv
 from pettingzoo.utils.wrappers.order_enforcing import OrderEnforcingWrapper
@@ -17,8 +17,8 @@ __all__ = [
     "BaseWrapper",
     "CaptureStdoutWrapper",
     "ClipOutOfBoundsWrapper",
-    "DtypeObservation",
-    "DtypeObservationParallel",
+    "DtypeObservationV1",
+    "DtypeObservationParallelV1",
     "MultiEpisodeEnv",
     "MultiEpisodeParallelEnv",
     "OrderEnforcingWrapper",

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -3,6 +3,7 @@ from pettingzoo.utils.wrappers.base import BaseWrapper
 from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
 from pettingzoo.utils.wrappers.capture_stdout import CaptureStdoutWrapper
 from pettingzoo.utils.wrappers.clip_out_of_bounds import ClipOutOfBoundsWrapper
+from pettingzoo.utils.wrappers.dtype import DtypeObservation, DtypeObservationParallel
 from pettingzoo.utils.wrappers.multi_episode_env import MultiEpisodeEnv
 from pettingzoo.utils.wrappers.multi_episode_parallel_env import MultiEpisodeParallelEnv
 from pettingzoo.utils.wrappers.order_enforcing import OrderEnforcingWrapper
@@ -16,6 +17,8 @@ __all__ = [
     "BaseWrapper",
     "CaptureStdoutWrapper",
     "ClipOutOfBoundsWrapper",
+    "DtypeObservation",
+    "DtypeObservationParallel",
     "MultiEpisodeEnv",
     "MultiEpisodeParallelEnv",
     "OrderEnforcingWrapper",

--- a/pettingzoo/utils/wrappers/dtype.py
+++ b/pettingzoo/utils/wrappers/dtype.py
@@ -33,7 +33,7 @@ def _cast_space(
         ) from e
 
 
-class DtypeObservation(BaseWrapper[AgentID, Any, ActionType]):
+class DtypeObservationV1(BaseWrapper[AgentID, Any, ActionType]):
     """Recasts each agent's observation to ``dtype``.
 
     The observation space becomes a Box with the same shape and the new dtype,
@@ -51,8 +51,8 @@ class DtypeObservation(BaseWrapper[AgentID, Any, ActionType]):
 
     def __init__(self, env: AECEnv[AgentID, ObsType, ActionType], dtype: Any):
         assert isinstance(env, AECEnv), (
-            "DtypeObservation is only compatible with AEC environments, "
-            "use DtypeObservationParallel instead."
+            "DtypeObservationV1 is only compatible with AEC environments, "
+            "use DtypeObservationParallelV1 instead."
         )
         super().__init__(env)
         self.dtype = np.dtype(dtype)
@@ -83,10 +83,10 @@ class DtypeObservation(BaseWrapper[AgentID, Any, ActionType]):
 
     @override
     def __str__(self) -> str:
-        return f"DtypeObservation<{self.env!s}>"
+        return f"DtypeObservationV1<{self.env!s}>"
 
 
-class DtypeObservationParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
+class DtypeObservationParallelV1(BaseParallelWrapper[AgentID, Any, ActionType]):
     """Recasts each agent's observation to ``dtype``.
 
     The observation space becomes a Box with the same shape and the new dtype,
@@ -151,4 +151,4 @@ class DtypeObservationParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
 
     @override
     def __str__(self) -> str:
-        return f"DtypeObservationParallel<{self.env!s}>"
+        return f"DtypeObservationParallelV1<{self.env!s}>"

--- a/pettingzoo/utils/wrappers/dtype.py
+++ b/pettingzoo/utils/wrappers/dtype.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any
+
+import gymnasium.spaces
+import numpy as np
+from gymnasium.spaces import Box
+from typing_extensions import override
+
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
+from pettingzoo.utils.wrappers.base import BaseWrapper
+from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
+
+
+def _cast_space(
+    space: gymnasium.spaces.Space[Any], dtype: np.dtype, agent: AgentID, wrapper: str
+) -> Box:
+    """Returns ``space`` with its bounds and dtype cast to ``dtype``."""
+    assert isinstance(space, Box), (
+        f"{wrapper} only supports Box observation spaces, "
+        f"agent {agent!r} has a {type(space).__name__}."
+    )
+    try:
+        return Box(
+            low=space.low.astype(dtype),
+            high=space.high.astype(dtype),
+            dtype=dtype.type,
+        )
+    except ValueError as e:
+        raise ValueError(
+            f"{wrapper} cannot cast agent {agent!r}'s observation space "
+            f"{space} to {dtype}: the cast bounds are not a valid Box."
+        ) from e
+
+
+class DtypeObservation(BaseWrapper[AgentID, Any, ActionType]):
+    """Recasts each agent's observation to ``dtype``.
+
+    The observation space becomes a Box with the same shape and the new dtype,
+    with the old bounds put through the same cast. Every space in
+    ``possible_agents`` is built and checked when the wrapper is created.
+
+    Bounds that do not fit the new dtype wrap around, and casting an infinite
+    bound to an integer dtype is undefined in numpy, so an unbounded Box cast to
+    an integer dtype collapses to a single point that will not contain the
+    observations. Both match SuperSuit's ``dtype_v0``.
+
+    :param env: The AEC environment to wrap.
+    :param dtype: Anything ``numpy.dtype`` accepts, e.g. ``np.float32``.
+    """
+
+    def __init__(self, env: AECEnv[AgentID, ObsType, ActionType], dtype: Any):
+        assert isinstance(env, AECEnv), (
+            "DtypeObservation is only compatible with AEC environments, "
+            "use DtypeObservationParallel instead."
+        )
+        super().__init__(env)
+        self.dtype = np.dtype(dtype)
+        self._obs_spaces: dict[AgentID, Box] = {
+            agent: _cast_space(
+                env.observation_space(agent), self.dtype, agent, type(self).__name__
+            )
+            for agent in getattr(env, "possible_agents", [])
+        }
+
+    @override
+    def observation_space(self, agent: AgentID) -> Box:
+        if agent not in self._obs_spaces:
+            self._obs_spaces[agent] = _cast_space(
+                self.env.observation_space(agent),
+                self.dtype,
+                agent,
+                type(self).__name__,
+            )
+        return self._obs_spaces[agent]
+
+    @override
+    def observe(self, agent: AgentID) -> Any:
+        obs = self.env.observe(agent)
+        if obs is None:
+            return None
+        return np.asarray(obs).astype(self.dtype)
+
+    @override
+    def __str__(self) -> str:
+        return f"DtypeObservation<{self.env!s}>"
+
+
+class DtypeObservationParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
+    """Recasts each agent's observation to ``dtype``.
+
+    The observation space becomes a Box with the same shape and the new dtype,
+    with the old bounds put through the same cast. Every space in
+    ``possible_agents`` is built and checked when the wrapper is created.
+
+    Bounds that do not fit the new dtype wrap around, and casting an infinite
+    bound to an integer dtype is undefined in numpy, so an unbounded Box cast to
+    an integer dtype collapses to a single point that will not contain the
+    observations. Both match SuperSuit's ``dtype_v0``.
+
+    :param env: The parallel environment to wrap.
+    :param dtype: Anything ``numpy.dtype`` accepts, e.g. ``np.float32``.
+    """
+
+    def __init__(self, env: ParallelEnv[AgentID, ObsType, ActionType], dtype: Any):
+        super().__init__(env)
+        self.dtype = np.dtype(dtype)
+        self._obs_spaces: dict[AgentID, Box] = {
+            agent: _cast_space(
+                env.observation_space(agent), self.dtype, agent, type(self).__name__
+            )
+            for agent in getattr(env, "possible_agents", [])
+        }
+
+    @override
+    def observation_space(self, agent: AgentID) -> Box:
+        if agent not in self._obs_spaces:
+            self._obs_spaces[agent] = _cast_space(
+                self.env.observation_space(agent),
+                self.dtype,
+                agent,
+                type(self).__name__,
+            )
+        return self._obs_spaces[agent]
+
+    def _cast(self, observations: dict[AgentID, Any]) -> dict[AgentID, Any]:
+        return {
+            agent: np.asarray(obs).astype(self.dtype)
+            for agent, obs in observations.items()
+        }
+
+    @override
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[dict[AgentID, Any], dict[AgentID, dict[str, Any]]]:
+        observations, infos = self.env.reset(seed=seed, options=options)
+        return self._cast(observations), infos
+
+    @override
+    def step(
+        self, actions: dict[AgentID, ActionType]
+    ) -> tuple[
+        dict[AgentID, Any],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict[str, Any]],
+    ]:
+        observations, rewards, terminations, truncations, infos = self.env.step(actions)
+        return self._cast(observations), rewards, terminations, truncations, infos
+
+    @override
+    def __str__(self) -> str:
+        return f"DtypeObservationParallel<{self.env!s}>"

--- a/test/dtype_test.py
+++ b/test/dtype_test.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pytest
+from gymnasium.spaces import Box, Discrete
+
+from pettingzoo.test import api_test, parallel_api_test
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+from pettingzoo.utils.wrappers import DtypeObservation, DtypeObservationParallel
+
+AGENTS = ["agent_0", "agent_1"]
+
+FIXED_OBS = {
+    "agent_0": np.arange(12, dtype=np.uint8).reshape(2, 2, 3),
+    "agent_1": np.array([-1.0, -0.5, 0.25, 1.0], dtype=np.float32),
+}
+
+
+@functools.cache
+def obs_space(agent):
+    if agent == "agent_0":
+        return Box(low=0, high=255, shape=(2, 2, 3), dtype=np.uint8)
+    return Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float32)
+
+
+class DummyAEC(AECEnv):
+    metadata = {"render_modes": [], "name": "dummy_aec"}
+
+    def __init__(self):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+
+    def observation_space(self, agent):
+        return obs_space(agent)
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        self._cumulative_rewards = dict.fromkeys(self.agents, 0.0)
+        self.terminations = dict.fromkeys(self.agents, False)
+        self.truncations = dict.fromkeys(self.agents, False)
+        self.infos = {a: {} for a in self.agents}
+        self._idx = 0
+        self._step_count = 0
+        self.agent_selection = self.agents[0]
+
+    def observe(self, agent):
+        return FIXED_OBS[agent]
+
+    def step(self, action):
+        self._step_count += 1
+        self._cumulative_rewards[self.agent_selection] = 0.0
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        if self._step_count >= 8:
+            self.terminations = dict.fromkeys(self.agents, True)
+        self._idx = (self._idx + 1) % len(self.agents)
+        self.agent_selection = self.agents[self._idx]
+        self._accumulate_rewards()
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class DummyParallel(ParallelEnv):
+    metadata = {"render_modes": [], "name": "dummy_parallel"}
+
+    def __init__(self):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+
+    def observation_space(self, agent):
+        return obs_space(agent)
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self._step_count = 0
+        return dict(FIXED_OBS), {a: {} for a in self.agents}
+
+    def step(self, actions):
+        self._step_count += 1
+        done = self._step_count >= 8
+        obs = dict(FIXED_OBS)
+        rewards = dict.fromkeys(self.agents, 0.0)
+        terminations = dict.fromkeys(self.agents, done)
+        truncations = dict.fromkeys(self.agents, False)
+        infos = {a: {} for a in self.agents}
+        if done:
+            self.agents = []
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class WideAEC(DummyAEC):
+    """One agent, bounds and values that do not fit in a uint8."""
+
+    def observation_space(self, agent):
+        return Box(low=0.0, high=300.0, shape=(2,), dtype=np.float32)
+
+    def observe(self, agent):
+        return np.array([1.0, 300.0], dtype=np.float32)
+
+
+class WideParallel(DummyParallel):
+    def observation_space(self, agent):
+        return Box(low=0.0, high=300.0, shape=(2,), dtype=np.float32)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self._step_count = 0
+        obs = dict.fromkeys(self.agents, np.array([1.0, 300.0], dtype=np.float32))
+        return obs, {a: {} for a in self.agents}
+
+
+class UnboundedAEC(DummyAEC):
+    def observation_space(self, agent):
+        return Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.float32)
+
+    def observe(self, agent):
+        return np.array([1.5, -2.5], dtype=np.float32)
+
+
+# shape, low, high each agent's space should have after a cast to float32.
+EXPECTED_FLOAT32 = {
+    "agent_0": ((2, 2, 3), 0.0, 255.0),
+    "agent_1": ((4,), -1.0, 1.0),
+}
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_observation_space(agent):
+    space = DtypeObservation(DummyAEC(), np.float32).observation_space(agent)
+    shape, low, high = EXPECTED_FLOAT32[agent]
+    assert isinstance(space, Box)
+    assert space.dtype == np.float32
+    assert space.shape == shape
+    assert (space.low == low).all()
+    assert (space.high == high).all()
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_parallel_observation_space(agent):
+    space = DtypeObservationParallel(DummyParallel(), np.float32).observation_space(
+        agent
+    )
+    shape, low, high = EXPECTED_FLOAT32[agent]
+    assert isinstance(space, Box)
+    assert space.dtype == np.float32
+    assert space.shape == shape
+    assert (space.low == low).all()
+    assert (space.high == high).all()
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_observe_is_cast(agent):
+    env = DtypeObservation(DummyAEC(), np.float32)
+    env.reset(seed=0)
+
+    obs = env.observe(agent)
+    assert obs.dtype == np.float32
+    assert np.array_equal(obs, FIXED_OBS[agent].astype(np.float32))
+    assert env.observation_space(agent).contains(obs)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_parallel_reset_and_step_are_cast(agent):
+    env = DtypeObservationParallel(DummyParallel(), np.float32)
+
+    obs, _ = env.reset(seed=0)
+    assert obs[agent].dtype == np.float32
+    assert np.array_equal(obs[agent], FIXED_OBS[agent].astype(np.float32))
+    assert env.observation_space(agent).contains(obs[agent])
+
+    obs, _, _, _, _ = env.step(dict.fromkeys(env.agents, 0))
+    assert obs[agent].dtype == np.float32
+    assert np.array_equal(obs[agent], FIXED_OBS[agent].astype(np.float32))
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_last_is_cast(agent):
+    env = DtypeObservation(DummyAEC(), np.float32)
+    env.reset(seed=0)
+    while env.agent_selection != agent:
+        env.step(0)
+
+    obs, _, _, _, _ = env.last()
+    assert obs.dtype == np.float32
+    assert np.array_equal(obs, FIXED_OBS[agent].astype(np.float32))
+
+
+def test_uint8_image_to_float32():
+    env = DtypeObservation(DummyAEC(), np.float32)
+    env.reset(seed=0)
+
+    space = env.observation_space("agent_0")
+    assert space.shape == (2, 2, 3)
+    assert (space.low == 0.0).all()
+    assert (space.high == 255.0).all()
+
+    obs = env.observe("agent_0")
+    assert obs.dtype == np.float32
+    assert np.array_equal(obs, np.arange(12, dtype=np.float32).reshape(2, 2, 3))
+
+
+def test_downcast_wraps_bounds_like_supersuit():
+    """A cast that overflows the new dtype wraps, in the space and the value."""
+    env = DtypeObservation(WideAEC(), np.uint8)
+    env.reset(seed=0)
+
+    space = env.observation_space("agent_0")
+    assert space.dtype == np.uint8
+    assert np.array_equal(space.low, np.array([0, 0], dtype=np.uint8))
+    assert np.array_equal(space.high, np.array([44, 44], dtype=np.uint8))  # 300 % 256
+
+    obs = env.observe("agent_0")
+    assert obs.dtype == np.uint8
+    assert np.array_equal(obs, np.array([1, 44], dtype=np.uint8))
+
+
+def test_parallel_downcast_wraps_bounds_like_supersuit():
+    env = DtypeObservationParallel(WideParallel(), np.uint8)
+
+    space = env.observation_space("agent_0")
+    assert space.dtype == np.uint8
+    assert np.array_equal(space.low, np.array([0, 0], dtype=np.uint8))
+    assert np.array_equal(space.high, np.array([44, 44], dtype=np.uint8))
+
+    obs, _ = env.reset(seed=0)
+    assert obs["agent_0"].dtype == np.uint8
+    assert np.array_equal(obs["agent_0"], np.array([1, 44], dtype=np.uint8))
+
+
+def test_unbounded_space_cast_to_int_collapses():
+    """Casting an infinite bound to an int dtype is undefined, as in SuperSuit."""
+    with pytest.warns(RuntimeWarning, match="invalid value encountered in cast"):
+        env = DtypeObservation(UnboundedAEC(), np.int32)
+
+    space = env.observation_space("agent_0")
+    assert space.dtype == np.int32
+    assert np.array_equal(space.low, np.array([np.iinfo(np.int32).min] * 2))
+    assert np.array_equal(space.high, np.array([np.iinfo(np.int32).min] * 2))
+
+    env.reset(seed=0)
+    assert not space.contains(env.observe("agent_0"))
+    with pytest.raises(AssertionError, match="Out of bounds observation"):
+        api_test(env, num_cycles=2)
+
+
+def test_impossible_cast_names_the_wrapper_and_agent():
+    with pytest.raises(
+        ValueError, match=r"DtypeObservation cannot cast agent 'agent_0'"
+    ):
+        DtypeObservation(DummyAEC(), np.int8)
+
+    with pytest.raises(
+        ValueError, match=r"DtypeObservationParallel cannot cast agent 'agent_0'"
+    ):
+        DtypeObservationParallel(DummyParallel(), np.int8)
+
+
+def test_str():
+    inner = DummyAEC()
+    assert str(DtypeObservation(inner, np.float32)) == f"DtypeObservation<{inner!s}>"
+    inner = DummyParallel()
+    assert (
+        str(DtypeObservationParallel(inner, np.float32))
+        == f"DtypeObservationParallel<{inner!s}>"
+    )
+
+
+def test_observe_passes_through_none():
+    class NoneObsEnv(DummyAEC):
+        def observe(self, agent):
+            return None
+
+    env = DtypeObservation(NoneObsEnv(), np.float32)
+    env.reset(seed=0)
+    assert env.observe("agent_0") is None
+
+
+def test_aec_api():
+    api_test(DtypeObservation(DummyAEC(), np.float32), num_cycles=5)
+
+
+def test_parallel_api():
+    parallel_api_test(
+        DtypeObservationParallel(DummyParallel(), np.float32), num_cycles=5
+    )
+
+
+def test_rejects_parallel_env():
+    with pytest.raises(AssertionError):
+        DtypeObservation(DummyParallel(), np.float32)
+
+
+def test_rejects_bad_dtype():
+    with pytest.raises(TypeError):
+        DtypeObservation(DummyAEC(), "not_a_dtype")
+
+
+def test_rejects_non_box_space_at_construction():
+    class DiscreteObsAEC(DummyAEC):
+        def observation_space(self, agent):
+            return Discrete(4)
+
+    class DiscreteObsParallel(DummyParallel):
+        def observation_space(self, agent):
+            return Discrete(4)
+
+    with pytest.raises(
+        AssertionError, match="DtypeObservation only supports Box observation spaces"
+    ):
+        DtypeObservation(DiscreteObsAEC(), np.float32)
+
+    with pytest.raises(
+        AssertionError,
+        match="DtypeObservationParallel only supports Box observation spaces",
+    ):
+        DtypeObservationParallel(DiscreteObsParallel(), np.float32)
+
+
+def test_agent_outside_possible_agents_resolves_lazily():
+    class ExtraAgentEnv(DummyAEC):
+        def observation_space(self, agent):
+            if agent == "agent_2":
+                return Box(low=0.0, high=1.0, shape=(3,), dtype=np.float64)
+            return obs_space(agent)
+
+    env = DtypeObservation(ExtraAgentEnv(), np.float32)
+    space = env.observation_space("agent_2")
+    assert space.dtype == np.float32
+    assert space.shape == (3,)

--- a/test/dtype_test.py
+++ b/test/dtype_test.py
@@ -8,7 +8,7 @@ from gymnasium.spaces import Box, Discrete
 
 from pettingzoo.test import api_test, parallel_api_test
 from pettingzoo.utils.env import AECEnv, ParallelEnv
-from pettingzoo.utils.wrappers import DtypeObservation, DtypeObservationParallel
+from pettingzoo.utils.wrappers import DtypeObservationV1, DtypeObservationParallelV1
 
 AGENTS = ["agent_0", "agent_1"]
 
@@ -146,7 +146,7 @@ EXPECTED_FLOAT32 = {
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_observation_space(agent):
-    space = DtypeObservation(DummyAEC(), np.float32).observation_space(agent)
+    space = DtypeObservationV1(DummyAEC(), np.float32).observation_space(agent)
     shape, low, high = EXPECTED_FLOAT32[agent]
     assert isinstance(space, Box)
     assert space.dtype == np.float32
@@ -157,7 +157,7 @@ def test_aec_observation_space(agent):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_parallel_observation_space(agent):
-    space = DtypeObservationParallel(DummyParallel(), np.float32).observation_space(
+    space = DtypeObservationParallelV1(DummyParallel(), np.float32).observation_space(
         agent
     )
     shape, low, high = EXPECTED_FLOAT32[agent]
@@ -170,7 +170,7 @@ def test_parallel_observation_space(agent):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_observe_is_cast(agent):
-    env = DtypeObservation(DummyAEC(), np.float32)
+    env = DtypeObservationV1(DummyAEC(), np.float32)
     env.reset(seed=0)
 
     obs = env.observe(agent)
@@ -181,7 +181,7 @@ def test_aec_observe_is_cast(agent):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_parallel_reset_and_step_are_cast(agent):
-    env = DtypeObservationParallel(DummyParallel(), np.float32)
+    env = DtypeObservationParallelV1(DummyParallel(), np.float32)
 
     obs, _ = env.reset(seed=0)
     assert obs[agent].dtype == np.float32
@@ -195,7 +195,7 @@ def test_parallel_reset_and_step_are_cast(agent):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_last_is_cast(agent):
-    env = DtypeObservation(DummyAEC(), np.float32)
+    env = DtypeObservationV1(DummyAEC(), np.float32)
     env.reset(seed=0)
     while env.agent_selection != agent:
         env.step(0)
@@ -206,7 +206,7 @@ def test_aec_last_is_cast(agent):
 
 
 def test_uint8_image_to_float32():
-    env = DtypeObservation(DummyAEC(), np.float32)
+    env = DtypeObservationV1(DummyAEC(), np.float32)
     env.reset(seed=0)
 
     space = env.observation_space("agent_0")
@@ -221,7 +221,7 @@ def test_uint8_image_to_float32():
 
 def test_downcast_wraps_bounds_like_supersuit():
     """A cast that overflows the new dtype wraps, in the space and the value."""
-    env = DtypeObservation(WideAEC(), np.uint8)
+    env = DtypeObservationV1(WideAEC(), np.uint8)
     env.reset(seed=0)
 
     space = env.observation_space("agent_0")
@@ -235,7 +235,7 @@ def test_downcast_wraps_bounds_like_supersuit():
 
 
 def test_parallel_downcast_wraps_bounds_like_supersuit():
-    env = DtypeObservationParallel(WideParallel(), np.uint8)
+    env = DtypeObservationParallelV1(WideParallel(), np.uint8)
 
     space = env.observation_space("agent_0")
     assert space.dtype == np.uint8
@@ -250,7 +250,7 @@ def test_parallel_downcast_wraps_bounds_like_supersuit():
 def test_unbounded_space_cast_to_int_collapses():
     """Casting an infinite bound to an int dtype is undefined, as in SuperSuit."""
     with pytest.warns(RuntimeWarning, match="invalid value encountered in cast"):
-        env = DtypeObservation(UnboundedAEC(), np.int32)
+        env = DtypeObservationV1(UnboundedAEC(), np.int32)
 
     space = env.observation_space("agent_0")
     assert space.dtype == np.int32
@@ -265,23 +265,23 @@ def test_unbounded_space_cast_to_int_collapses():
 
 def test_impossible_cast_names_the_wrapper_and_agent():
     with pytest.raises(
-        ValueError, match=r"DtypeObservation cannot cast agent 'agent_0'"
+        ValueError, match=r"DtypeObservationV1 cannot cast agent 'agent_0'"
     ):
-        DtypeObservation(DummyAEC(), np.int8)
+        DtypeObservationV1(DummyAEC(), np.int8)
 
     with pytest.raises(
-        ValueError, match=r"DtypeObservationParallel cannot cast agent 'agent_0'"
+        ValueError, match=r"DtypeObservationParallelV1 cannot cast agent 'agent_0'"
     ):
-        DtypeObservationParallel(DummyParallel(), np.int8)
+        DtypeObservationParallelV1(DummyParallel(), np.int8)
 
 
 def test_str():
     inner = DummyAEC()
-    assert str(DtypeObservation(inner, np.float32)) == f"DtypeObservation<{inner!s}>"
+    assert str(DtypeObservationV1(inner, np.float32)) == f"DtypeObservationV1<{inner!s}>"
     inner = DummyParallel()
     assert (
-        str(DtypeObservationParallel(inner, np.float32))
-        == f"DtypeObservationParallel<{inner!s}>"
+        str(DtypeObservationParallelV1(inner, np.float32))
+        == f"DtypeObservationParallelV1<{inner!s}>"
     )
 
 
@@ -290,29 +290,29 @@ def test_observe_passes_through_none():
         def observe(self, agent):
             return None
 
-    env = DtypeObservation(NoneObsEnv(), np.float32)
+    env = DtypeObservationV1(NoneObsEnv(), np.float32)
     env.reset(seed=0)
     assert env.observe("agent_0") is None
 
 
 def test_aec_api():
-    api_test(DtypeObservation(DummyAEC(), np.float32), num_cycles=5)
+    api_test(DtypeObservationV1(DummyAEC(), np.float32), num_cycles=5)
 
 
 def test_parallel_api():
     parallel_api_test(
-        DtypeObservationParallel(DummyParallel(), np.float32), num_cycles=5
+        DtypeObservationParallelV1(DummyParallel(), np.float32), num_cycles=5
     )
 
 
 def test_rejects_parallel_env():
     with pytest.raises(AssertionError):
-        DtypeObservation(DummyParallel(), np.float32)
+        DtypeObservationV1(DummyParallel(), np.float32)
 
 
 def test_rejects_bad_dtype():
     with pytest.raises(TypeError):
-        DtypeObservation(DummyAEC(), "not_a_dtype")
+        DtypeObservationV1(DummyAEC(), "not_a_dtype")
 
 
 def test_rejects_non_box_space_at_construction():
@@ -325,15 +325,15 @@ def test_rejects_non_box_space_at_construction():
             return Discrete(4)
 
     with pytest.raises(
-        AssertionError, match="DtypeObservation only supports Box observation spaces"
+        AssertionError, match="DtypeObservationV1 only supports Box observation spaces"
     ):
-        DtypeObservation(DiscreteObsAEC(), np.float32)
+        DtypeObservationV1(DiscreteObsAEC(), np.float32)
 
     with pytest.raises(
         AssertionError,
-        match="DtypeObservationParallel only supports Box observation spaces",
+        match="DtypeObservationParallelV1 only supports Box observation spaces",
     ):
-        DtypeObservationParallel(DiscreteObsParallel(), np.float32)
+        DtypeObservationParallelV1(DiscreteObsParallel(), np.float32)
 
 
 def test_agent_outside_possible_agents_resolves_lazily():
@@ -343,7 +343,7 @@ def test_agent_outside_possible_agents_resolves_lazily():
                 return Box(low=0.0, high=1.0, shape=(3,), dtype=np.float64)
             return obs_space(agent)
 
-    env = DtypeObservation(ExtraAgentEnv(), np.float32)
+    env = DtypeObservationV1(ExtraAgentEnv(), np.float32)
     space = env.observation_space("agent_2")
     assert space.dtype == np.float32
     assert space.shape == (3,)


### PR DESCRIPTION
# Description

Ports SuperSuit's `dtype_v0` as `DtypeObservationV1` and `DtypeObservationParallelV1`, part of #1365. Recasts each agent's observation and rewrites the advertised observation space to the new dtype.

Classes rather than a factory function, per @virgilt's note in the issue about mirroring `gymnasium.wrappers`, and named after the Gymnasium equivalent. AEC and Parallel are both implemented directly on the PettingZoo wrapper bases, so the Parallel class works on a Parallel env without converting to AEC and back.

Same shape as #1415, which is the other wrapper port currently open.

## One thing worth knowing

The space conversion follows SuperSuit's `convert_box`: cast the bounds, then hand them to `Box`. `gymnasium.wrappers.DtypeObservationV1` hands the original bounds to `Box` and lets it validate. The two disagree on finite overflow, and I kept SuperSuit's behaviour so migrating code doesn't change under people:

    Box(0.0, 300.0, float32) -> uint8
      here and in SuperSuit:  Box(0, 44, uint8)      # 300 % 256
      gymnasium:              ValueError, high is out of bounds for the dtype

They agree on infinite bounds (both collapse to a degenerate box, neither raises), and both raise when a downcast flips low above high. `test_downcast_wraps_bounds_like_supersuit` pins this with literals so it's obvious if anyone changes it.

One related trap that has a test and a docstring line now: an unbounded Box cast to an integer dtype collapses to a single point, and `api_test` then fails with an out of bounds observation. That's true of SuperSuit too, but unbounded spaces are common in PettingZoo so it's worth saying out loud rather than leaving people to find it.

Box only, matching SuperSuit. Gymnasium's version also takes Discrete, MultiDiscrete and MultiBinary, so anyone coming from that one hits the assert.

## Verification

    $ pytest test/dtype_test.py -q
    23 passed, 5 warnings in 0.12s

    $ pytest test/wrapper_test.py -q
    13 passed, 18 warnings in 22.93s

I checked the port against SuperSuit's actual `change_obs_space` and `change_observation` rather than against my reading of them, on uint8, float32, float64, int8, int32 and unbounded spaces. No divergences.

## A question

`observation_space(agent)` returns the cast space, but `observation_spaces[agent]` still returns the original, because neither base wrapper overrides the dict and `__getattr__` forwards it to the inner env. This PR and #1415 are the first PettingZoo wrappers that change an observation space, so it's the first time the two can disagree. Worth fixing once in `BaseWrapper` and `BaseParallelWrapper` rather than in each wrapper? Happy to do it in a separate PR if you want it, I just didn't want to change the base classes inside a wrapper PR.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the `pre-commit` checks on the changed files, all hooks pass including `ty` and `pydocstyle`
- [ ] I have not run the full `pytest -v`, since I don't have the Atari ROMs and some of the extras installed. I ran the new test file and `test/wrapper_test.py`, both green, and the exact output is above.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
