### PR TITLE
Add ColorReductionObservationV1 wrappers, ported from SuperSuit color_reduction_v0

### DIFF
--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -129,6 +129,8 @@ while parallel_env.agents:
 .. autoclass:: AssertOutOfBoundsWrapper
 .. autoclass:: ClipOutOfBoundsWrapper
 .. autoclass:: OrderEnforcingWrapper
+.. autoclass:: ColorReductionObservation
+.. autoclass:: ColorReductionObservationParallel
 .. autoclass:: DtypeObservationV1
 .. autoclass:: DtypeObservationParallelV1
 

--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -129,8 +129,8 @@ while parallel_env.agents:
 .. autoclass:: AssertOutOfBoundsWrapper
 .. autoclass:: ClipOutOfBoundsWrapper
 .. autoclass:: OrderEnforcingWrapper
-.. autoclass:: ColorReductionObservation
-.. autoclass:: ColorReductionObservationParallel
+.. autoclass:: ColorReductionObservationV1
+.. autoclass:: ColorReductionObservationParallelV1
 .. autoclass:: DtypeObservationV1
 .. autoclass:: DtypeObservationParallelV1
 

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -4,8 +4,8 @@ from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
 from pettingzoo.utils.wrappers.capture_stdout import CaptureStdoutWrapper
 from pettingzoo.utils.wrappers.clip_out_of_bounds import ClipOutOfBoundsWrapper
 from pettingzoo.utils.wrappers.color_reduction import (
-    ColorReductionObservation,
-    ColorReductionObservationParallel,
+    ColorReductionObservationV1,
+    ColorReductionObservationParallelV1,
 )
 from pettingzoo.utils.wrappers.dtype import DtypeObservationV1, DtypeObservationParallelV1
 from pettingzoo.utils.wrappers.multi_episode_env import MultiEpisodeEnv
@@ -21,8 +21,8 @@ __all__ = [
     "BaseWrapper",
     "CaptureStdoutWrapper",
     "ClipOutOfBoundsWrapper",
-    "ColorReductionObservation",
-    "ColorReductionObservationParallel",
+    "ColorReductionObservationV1",
+    "ColorReductionObservationParallelV1",
     "DtypeObservationV1",
     "DtypeObservationParallelV1",
     "MultiEpisodeEnv",

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -3,6 +3,10 @@ from pettingzoo.utils.wrappers.base import BaseWrapper
 from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
 from pettingzoo.utils.wrappers.capture_stdout import CaptureStdoutWrapper
 from pettingzoo.utils.wrappers.clip_out_of_bounds import ClipOutOfBoundsWrapper
+from pettingzoo.utils.wrappers.color_reduction import (
+    ColorReductionObservation,
+    ColorReductionObservationParallel,
+)
 from pettingzoo.utils.wrappers.dtype import DtypeObservationV1, DtypeObservationParallelV1
 from pettingzoo.utils.wrappers.multi_episode_env import MultiEpisodeEnv
 from pettingzoo.utils.wrappers.multi_episode_parallel_env import MultiEpisodeParallelEnv
@@ -17,6 +21,8 @@ __all__ = [
     "BaseWrapper",
     "CaptureStdoutWrapper",
     "ClipOutOfBoundsWrapper",
+    "ColorReductionObservation",
+    "ColorReductionObservationParallel",
     "DtypeObservationV1",
     "DtypeObservationParallelV1",
     "MultiEpisodeEnv",

--- a/pettingzoo/utils/wrappers/color_reduction.py
+++ b/pettingzoo/utils/wrappers/color_reduction.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import Any
+
+import gymnasium.spaces
+import numpy as np
+from typing_extensions import override
+
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
+from pettingzoo.utils.wrappers.base import BaseWrapper
+from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
+
+COLOR_REDUCTION_MODES = ("full", "R", "G", "B")
+GRAYSCALE_WEIGHTS = np.array([0.299, 0.587, 0.114], dtype=np.float32)
+_CHANNELS = {"R": 0, "G": 1, "B": 2}
+
+
+def _check_mode(mode: str) -> None:
+    assert mode in COLOR_REDUCTION_MODES, (
+        f"mode must be one of {list(COLOR_REDUCTION_MODES)}, got {mode!r}"
+    )
+
+
+def _reduce(obs: np.ndarray, mode: str) -> np.ndarray:
+    if mode == "full":
+        return (np.asarray(obs, dtype=np.float32) @ GRAYSCALE_WEIGHTS).astype(np.uint8)
+    return np.asarray(obs)[:, :, _CHANNELS[mode]].copy()
+
+
+def _reduced_space(
+    space: gymnasium.spaces.Space[Any], mode: str, agent: Any
+) -> gymnasium.spaces.Box:
+    assert (
+        isinstance(space, gymnasium.spaces.Box)
+        and len(space.shape) == 3
+        and space.shape[2] == 3
+    ), (
+        "color reduction needs a 3d Box observation space with a last dimension of "
+        f"size 3, got {space} for agent {agent}"
+    )
+    low = _reduce(space.low, mode)
+    high = _reduce(space.high, mode)
+    return gymnasium.spaces.Box(low=low, high=high, dtype=low.dtype.type)
+
+
+class ColorReductionObservation(BaseWrapper[AgentID, Any, ActionType]):
+    """Reduces an image observation to a single channel.
+
+    ``"full"`` converts to grayscale with the luminance weights
+    [0.299, 0.587, 0.114] and returns uint8 whatever the input dtype was. ``"R"``,
+    ``"G"`` and ``"B"`` take the named channel and keep the input dtype. Either way
+    the trailing channel axis is dropped, so an (H, W, 3) observation becomes (H, W).
+
+    :param env: The AEC environment to wrap.
+    :param mode: One of "full", "R", "G", "B".
+    """
+
+    def __init__(self, env: AECEnv[AgentID, ObsType, ActionType], mode: str = "full"):
+        assert isinstance(env, AECEnv), (
+            "ColorReductionObservation is only compatible with AEC environments, "
+            "use ColorReductionObservationParallel instead."
+        )
+        _check_mode(mode)
+        super().__init__(env)
+        self.mode = mode
+        self._obs_spaces: dict[AgentID, gymnasium.spaces.Box] = {}
+        # SuperSuit checks the spaces when you wrap rather than on first use, and
+        # skips the check for envs that have no possible_agents to check yet.
+        for known_agent in getattr(env, "possible_agents", []):
+            self.observation_space(known_agent)
+
+    @override
+    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Box:
+        if agent not in self._obs_spaces:
+            self._obs_spaces[agent] = _reduced_space(
+                self.env.observation_space(agent), self.mode, agent
+            )
+        return self._obs_spaces[agent]
+
+    @override
+    def observe(self, agent: AgentID) -> Any:
+        obs = self.env.observe(agent)
+        if obs is None:
+            return None
+        return _reduce(obs, self.mode)
+
+    @override
+    def __str__(self) -> str:
+        return f"ColorReductionObservation<{self.env!s}>"
+
+
+class ColorReductionObservationParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
+    """Reduces an image observation to a single channel.
+
+    ``"full"`` converts to grayscale with the luminance weights
+    [0.299, 0.587, 0.114] and returns uint8 whatever the input dtype was. ``"R"``,
+    ``"G"`` and ``"B"`` take the named channel and keep the input dtype. Either way
+    the trailing channel axis is dropped, so an (H, W, 3) observation becomes (H, W).
+
+    :param env: The parallel environment to wrap.
+    :param mode: One of "full", "R", "G", "B".
+    """
+
+    def __init__(
+        self, env: ParallelEnv[AgentID, ObsType, ActionType], mode: str = "full"
+    ):
+        _check_mode(mode)
+        super().__init__(env)
+        self.mode = mode
+        self._obs_spaces: dict[AgentID, gymnasium.spaces.Box] = {}
+        # SuperSuit checks the spaces when you wrap rather than on first use, and
+        # skips the check for envs that have no possible_agents to check yet.
+        for known_agent in getattr(env, "possible_agents", []):
+            self.observation_space(known_agent)
+
+    @override
+    def observation_space(self, agent: AgentID) -> gymnasium.spaces.Box:
+        if agent not in self._obs_spaces:
+            self._obs_spaces[agent] = _reduced_space(
+                self.env.observation_space(agent), self.mode, agent
+            )
+        return self._obs_spaces[agent]
+
+    def _reduce_all(self, observations: dict[AgentID, Any]) -> dict[AgentID, Any]:
+        return {agent: _reduce(obs, self.mode) for agent, obs in observations.items()}
+
+    @override
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[dict[AgentID, Any], dict[AgentID, dict[str, Any]]]:
+        observations, infos = self.env.reset(seed=seed, options=options)
+        return self._reduce_all(observations), infos
+
+    @override
+    def step(
+        self, actions: dict[AgentID, ActionType]
+    ) -> tuple[
+        dict[AgentID, Any],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict[str, Any]],
+    ]:
+        observations, rewards, terminations, truncations, infos = self.env.step(actions)
+        return self._reduce_all(observations), rewards, terminations, truncations, infos
+
+    @override
+    def __str__(self) -> str:
+        return f"ColorReductionObservationParallel<{self.env!s}>"

--- a/pettingzoo/utils/wrappers/color_reduction.py
+++ b/pettingzoo/utils/wrappers/color_reduction.py
@@ -43,7 +43,7 @@ def _reduced_space(
     return gymnasium.spaces.Box(low=low, high=high, dtype=low.dtype.type)
 
 
-class ColorReductionObservation(BaseWrapper[AgentID, Any, ActionType]):
+class ColorReductionObservationV1(BaseWrapper[AgentID, Any, ActionType]):
     """Reduces an image observation to a single channel.
 
     ``"full"`` converts to grayscale with the luminance weights
@@ -57,8 +57,8 @@ class ColorReductionObservation(BaseWrapper[AgentID, Any, ActionType]):
 
     def __init__(self, env: AECEnv[AgentID, ObsType, ActionType], mode: str = "full"):
         assert isinstance(env, AECEnv), (
-            "ColorReductionObservation is only compatible with AEC environments, "
-            "use ColorReductionObservationParallel instead."
+            "ColorReductionObservationV1 is only compatible with AEC environments, "
+            "use ColorReductionObservationParallelV1 instead."
         )
         _check_mode(mode)
         super().__init__(env)
@@ -86,10 +86,10 @@ class ColorReductionObservation(BaseWrapper[AgentID, Any, ActionType]):
 
     @override
     def __str__(self) -> str:
-        return f"ColorReductionObservation<{self.env!s}>"
+        return f"ColorReductionObservationV1<{self.env!s}>"
 
 
-class ColorReductionObservationParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
+class ColorReductionObservationParallelV1(BaseParallelWrapper[AgentID, Any, ActionType]):
     """Reduces an image observation to a single channel.
 
     ``"full"`` converts to grayscale with the luminance weights
@@ -146,4 +146,4 @@ class ColorReductionObservationParallel(BaseParallelWrapper[AgentID, Any, Action
 
     @override
     def __str__(self) -> str:
-        return f"ColorReductionObservationParallel<{self.env!s}>"
+        return f"ColorReductionObservationParallelV1<{self.env!s}>"

--- a/test/color_reduction_test.py
+++ b/test/color_reduction_test.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pytest
+from gymnasium.spaces import Box, Discrete
+
+from pettingzoo.test import api_test, parallel_api_test
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+from pettingzoo.utils.wrappers import (
+    ColorReductionObservation,
+    ColorReductionObservationParallel,
+)
+
+AGENTS = ["agent_0", "agent_1"]
+
+DEFAULT_SPACE = Box(low=0, high=255, shape=(2, 2, 3), dtype=np.uint8)
+
+# 2x2 RGB images, one per agent.
+FIXED_OBS = {
+    "agent_0": np.array(
+        [[[10, 20, 30], [0, 0, 0]], [[255, 255, 255], [100, 150, 200]]], dtype=np.uint8
+    ),
+    "agent_1": np.array(
+        [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]], dtype=np.uint8
+    ),
+}
+
+# 0.299 * 10 + 0.587 * 20 + 0.114 * 30 = 18.15, and so on, truncated to uint8.
+EXPECTED_GRAY_0 = np.array([[18, 0], [255, 140]], dtype=np.uint8)
+
+# A space whose upper bound differs per channel, so the four modes give four
+# different reduced spaces: 18 for full (18.15 truncated), then 10, 20, 30.
+CHANNEL_SPACE = Box(
+    low=0,
+    high=np.tile(np.array([10, 20, 30], dtype=np.uint8), (2, 2, 1)),
+    dtype=np.uint8,
+)
+CHANNEL_HIGHS = [("full", 18), ("R", 10), ("G", 20), ("B", 30)]
+
+# A non-uint8 space, to pin down what each mode does to the dtype.
+FLOAT_SPACE = Box(low=0.0, high=1.0, shape=(2, 2, 3), dtype=np.float32)
+FLOAT_OBS = (np.arange(12, dtype=np.float32) / 11.0).reshape(2, 2, 3)
+
+
+class DummyAEC(AECEnv):
+    metadata = {"render_modes": [], "name": "dummy_aec"}
+
+    def __init__(self, space=None, obs=None):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+        self._space = DEFAULT_SPACE if space is None else space
+        self._obs = FIXED_OBS if obs is None else obs
+
+    def observation_space(self, agent):
+        return self._space
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        self._cumulative_rewards = dict.fromkeys(self.agents, 0.0)
+        self.terminations = dict.fromkeys(self.agents, False)
+        self.truncations = dict.fromkeys(self.agents, False)
+        self.infos = {a: {} for a in self.agents}
+        self._idx = 0
+        self._step_count = 0
+        self.agent_selection = self.agents[0]
+
+    def observe(self, agent):
+        return self._obs[agent]
+
+    def step(self, action):
+        self._step_count += 1
+        self._cumulative_rewards[self.agent_selection] = 0.0
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        if self._step_count >= 8:
+            self.terminations = dict.fromkeys(self.agents, True)
+        self._idx = (self._idx + 1) % len(self.agents)
+        self.agent_selection = self.agents[self._idx]
+        self._accumulate_rewards()
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class DummyParallel(ParallelEnv):
+    metadata = {"render_modes": [], "name": "dummy_parallel"}
+
+    def __init__(self, space=None, obs=None):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+        self._space = DEFAULT_SPACE if space is None else space
+        self._obs = FIXED_OBS if obs is None else obs
+
+    def observation_space(self, agent):
+        return self._space
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self._step_count = 0
+        return dict(self._obs), {a: {} for a in self.agents}
+
+    def step(self, actions):
+        self._step_count += 1
+        done = self._step_count >= 8
+        obs = dict(self._obs)
+        rewards = dict.fromkeys(self.agents, 0.0)
+        terminations = dict.fromkeys(self.agents, done)
+        truncations = dict.fromkeys(self.agents, False)
+        infos = {a: {} for a in self.agents}
+        if done:
+            self.agents = []
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+def float_obs():
+    return dict.fromkeys(AGENTS, FLOAT_OBS)
+
+
+@pytest.mark.parametrize("mode", ["full", "R", "G", "B"])
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_observation_space_drops_channel_axis(mode, agent):
+    space = ColorReductionObservation(DummyAEC(), mode).observation_space(agent)
+    assert isinstance(space, Box)
+    assert space.shape == (2, 2)
+    assert space.dtype == np.uint8
+    assert np.array_equal(space.low, np.zeros((2, 2), dtype=np.uint8))
+    assert np.array_equal(space.high, np.full((2, 2), 255, dtype=np.uint8))
+
+
+@pytest.mark.parametrize("mode", ["full", "R", "G", "B"])
+def test_parallel_observation_space_drops_channel_axis(mode):
+    space = ColorReductionObservationParallel(DummyParallel(), mode).observation_space(
+        "agent_0"
+    )
+    assert space.shape == (2, 2)
+    assert space.dtype == np.uint8
+
+
+@pytest.mark.parametrize("mode,high", CHANNEL_HIGHS)
+def test_aec_space_bounds_follow_the_mode(mode, high):
+    space = ColorReductionObservation(
+        DummyAEC(space=CHANNEL_SPACE), mode
+    ).observation_space("agent_0")
+    assert np.array_equal(space.low, np.zeros((2, 2), dtype=np.uint8))
+    assert np.array_equal(space.high, np.full((2, 2), high, dtype=np.uint8))
+
+
+@pytest.mark.parametrize("mode,high", CHANNEL_HIGHS)
+def test_parallel_space_bounds_follow_the_mode(mode, high):
+    space = ColorReductionObservationParallel(
+        DummyParallel(space=CHANNEL_SPACE), mode
+    ).observation_space("agent_0")
+    assert np.array_equal(space.high, np.full((2, 2), high, dtype=np.uint8))
+
+
+def test_aec_grayscale_matches_hand_computed_values():
+    env = ColorReductionObservation(DummyAEC(), "full")
+    env.reset(seed=0)
+
+    obs = env.observe("agent_0")
+    assert np.array_equal(obs, EXPECTED_GRAY_0)
+    assert obs.dtype == np.uint8
+    assert env.observation_space("agent_0").contains(obs)
+
+
+@pytest.mark.parametrize("mode,channel", [("R", 0), ("G", 1), ("B", 2)])
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_single_channel_modes(mode, channel, agent):
+    env = ColorReductionObservation(DummyAEC(), mode)
+    env.reset(seed=0)
+
+    obs = env.observe(agent)
+    assert np.array_equal(obs, FIXED_OBS[agent][:, :, channel])
+    assert env.observation_space(agent).contains(obs)
+
+
+@pytest.mark.parametrize("mode,channel", [("R", 0), ("G", 1), ("B", 2)])
+def test_aec_single_channel_modes_keep_the_input_dtype(mode, channel):
+    env = ColorReductionObservation(DummyAEC(space=FLOAT_SPACE, obs=float_obs()), mode)
+    env.reset(seed=0)
+
+    space = env.observation_space("agent_0")
+    assert space.dtype == np.float32
+    assert np.array_equal(space.high, np.ones((2, 2), dtype=np.float32))
+
+    obs = env.observe("agent_0")
+    assert obs.dtype == np.float32
+    assert np.array_equal(obs, FLOAT_OBS[:, :, channel])
+    assert space.contains(obs)
+
+
+@pytest.mark.parametrize("mode,channel", [("R", 0), ("G", 1), ("B", 2)])
+def test_parallel_single_channel_modes_keep_the_input_dtype(mode, channel):
+    env = ColorReductionObservationParallel(
+        DummyParallel(space=FLOAT_SPACE, obs=float_obs()), mode
+    )
+    obs, _ = env.reset(seed=0)
+
+    assert env.observation_space("agent_0").dtype == np.float32
+    assert obs["agent_0"].dtype == np.float32
+    assert np.array_equal(obs["agent_0"], FLOAT_OBS[:, :, channel])
+
+
+def test_full_mode_returns_uint8_for_a_float_space():
+    # SuperSuit casts the grayscale result to uint8 whatever went in, so a float
+    # space in [0, 1] comes out as a uint8 Box and the values truncate to 0.
+    env = ColorReductionObservation(
+        DummyAEC(space=FLOAT_SPACE, obs=float_obs()), "full"
+    )
+    env.reset(seed=0)
+
+    space = env.observation_space("agent_0")
+    assert space.dtype == np.uint8
+    assert np.array_equal(space.high, np.ones((2, 2), dtype=np.uint8))
+
+    obs = env.observe("agent_0")
+    assert obs.dtype == np.uint8
+    assert np.array_equal(obs, np.zeros((2, 2), dtype=np.uint8))
+
+
+def test_observation_does_not_alias_the_env_buffer():
+    inner = DummyAEC()
+    env = ColorReductionObservation(inner, "R")
+    env.reset(seed=0)
+
+    obs = env.observe("agent_0")
+    obs[0, 0] = 99
+    assert np.array_equal(inner.observe("agent_0"), FIXED_OBS["agent_0"])
+
+
+def test_aec_last_is_reduced():
+    env = ColorReductionObservation(DummyAEC(), "full")
+    env.reset(seed=0)
+    while env.agent_selection != "agent_0":
+        env.step(0)
+
+    obs, _, _, _, _ = env.last()
+    assert np.array_equal(obs, EXPECTED_GRAY_0)
+
+
+def test_parallel_reset_and_step_are_reduced():
+    env = ColorReductionObservationParallel(DummyParallel(), "full")
+
+    obs, _ = env.reset(seed=0)
+    assert np.array_equal(obs["agent_0"], EXPECTED_GRAY_0)
+    assert env.observation_space("agent_0").contains(obs["agent_0"])
+
+    obs, _, _, _, _ = env.step(dict.fromkeys(env.agents, 0))
+    assert np.array_equal(obs["agent_0"], EXPECTED_GRAY_0)
+    assert obs["agent_1"].shape == (2, 2)
+
+
+def test_parallel_single_channel_mode():
+    env = ColorReductionObservationParallel(DummyParallel(), "G")
+    obs, _ = env.reset(seed=0)
+    assert np.array_equal(obs["agent_1"], FIXED_OBS["agent_1"][:, :, 1])
+
+
+def test_default_mode_is_full():
+    env = ColorReductionObservation(DummyAEC())
+    env.reset(seed=0)
+    assert np.array_equal(env.observe("agent_0"), EXPECTED_GRAY_0)
+
+
+def test_observe_passes_through_none():
+    class NoneObsEnv(DummyAEC):
+        def observe(self, agent):
+            return None
+
+    env = ColorReductionObservation(NoneObsEnv())
+    env.reset(seed=0)
+    assert env.observe("agent_0") is None
+
+
+def test_aec_str():
+    inner = DummyAEC()
+    assert (
+        str(ColorReductionObservation(inner)) == f"ColorReductionObservation<{inner}>"
+    )
+
+
+def test_parallel_str():
+    inner = DummyParallel()
+    assert (
+        str(ColorReductionObservationParallel(inner))
+        == f"ColorReductionObservationParallel<{inner}>"
+    )
+
+
+def test_aec_api():
+    api_test(ColorReductionObservation(DummyAEC()), num_cycles=5)
+
+
+def test_parallel_api():
+    parallel_api_test(ColorReductionObservationParallel(DummyParallel()), num_cycles=5)
+
+
+def test_rejects_parallel_env():
+    with pytest.raises(AssertionError):
+        ColorReductionObservation(DummyParallel())
+
+
+@pytest.mark.parametrize("mode", ["gray", "r", "", "RGB", 0])
+def test_rejects_unknown_mode(mode):
+    with pytest.raises(AssertionError):
+        ColorReductionObservation(DummyAEC(), mode)
+    with pytest.raises(AssertionError):
+        ColorReductionObservationParallel(DummyParallel(), mode)
+
+
+@pytest.mark.parametrize(
+    "space",
+    [
+        Discrete(4),
+        Box(low=0, high=1, shape=(6,), dtype=np.float32),
+        Box(low=0, high=255, shape=(2, 2, 4), dtype=np.uint8),
+        Box(low=0, high=255, shape=(2, 2, 3, 1), dtype=np.uint8),
+    ],
+)
+def test_rejects_non_image_observation_space(space):
+    with pytest.raises(AssertionError, match="agent_0"):
+        ColorReductionObservation(DummyAEC(space=space))
+    with pytest.raises(AssertionError, match="agent_0"):
+        ColorReductionObservationParallel(DummyParallel(space=space))

--- a/test/color_reduction_test.py
+++ b/test/color_reduction_test.py
@@ -9,8 +9,8 @@ from gymnasium.spaces import Box, Discrete
 from pettingzoo.test import api_test, parallel_api_test
 from pettingzoo.utils.env import AECEnv, ParallelEnv
 from pettingzoo.utils.wrappers import (
-    ColorReductionObservation,
-    ColorReductionObservationParallel,
+    ColorReductionObservationV1,
+    ColorReductionObservationParallelV1,
 )
 
 AGENTS = ["agent_0", "agent_1"]
@@ -138,7 +138,7 @@ def float_obs():
 @pytest.mark.parametrize("mode", ["full", "R", "G", "B"])
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_observation_space_drops_channel_axis(mode, agent):
-    space = ColorReductionObservation(DummyAEC(), mode).observation_space(agent)
+    space = ColorReductionObservationV1(DummyAEC(), mode).observation_space(agent)
     assert isinstance(space, Box)
     assert space.shape == (2, 2)
     assert space.dtype == np.uint8
@@ -148,7 +148,7 @@ def test_aec_observation_space_drops_channel_axis(mode, agent):
 
 @pytest.mark.parametrize("mode", ["full", "R", "G", "B"])
 def test_parallel_observation_space_drops_channel_axis(mode):
-    space = ColorReductionObservationParallel(DummyParallel(), mode).observation_space(
+    space = ColorReductionObservationParallelV1(DummyParallel(), mode).observation_space(
         "agent_0"
     )
     assert space.shape == (2, 2)
@@ -157,7 +157,7 @@ def test_parallel_observation_space_drops_channel_axis(mode):
 
 @pytest.mark.parametrize("mode,high", CHANNEL_HIGHS)
 def test_aec_space_bounds_follow_the_mode(mode, high):
-    space = ColorReductionObservation(
+    space = ColorReductionObservationV1(
         DummyAEC(space=CHANNEL_SPACE), mode
     ).observation_space("agent_0")
     assert np.array_equal(space.low, np.zeros((2, 2), dtype=np.uint8))
@@ -166,14 +166,14 @@ def test_aec_space_bounds_follow_the_mode(mode, high):
 
 @pytest.mark.parametrize("mode,high", CHANNEL_HIGHS)
 def test_parallel_space_bounds_follow_the_mode(mode, high):
-    space = ColorReductionObservationParallel(
+    space = ColorReductionObservationParallelV1(
         DummyParallel(space=CHANNEL_SPACE), mode
     ).observation_space("agent_0")
     assert np.array_equal(space.high, np.full((2, 2), high, dtype=np.uint8))
 
 
 def test_aec_grayscale_matches_hand_computed_values():
-    env = ColorReductionObservation(DummyAEC(), "full")
+    env = ColorReductionObservationV1(DummyAEC(), "full")
     env.reset(seed=0)
 
     obs = env.observe("agent_0")
@@ -185,7 +185,7 @@ def test_aec_grayscale_matches_hand_computed_values():
 @pytest.mark.parametrize("mode,channel", [("R", 0), ("G", 1), ("B", 2)])
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_single_channel_modes(mode, channel, agent):
-    env = ColorReductionObservation(DummyAEC(), mode)
+    env = ColorReductionObservationV1(DummyAEC(), mode)
     env.reset(seed=0)
 
     obs = env.observe(agent)
@@ -195,7 +195,7 @@ def test_aec_single_channel_modes(mode, channel, agent):
 
 @pytest.mark.parametrize("mode,channel", [("R", 0), ("G", 1), ("B", 2)])
 def test_aec_single_channel_modes_keep_the_input_dtype(mode, channel):
-    env = ColorReductionObservation(DummyAEC(space=FLOAT_SPACE, obs=float_obs()), mode)
+    env = ColorReductionObservationV1(DummyAEC(space=FLOAT_SPACE, obs=float_obs()), mode)
     env.reset(seed=0)
 
     space = env.observation_space("agent_0")
@@ -210,7 +210,7 @@ def test_aec_single_channel_modes_keep_the_input_dtype(mode, channel):
 
 @pytest.mark.parametrize("mode,channel", [("R", 0), ("G", 1), ("B", 2)])
 def test_parallel_single_channel_modes_keep_the_input_dtype(mode, channel):
-    env = ColorReductionObservationParallel(
+    env = ColorReductionObservationParallelV1(
         DummyParallel(space=FLOAT_SPACE, obs=float_obs()), mode
     )
     obs, _ = env.reset(seed=0)
@@ -223,7 +223,7 @@ def test_parallel_single_channel_modes_keep_the_input_dtype(mode, channel):
 def test_full_mode_returns_uint8_for_a_float_space():
     # SuperSuit casts the grayscale result to uint8 whatever went in, so a float
     # space in [0, 1] comes out as a uint8 Box and the values truncate to 0.
-    env = ColorReductionObservation(
+    env = ColorReductionObservationV1(
         DummyAEC(space=FLOAT_SPACE, obs=float_obs()), "full"
     )
     env.reset(seed=0)
@@ -239,7 +239,7 @@ def test_full_mode_returns_uint8_for_a_float_space():
 
 def test_observation_does_not_alias_the_env_buffer():
     inner = DummyAEC()
-    env = ColorReductionObservation(inner, "R")
+    env = ColorReductionObservationV1(inner, "R")
     env.reset(seed=0)
 
     obs = env.observe("agent_0")
@@ -248,7 +248,7 @@ def test_observation_does_not_alias_the_env_buffer():
 
 
 def test_aec_last_is_reduced():
-    env = ColorReductionObservation(DummyAEC(), "full")
+    env = ColorReductionObservationV1(DummyAEC(), "full")
     env.reset(seed=0)
     while env.agent_selection != "agent_0":
         env.step(0)
@@ -258,7 +258,7 @@ def test_aec_last_is_reduced():
 
 
 def test_parallel_reset_and_step_are_reduced():
-    env = ColorReductionObservationParallel(DummyParallel(), "full")
+    env = ColorReductionObservationParallelV1(DummyParallel(), "full")
 
     obs, _ = env.reset(seed=0)
     assert np.array_equal(obs["agent_0"], EXPECTED_GRAY_0)
@@ -270,13 +270,13 @@ def test_parallel_reset_and_step_are_reduced():
 
 
 def test_parallel_single_channel_mode():
-    env = ColorReductionObservationParallel(DummyParallel(), "G")
+    env = ColorReductionObservationParallelV1(DummyParallel(), "G")
     obs, _ = env.reset(seed=0)
     assert np.array_equal(obs["agent_1"], FIXED_OBS["agent_1"][:, :, 1])
 
 
 def test_default_mode_is_full():
-    env = ColorReductionObservation(DummyAEC())
+    env = ColorReductionObservationV1(DummyAEC())
     env.reset(seed=0)
     assert np.array_equal(env.observe("agent_0"), EXPECTED_GRAY_0)
 
@@ -286,7 +286,7 @@ def test_observe_passes_through_none():
         def observe(self, agent):
             return None
 
-    env = ColorReductionObservation(NoneObsEnv())
+    env = ColorReductionObservationV1(NoneObsEnv())
     env.reset(seed=0)
     assert env.observe("agent_0") is None
 
@@ -294,37 +294,37 @@ def test_observe_passes_through_none():
 def test_aec_str():
     inner = DummyAEC()
     assert (
-        str(ColorReductionObservation(inner)) == f"ColorReductionObservation<{inner}>"
+        str(ColorReductionObservationV1(inner)) == f"ColorReductionObservationV1<{inner}>"
     )
 
 
 def test_parallel_str():
     inner = DummyParallel()
     assert (
-        str(ColorReductionObservationParallel(inner))
-        == f"ColorReductionObservationParallel<{inner}>"
+        str(ColorReductionObservationParallelV1(inner))
+        == f"ColorReductionObservationParallelV1<{inner}>"
     )
 
 
 def test_aec_api():
-    api_test(ColorReductionObservation(DummyAEC()), num_cycles=5)
+    api_test(ColorReductionObservationV1(DummyAEC()), num_cycles=5)
 
 
 def test_parallel_api():
-    parallel_api_test(ColorReductionObservationParallel(DummyParallel()), num_cycles=5)
+    parallel_api_test(ColorReductionObservationParallelV1(DummyParallel()), num_cycles=5)
 
 
 def test_rejects_parallel_env():
     with pytest.raises(AssertionError):
-        ColorReductionObservation(DummyParallel())
+        ColorReductionObservationV1(DummyParallel())
 
 
 @pytest.mark.parametrize("mode", ["gray", "r", "", "RGB", 0])
 def test_rejects_unknown_mode(mode):
     with pytest.raises(AssertionError):
-        ColorReductionObservation(DummyAEC(), mode)
+        ColorReductionObservationV1(DummyAEC(), mode)
     with pytest.raises(AssertionError):
-        ColorReductionObservationParallel(DummyParallel(), mode)
+        ColorReductionObservationParallelV1(DummyParallel(), mode)
 
 
 @pytest.mark.parametrize(
@@ -338,6 +338,6 @@ def test_rejects_unknown_mode(mode):
 )
 def test_rejects_non_image_observation_space(space):
     with pytest.raises(AssertionError, match="agent_0"):
-        ColorReductionObservation(DummyAEC(space=space))
+        ColorReductionObservationV1(DummyAEC(space=space))
     with pytest.raises(AssertionError, match="agent_0"):
-        ColorReductionObservationParallel(DummyParallel(space=space))
+        ColorReductionObservationParallelV1(DummyParallel(space=space))


### PR DESCRIPTION
# Description

Ports SuperSuit's `color_reduction_v0` as `ColorReductionObservationV1` and `ColorReductionObservationParallelV1`, part of #1365. Drops the channel axis of an image observation, either by converting to grayscale or by taking one of R, G or B, and rewrites the advertised Box to match.

Classes rather than a factory function, per @virgilt's note about mirroring `gymnasium.wrappers`. AEC and Parallel are both implemented directly on the PettingZoo wrapper bases. Same shape as #1415.

## On the name

I did not reuse `GrayscaleObservation`. Three of the four modes return a raw colour channel with no grayscale conversion in them at all, so the name would be wrong for most of what the wrapper does. Gymnasium's version also has a `keep_dim` argument this doesn't, so the mapping isn't clean in either direction. If you'd rather have a `GrayscaleObservation` that only does `"full"` plus a separate channel-picking wrapper, that's a reasonable split, but it's a different API from SuperSuit's rather than a rename.

## Two things worth knowing

`"full"` returns uint8 whatever the input dtype was, because that's what SuperSuit does. A float image in [0, 1] therefore comes out all zeros. It's a trap, it's now in the docstring, and there's a test pinning it as deliberate rather than accidental.

The R, G and B modes return a copy. SuperSuit returned a view into the environment's own buffer, so writing into the observation wrote into env state.

`state()` and `state_space` pass through unreduced, same as SuperSuit and #1415, so a wrapped image env's global state stays three-channel while observations go to one.

## Verification

    $ pytest test/color_reduction_test.py -q
    54 passed, 2 warnings in 0.14s

    $ pytest test/wrapper_test.py -q
    13 passed, 18 warnings in 23.17s

I ran the transform and the derived space against SuperSuit's `change_observation` and `convert_box` over 800 random uint8 images in all four modes, plus float32, float64, int16 and uint16 inputs across six different observation spaces. No divergences in values or dtypes.

## A question

SuperSuit's `"full"` uses the BT.601 luminance weights `[0.299, 0.587, 0.114]`. `gymnasium.wrappers.GrayscaleObservation` uses BT.709, `[0.2125, 0.7154, 0.0721]`. This PR keeps SuperSuit's, so the same environment grayscaled through PettingZoo and through Gymnasium gives different pixel values. Do you want them to match inside Farama, at the cost of silently changing results for anyone migrating off SuperSuit?

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the `pre-commit` checks on the changed files, all hooks pass including `ty` and `pydocstyle`
- [ ] I have not run the full `pytest -v`, since I don't have the Atari ROMs and some of the extras installed. I ran the new test file and `test/wrapper_test.py`, both green, and the exact output is above.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
