### PR TITLE
Add ReshapeObservationV1 wrappers, ported from SuperSuit reshape_v0

### DIFF
--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -140,5 +140,7 @@ while parallel_env.agents:
 .. autoclass:: DtypeObservationParallelV1
 .. autoclass:: PadObservationsV1
 .. autoclass:: PadObservationsParallelV1
+.. autoclass:: ReshapeObservation
+.. autoclass:: ReshapeObservationParallel
 
 ```

--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -140,7 +140,7 @@ while parallel_env.agents:
 .. autoclass:: DtypeObservationParallelV1
 .. autoclass:: PadObservationsV1
 .. autoclass:: PadObservationsParallelV1
-.. autoclass:: ReshapeObservation
-.. autoclass:: ReshapeObservationParallel
+.. autoclass:: ReshapeObservationV1
+.. autoclass:: ReshapeObservationParallelV1
 
 ```

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -24,6 +24,10 @@ from pettingzoo.utils.wrappers.pad_observations import (
 )
 from pettingzoo.utils.wrappers.record_video import RecordVideo
 from pettingzoo.utils.wrappers.record_video_parallel import RecordVideoParallel
+from pettingzoo.utils.wrappers.reshape import (
+    ReshapeObservation,
+    ReshapeObservationParallel,
+)
 from pettingzoo.utils.wrappers.terminate_illegal import TerminateIllegalWrapper
 
 __all__ = [
@@ -45,5 +49,7 @@ __all__ = [
     "PadObservationsV1",
     "RecordVideo",
     "RecordVideoParallel",
+    "ReshapeObservation",
+    "ReshapeObservationParallel",
     "TerminateIllegalWrapper",
 ]

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -25,8 +25,8 @@ from pettingzoo.utils.wrappers.pad_observations import (
 from pettingzoo.utils.wrappers.record_video import RecordVideo
 from pettingzoo.utils.wrappers.record_video_parallel import RecordVideoParallel
 from pettingzoo.utils.wrappers.reshape import (
-    ReshapeObservation,
-    ReshapeObservationParallel,
+    ReshapeObservationParallelV1,
+    ReshapeObservationV1,
 )
 from pettingzoo.utils.wrappers.terminate_illegal import TerminateIllegalWrapper
 
@@ -49,7 +49,7 @@ __all__ = [
     "PadObservationsV1",
     "RecordVideo",
     "RecordVideoParallel",
-    "ReshapeObservation",
-    "ReshapeObservationParallel",
+    "ReshapeObservationParallelV1",
+    "ReshapeObservationV1",
     "TerminateIllegalWrapper",
 ]

--- a/pettingzoo/utils/wrappers/reshape.py
+++ b/pettingzoo/utils/wrappers/reshape.py
@@ -45,7 +45,7 @@ def _reshaped_space(
     )
 
 
-class ReshapeObservation(BaseWrapper[AgentID, Any, ActionType]):
+class ReshapeObservationV1(BaseWrapper[AgentID, Any, ActionType]):
     """Reshapes each agent's observation to the given shape.
 
     The observation space is reshaped the same way, so per-element bounds are kept.
@@ -59,8 +59,8 @@ class ReshapeObservation(BaseWrapper[AgentID, Any, ActionType]):
         self, env: AECEnv[AgentID, ObsType, ActionType], shape: tuple[int, ...]
     ):
         assert isinstance(env, AECEnv), (
-            "ReshapeObservation is only compatible with AEC environments, "
-            "use ReshapeObservationParallel instead."
+            "ReshapeObservationV1 is only compatible with AEC environments, "
+            "use ReshapeObservationParallelV1 instead."
         )
         _check_shape(shape)
         super().__init__(env)
@@ -90,10 +90,10 @@ class ReshapeObservation(BaseWrapper[AgentID, Any, ActionType]):
 
     @override
     def __str__(self) -> str:
-        return f"ReshapeObservation<{self.env!s}>"
+        return f"ReshapeObservationV1<{self.env!s}>"
 
 
-class ReshapeObservationParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
+class ReshapeObservationParallelV1(BaseParallelWrapper[AgentID, Any, ActionType]):
     """Reshapes each agent's observation to the given shape.
 
     The observation space is reshaped the same way, so per-element bounds are kept.
@@ -153,4 +153,4 @@ class ReshapeObservationParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
 
     @override
     def __str__(self) -> str:
-        return f"ReshapeObservationParallel<{self.env!s}>"
+        return f"ReshapeObservationParallelV1<{self.env!s}>"

--- a/pettingzoo/utils/wrappers/reshape.py
+++ b/pettingzoo/utils/wrappers/reshape.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import gymnasium.spaces
+import numpy as np
+from gymnasium.spaces import Box
+from typing_extensions import override
+
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
+from pettingzoo.utils.wrappers.base import BaseWrapper
+from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
+
+
+def _check_shape(shape: tuple[int, ...]) -> None:
+    assert isinstance(shape, tuple), f"shape must be a tuple, is {shape}"
+    assert len(shape) > 0, "shape must not be empty"
+    assert all(np.issubdtype(type(element), np.integer) for element in shape), (
+        f"shape must be a tuple of ints, is {shape}"
+    )
+    assert all(element != -1 for element in shape), (
+        f"-1 is not supported, give the size of every axis. shape is {shape}"
+    )
+    assert all(element > 0 for element in shape), (
+        f"shape must be a tuple of positive ints, is {shape}"
+    )
+
+
+def _reshaped_space(
+    space: gymnasium.spaces.Space[Any], shape: tuple[int, ...], agent: AgentID
+) -> Box:
+    """Returns `space` reshaped to `shape`, keeping the per-element bounds."""
+    assert isinstance(space, Box), (
+        f"reshape is only defined for Box observation spaces, "
+        f"the space of agent {agent} is {space}."
+    )
+    assert np.prod(shape) == np.prod(space.shape), (
+        f"new shape {shape} must have as many elements as the observation "
+        f"space of agent {agent}, which has shape {space.shape}."
+    )
+    # Box accepts a numpy dtype, its annotation just says otherwise.
+    dtype = cast("type[np.floating[Any] | np.integer[Any]]", space.dtype)
+    return Box(
+        low=space.low.reshape(shape), high=space.high.reshape(shape), dtype=dtype
+    )
+
+
+class ReshapeObservation(BaseWrapper[AgentID, Any, ActionType]):
+    """Reshapes each agent's observation to the given shape.
+
+    The observation space is reshaped the same way, so per-element bounds are kept.
+    Only works on Box observation spaces.
+
+    :param env: The AEC environment to wrap.
+    :param shape: The new observation shape. Must have as many elements as the old one.
+    """
+
+    def __init__(
+        self, env: AECEnv[AgentID, ObsType, ActionType], shape: tuple[int, ...]
+    ):
+        assert isinstance(env, AECEnv), (
+            "ReshapeObservation is only compatible with AEC environments, "
+            "use ReshapeObservationParallel instead."
+        )
+        _check_shape(shape)
+        super().__init__(env)
+        self.shape = shape
+        self._obs_spaces: dict[AgentID, Box] = {}
+        # Fail on construction for envs that already know their agents. Envs that
+        # only fill possible_agents in reset() are caught on the first observation.
+        for agent in getattr(env, "possible_agents", []):
+            self.observation_space(agent)
+
+    @override
+    def observation_space(self, agent: AgentID) -> Box:
+        if agent not in self._obs_spaces:
+            self._obs_spaces[agent] = _reshaped_space(
+                self.env.observation_space(agent), self.shape, agent
+            )
+        return self._obs_spaces[agent]
+
+    @override
+    def observe(self, agent: AgentID) -> np.ndarray | None:
+        # Checks the shape against this agent's space. Cached after the first call.
+        self.observation_space(agent)
+        obs = self.env.observe(agent)
+        if obs is None:
+            return None
+        return np.reshape(obs, self.shape)
+
+    @override
+    def __str__(self) -> str:
+        return f"ReshapeObservation<{self.env!s}>"
+
+
+class ReshapeObservationParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
+    """Reshapes each agent's observation to the given shape.
+
+    The observation space is reshaped the same way, so per-element bounds are kept.
+    Only works on Box observation spaces.
+
+    :param env: The parallel environment to wrap.
+    :param shape: The new observation shape. Must have as many elements as the old one.
+    """
+
+    def __init__(
+        self, env: ParallelEnv[AgentID, ObsType, ActionType], shape: tuple[int, ...]
+    ):
+        _check_shape(shape)
+        super().__init__(env)
+        self.shape = shape
+        self._obs_spaces: dict[AgentID, Box] = {}
+        # Fail on construction for envs that already know their agents. Envs that
+        # only fill possible_agents in reset() are caught on the first observation.
+        for agent in getattr(env, "possible_agents", []):
+            self.observation_space(agent)
+
+    @override
+    def observation_space(self, agent: AgentID) -> Box:
+        if agent not in self._obs_spaces:
+            self._obs_spaces[agent] = _reshaped_space(
+                self.env.observation_space(agent), self.shape, agent
+            )
+        return self._obs_spaces[agent]
+
+    def _reshape(self, observations: dict[AgentID, Any]) -> dict[AgentID, np.ndarray]:
+        reshaped = {}
+        for agent, obs in observations.items():
+            # Checks the shape against this agent's space. Cached after the first call.
+            self.observation_space(agent)
+            reshaped[agent] = np.reshape(obs, self.shape)
+        return reshaped
+
+    @override
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[dict[AgentID, np.ndarray], dict[AgentID, dict[str, Any]]]:
+        observations, infos = self.env.reset(seed=seed, options=options)
+        return self._reshape(observations), infos
+
+    @override
+    def step(
+        self, actions: dict[AgentID, ActionType]
+    ) -> tuple[
+        dict[AgentID, np.ndarray],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict[str, Any]],
+    ]:
+        observations, rewards, terminations, truncations, infos = self.env.step(actions)
+        return self._reshape(observations), rewards, terminations, truncations, infos
+
+    @override
+    def __str__(self) -> str:
+        return f"ReshapeObservationParallel<{self.env!s}>"

--- a/test/reshape_test.py
+++ b/test/reshape_test.py
@@ -8,7 +8,7 @@ from gymnasium.spaces import Box, Discrete
 
 from pettingzoo.test import api_test, parallel_api_test
 from pettingzoo.utils.env import AECEnv, ParallelEnv
-from pettingzoo.utils.wrappers import ReshapeObservation, ReshapeObservationParallel
+from pettingzoo.utils.wrappers import ReshapeObservationV1, ReshapeObservationParallelV1
 
 AGENTS = ["agent_0", "agent_1"]
 
@@ -162,7 +162,7 @@ class LateAgentsParallel(DummyParallel):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_observation_space_has_new_shape(agent):
-    space = ReshapeObservation(DummyAEC(), NEW_SHAPE).observation_space(agent)
+    space = ReshapeObservationV1(DummyAEC(), NEW_SHAPE).observation_space(agent)
     assert isinstance(space, Box)
     assert space.shape == NEW_SHAPE
     assert space.dtype == np.float32
@@ -170,7 +170,7 @@ def test_aec_observation_space_has_new_shape(agent):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_parallel_observation_space_has_new_shape(agent):
-    space = ReshapeObservationParallel(DummyParallel(), NEW_SHAPE).observation_space(
+    space = ReshapeObservationParallelV1(DummyParallel(), NEW_SHAPE).observation_space(
         agent
     )
     assert isinstance(space, Box)
@@ -179,7 +179,7 @@ def test_parallel_observation_space_has_new_shape(agent):
 
 @pytest.mark.parametrize(
     "wrapper,env",
-    [(ReshapeObservation, DummyAEC), (ReshapeObservationParallel, DummyParallel)],
+    [(ReshapeObservationV1, DummyAEC), (ReshapeObservationParallelV1, DummyParallel)],
 )
 def test_per_element_bounds_are_reshaped_not_collapsed(wrapper, env):
     space = wrapper(env(), NEW_SHAPE).observation_space("agent_0")
@@ -189,7 +189,7 @@ def test_per_element_bounds_are_reshaped_not_collapsed(wrapper, env):
 
 
 def test_aec_keeps_dtype():
-    env = ReshapeObservation(Uint8AEC(), NEW_SHAPE)
+    env = ReshapeObservationV1(Uint8AEC(), NEW_SHAPE)
     env.reset(seed=0)
     space = env.observation_space("agent_0")
     assert space.dtype == np.uint8
@@ -199,7 +199,7 @@ def test_aec_keeps_dtype():
 
 
 def test_parallel_keeps_dtype():
-    env = ReshapeObservationParallel(Uint8Parallel(), NEW_SHAPE)
+    env = ReshapeObservationParallelV1(Uint8Parallel(), NEW_SHAPE)
     obs, _ = env.reset(seed=0)
     assert env.observation_space("agent_0").dtype == np.uint8
     assert obs["agent_0"].dtype == np.uint8
@@ -207,7 +207,7 @@ def test_parallel_keeps_dtype():
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_observe_matches_reshape(agent):
-    env = ReshapeObservation(DummyAEC(), NEW_SHAPE)
+    env = ReshapeObservationV1(DummyAEC(), NEW_SHAPE)
     env.reset(seed=0)
 
     obs = env.observe(agent)
@@ -218,7 +218,7 @@ def test_aec_observe_matches_reshape(agent):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_parallel_reset_matches_reshape(agent):
-    env = ReshapeObservationParallel(DummyParallel(), NEW_SHAPE)
+    env = ReshapeObservationParallelV1(DummyParallel(), NEW_SHAPE)
     obs, _ = env.reset(seed=0)
     assert np.array_equal(obs[agent], FIXED_OBS[agent].reshape(NEW_SHAPE))
     assert env.observation_space(agent).contains(obs[agent])
@@ -226,7 +226,7 @@ def test_parallel_reset_matches_reshape(agent):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_parallel_step_matches_reshape(agent):
-    env = ReshapeObservationParallel(DummyParallel(), NEW_SHAPE)
+    env = ReshapeObservationParallelV1(DummyParallel(), NEW_SHAPE)
     env.reset(seed=0)
     obs, _, _, _, _ = env.step(dict.fromkeys(env.agents, 0))
     assert np.array_equal(obs[agent], FIXED_OBS[agent].reshape(NEW_SHAPE))
@@ -234,7 +234,7 @@ def test_parallel_step_matches_reshape(agent):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_last_matches_reshape(agent):
-    env = ReshapeObservation(DummyAEC(), NEW_SHAPE)
+    env = ReshapeObservationV1(DummyAEC(), NEW_SHAPE)
     env.reset(seed=0)
     while env.agent_selection != agent:
         env.step(0)
@@ -248,14 +248,14 @@ def test_observe_passes_through_none():
         def observe(self, agent):
             return None
 
-    env = ReshapeObservation(NoneObsEnv(), NEW_SHAPE)
+    env = ReshapeObservationV1(NoneObsEnv(), NEW_SHAPE)
     env.reset(seed=0)
     assert env.observe("agent_0") is None
 
 
 @pytest.mark.parametrize(
     "wrapper,env",
-    [(ReshapeObservation, DummyAEC), (ReshapeObservationParallel, DummyParallel)],
+    [(ReshapeObservationV1, DummyAEC), (ReshapeObservationParallelV1, DummyParallel)],
 )
 def test_rejects_shape_with_wrong_number_of_elements(wrapper, env):
     with pytest.raises(AssertionError, match="as many elements"):
@@ -265,41 +265,41 @@ def test_rejects_shape_with_wrong_number_of_elements(wrapper, env):
 @pytest.mark.parametrize("shape", [6, [3, 2], (3.0, 2.0), (-1, 6), (-2, -3)])
 def test_rejects_invalid_shapes(shape):
     with pytest.raises(AssertionError):
-        ReshapeObservation(DummyAEC(), shape)
+        ReshapeObservationV1(DummyAEC(), shape)
 
 
 def test_rejects_empty_shape():
     with pytest.raises(AssertionError, match="must not be empty"):
-        ReshapeObservation(DummyAEC(), ())
+        ReshapeObservationV1(DummyAEC(), ())
 
 
 def test_minus_one_message_is_only_about_minus_one():
     with pytest.raises(AssertionError, match="-1 is not supported"):
-        ReshapeObservation(DummyAEC(), (-1, 6))
+        ReshapeObservationV1(DummyAEC(), (-1, 6))
     with pytest.raises(AssertionError, match="positive ints"):
-        ReshapeObservation(DummyAEC(), (0, 6))
+        ReshapeObservationV1(DummyAEC(), (0, 6))
 
 
 def test_bad_shape_is_caught_when_agents_appear_late():
-    env = ReshapeObservation(LateAgentsAEC(), (5, 7))
+    env = ReshapeObservationV1(LateAgentsAEC(), (5, 7))
     env.reset(seed=0)
     with pytest.raises(AssertionError, match="as many elements"):
         env.observe("agent_0")
 
 
 def test_parallel_bad_shape_is_caught_when_agents_appear_late():
-    env = ReshapeObservationParallel(LateAgentsParallel(), (5, 7))
+    env = ReshapeObservationParallelV1(LateAgentsParallel(), (5, 7))
     with pytest.raises(AssertionError, match="agent_0"):
         env.reset(seed=0)
 
 
 def test_str():
     aec = DummyAEC()
-    assert str(ReshapeObservation(aec, NEW_SHAPE)) == f"ReshapeObservation<{aec!s}>"
+    assert str(ReshapeObservationV1(aec, NEW_SHAPE)) == f"ReshapeObservationV1<{aec!s}>"
     par = DummyParallel()
     assert (
-        str(ReshapeObservationParallel(par, NEW_SHAPE))
-        == f"ReshapeObservationParallel<{par!s}>"
+        str(ReshapeObservationParallelV1(par, NEW_SHAPE))
+        == f"ReshapeObservationParallelV1<{par!s}>"
     )
 
 
@@ -309,19 +309,19 @@ def test_rejects_non_box_observation_space():
             return Discrete(6)
 
     with pytest.raises(AssertionError, match="Box observation spaces"):
-        ReshapeObservation(DiscreteObsEnv(), NEW_SHAPE)
+        ReshapeObservationV1(DiscreteObsEnv(), NEW_SHAPE)
 
 
 def test_aec_api():
-    api_test(ReshapeObservation(DummyAEC(), NEW_SHAPE), num_cycles=5)
+    api_test(ReshapeObservationV1(DummyAEC(), NEW_SHAPE), num_cycles=5)
 
 
 def test_parallel_api():
     parallel_api_test(
-        ReshapeObservationParallel(DummyParallel(), NEW_SHAPE), num_cycles=5
+        ReshapeObservationParallelV1(DummyParallel(), NEW_SHAPE), num_cycles=5
     )
 
 
 def test_rejects_parallel_env():
     with pytest.raises(AssertionError):
-        ReshapeObservation(DummyParallel(), NEW_SHAPE)
+        ReshapeObservationV1(DummyParallel(), NEW_SHAPE)

--- a/test/reshape_test.py
+++ b/test/reshape_test.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pytest
+from gymnasium.spaces import Box, Discrete
+
+from pettingzoo.test import api_test, parallel_api_test
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+from pettingzoo.utils.wrappers import ReshapeObservation, ReshapeObservationParallel
+
+AGENTS = ["agent_0", "agent_1"]
+
+NEW_SHAPE = (3, 2)
+
+LOW_0 = np.arange(6, dtype=np.float32).reshape(2, 3)
+HIGH_0 = LOW_0 + 1.0
+LOW_1 = -np.arange(1, 7, dtype=np.float32)
+HIGH_1 = -LOW_1
+
+FIXED_OBS = {
+    "agent_0": LOW_0 + 0.5,
+    "agent_1": np.arange(6, dtype=np.float32) / 10.0,
+}
+
+
+@functools.cache
+def obs_space(agent):
+    if agent == "agent_0":
+        return Box(low=LOW_0, high=HIGH_0, dtype=np.float32)
+    return Box(low=LOW_1, high=HIGH_1, dtype=np.float32)
+
+
+class DummyAEC(AECEnv):
+    metadata = {"render_modes": [], "name": "dummy_aec"}
+
+    def __init__(self):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+
+    def observation_space(self, agent):
+        return obs_space(agent)
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        self._cumulative_rewards = dict.fromkeys(self.agents, 0.0)
+        self.terminations = dict.fromkeys(self.agents, False)
+        self.truncations = dict.fromkeys(self.agents, False)
+        self.infos = {a: {} for a in self.agents}
+        self._idx = 0
+        self._step_count = 0
+        self.agent_selection = self.agents[0]
+
+    def observe(self, agent):
+        return FIXED_OBS[agent]
+
+    def step(self, action):
+        self._step_count += 1
+        self._cumulative_rewards[self.agent_selection] = 0.0
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        if self._step_count >= 8:
+            self.terminations = dict.fromkeys(self.agents, True)
+        self._idx = (self._idx + 1) % len(self.agents)
+        self.agent_selection = self.agents[self._idx]
+        self._accumulate_rewards()
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class DummyParallel(ParallelEnv):
+    metadata = {"render_modes": [], "name": "dummy_parallel"}
+
+    def __init__(self):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+
+    def observation_space(self, agent):
+        return obs_space(agent)
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self._step_count = 0
+        return dict(FIXED_OBS), {a: {} for a in self.agents}
+
+    def step(self, actions):
+        self._step_count += 1
+        done = self._step_count >= 8
+        obs = dict(FIXED_OBS)
+        rewards = dict.fromkeys(self.agents, 0.0)
+        terminations = dict.fromkeys(self.agents, done)
+        truncations = dict.fromkeys(self.agents, False)
+        infos = {a: {} for a in self.agents}
+        if done:
+            self.agents = []
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class Uint8AEC(DummyAEC):
+    """An env whose observations are uint8, to check the dtype survives."""
+
+    def observation_space(self, agent):
+        return Box(low=0, high=255, shape=(2, 3), dtype=np.uint8)
+
+    def observe(self, agent):
+        return np.arange(6, dtype=np.uint8).reshape(2, 3)
+
+
+class Uint8Parallel(DummyParallel):
+    """An env whose observations are uint8, to check the dtype survives."""
+
+    def observation_space(self, agent):
+        return Box(low=0, high=255, shape=(2, 3), dtype=np.uint8)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self._step_count = 0
+        obs = {a: np.arange(6, dtype=np.uint8).reshape(2, 3) for a in self.agents}
+        return obs, {a: {} for a in self.agents}
+
+
+class LateAgentsAEC(DummyAEC):
+    """An env that only fills possible_agents in reset, like the generated_agents envs."""
+
+    def __init__(self):
+        AECEnv.__init__(self)
+
+    def reset(self, seed=None, options=None):
+        self.possible_agents = list(AGENTS)
+        super().reset(seed=seed, options=options)
+
+
+class LateAgentsParallel(DummyParallel):
+    """An env that only fills possible_agents in reset, like the generated_agents envs."""
+
+    def __init__(self):
+        ParallelEnv.__init__(self)
+
+    def reset(self, seed=None, options=None):
+        self.possible_agents = list(AGENTS)
+        return super().reset(seed=seed, options=options)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_observation_space_has_new_shape(agent):
+    space = ReshapeObservation(DummyAEC(), NEW_SHAPE).observation_space(agent)
+    assert isinstance(space, Box)
+    assert space.shape == NEW_SHAPE
+    assert space.dtype == np.float32
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_parallel_observation_space_has_new_shape(agent):
+    space = ReshapeObservationParallel(DummyParallel(), NEW_SHAPE).observation_space(
+        agent
+    )
+    assert isinstance(space, Box)
+    assert space.shape == NEW_SHAPE
+
+
+@pytest.mark.parametrize(
+    "wrapper,env",
+    [(ReshapeObservation, DummyAEC), (ReshapeObservationParallel, DummyParallel)],
+)
+def test_per_element_bounds_are_reshaped_not_collapsed(wrapper, env):
+    space = wrapper(env(), NEW_SHAPE).observation_space("agent_0")
+    assert np.array_equal(space.low, LOW_0.reshape(NEW_SHAPE))
+    assert np.array_equal(space.high, HIGH_0.reshape(NEW_SHAPE))
+    assert len(np.unique(space.low)) == 6
+
+
+def test_aec_keeps_dtype():
+    env = ReshapeObservation(Uint8AEC(), NEW_SHAPE)
+    env.reset(seed=0)
+    space = env.observation_space("agent_0")
+    assert space.dtype == np.uint8
+    assert space.low.dtype == np.uint8
+    assert space.high.max() == 255
+    assert env.observe("agent_0").dtype == np.uint8
+
+
+def test_parallel_keeps_dtype():
+    env = ReshapeObservationParallel(Uint8Parallel(), NEW_SHAPE)
+    obs, _ = env.reset(seed=0)
+    assert env.observation_space("agent_0").dtype == np.uint8
+    assert obs["agent_0"].dtype == np.uint8
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_observe_matches_reshape(agent):
+    env = ReshapeObservation(DummyAEC(), NEW_SHAPE)
+    env.reset(seed=0)
+
+    obs = env.observe(agent)
+    assert obs.shape == NEW_SHAPE
+    assert np.array_equal(obs, FIXED_OBS[agent].reshape(NEW_SHAPE))
+    assert env.observation_space(agent).contains(obs)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_parallel_reset_matches_reshape(agent):
+    env = ReshapeObservationParallel(DummyParallel(), NEW_SHAPE)
+    obs, _ = env.reset(seed=0)
+    assert np.array_equal(obs[agent], FIXED_OBS[agent].reshape(NEW_SHAPE))
+    assert env.observation_space(agent).contains(obs[agent])
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_parallel_step_matches_reshape(agent):
+    env = ReshapeObservationParallel(DummyParallel(), NEW_SHAPE)
+    env.reset(seed=0)
+    obs, _, _, _, _ = env.step(dict.fromkeys(env.agents, 0))
+    assert np.array_equal(obs[agent], FIXED_OBS[agent].reshape(NEW_SHAPE))
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_last_matches_reshape(agent):
+    env = ReshapeObservation(DummyAEC(), NEW_SHAPE)
+    env.reset(seed=0)
+    while env.agent_selection != agent:
+        env.step(0)
+
+    obs, _, _, _, _ = env.last()
+    assert np.array_equal(obs, FIXED_OBS[agent].reshape(NEW_SHAPE))
+
+
+def test_observe_passes_through_none():
+    class NoneObsEnv(DummyAEC):
+        def observe(self, agent):
+            return None
+
+    env = ReshapeObservation(NoneObsEnv(), NEW_SHAPE)
+    env.reset(seed=0)
+    assert env.observe("agent_0") is None
+
+
+@pytest.mark.parametrize(
+    "wrapper,env",
+    [(ReshapeObservation, DummyAEC), (ReshapeObservationParallel, DummyParallel)],
+)
+def test_rejects_shape_with_wrong_number_of_elements(wrapper, env):
+    with pytest.raises(AssertionError, match="as many elements"):
+        wrapper(env(), (2, 2))
+
+
+@pytest.mark.parametrize("shape", [6, [3, 2], (3.0, 2.0), (-1, 6), (-2, -3)])
+def test_rejects_invalid_shapes(shape):
+    with pytest.raises(AssertionError):
+        ReshapeObservation(DummyAEC(), shape)
+
+
+def test_rejects_empty_shape():
+    with pytest.raises(AssertionError, match="must not be empty"):
+        ReshapeObservation(DummyAEC(), ())
+
+
+def test_minus_one_message_is_only_about_minus_one():
+    with pytest.raises(AssertionError, match="-1 is not supported"):
+        ReshapeObservation(DummyAEC(), (-1, 6))
+    with pytest.raises(AssertionError, match="positive ints"):
+        ReshapeObservation(DummyAEC(), (0, 6))
+
+
+def test_bad_shape_is_caught_when_agents_appear_late():
+    env = ReshapeObservation(LateAgentsAEC(), (5, 7))
+    env.reset(seed=0)
+    with pytest.raises(AssertionError, match="as many elements"):
+        env.observe("agent_0")
+
+
+def test_parallel_bad_shape_is_caught_when_agents_appear_late():
+    env = ReshapeObservationParallel(LateAgentsParallel(), (5, 7))
+    with pytest.raises(AssertionError, match="agent_0"):
+        env.reset(seed=0)
+
+
+def test_str():
+    aec = DummyAEC()
+    assert str(ReshapeObservation(aec, NEW_SHAPE)) == f"ReshapeObservation<{aec!s}>"
+    par = DummyParallel()
+    assert (
+        str(ReshapeObservationParallel(par, NEW_SHAPE))
+        == f"ReshapeObservationParallel<{par!s}>"
+    )
+
+
+def test_rejects_non_box_observation_space():
+    class DiscreteObsEnv(DummyAEC):
+        def observation_space(self, agent):
+            return Discrete(6)
+
+    with pytest.raises(AssertionError, match="Box observation spaces"):
+        ReshapeObservation(DiscreteObsEnv(), NEW_SHAPE)
+
+
+def test_aec_api():
+    api_test(ReshapeObservation(DummyAEC(), NEW_SHAPE), num_cycles=5)
+
+
+def test_parallel_api():
+    parallel_api_test(
+        ReshapeObservationParallel(DummyParallel(), NEW_SHAPE), num_cycles=5
+    )
+
+
+def test_rejects_parallel_env():
+    with pytest.raises(AssertionError):
+        ReshapeObservation(DummyParallel(), NEW_SHAPE)


### PR DESCRIPTION
# Description

Ports SuperSuit's `reshape_v0` as `ReshapeObservationV1` and `ReshapeObservationParallelV1`, part of #1365. Reshapes each agent's observation and reshapes the advertised Box the same way, so per-element `low` and `high` bounds survive instead of collapsing to a scalar range.

Classes rather than a factory function, per @virgilt's note about mirroring `gymnasium.wrappers`, and named after the Gymnasium equivalent. AEC and Parallel are both implemented directly on the PettingZoo wrapper bases. Same shape as #1415.

## Two things worth knowing

`-1` in the shape is rejected with its own message telling you to give the size of every axis. `gymnasium.wrappers.ReshapeObservationV1` nominally allows it, but its own `np.prod(shape) == np.prod(obs_space.shape)` assert runs first and a shape containing -1 has a negative product, so the allowance is dead code there. Rejecting it with a message that says what to do seemed better than letting it fail with a confusing element-count error. Say the word if you'd rather match Gymnasium's signature exactly.

Shapes are validated in `__init__` for every agent in `possible_agents`, and again on first use for anything that turns up later. The second check matters more than it looks: `generated_agents_env_v0` has no `possible_agents` before `reset()`, so a construction-time-only check silently passes and the user gets a bare numpy `ValueError` several steps in with no mention of the wrapper or the agent. That's a deviation from #1415, which is purely lazy.

Empty shape `()` is rejected. SuperSuit accepted it vacuously and gave you a 0-d observation.

## Verification

    $ pytest test/reshape_test.py -q
    33 passed, 3 warnings in 0.14s

    $ pytest test/wrapper_test.py -q
    13 passed, 18 warnings in 23.58s

I compared the derived space against SuperSuit's `convert_box` on float32 with per-element bounds, float64, uint8, int8, and int64 and float32 with infinite bounds. Byte-identical low, high, shape and dtype in every case.

## A question

The wrapper takes one shape for every agent, so it only works when all agents' observations have the same element count. SuperSuit had the same limit. Would you rather it took an optional per-agent mapping, or is one shape the right scope?

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the `pre-commit` checks on the changed files, all hooks pass including `ty` and `pydocstyle`
- [ ] I have not run the full `pytest -v`, since I don't have the Atari ROMs and some of the extras installed. I ran the new test file and `test/wrapper_test.py`, both green, and the exact output is above.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
