### PR TITLE
Add RescaleObservationV1 wrappers, ported from SuperSuit normalize_obs_v0

### DIFF
--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -140,6 +140,8 @@ while parallel_env.agents:
 .. autoclass:: DtypeObservationParallelV1
 .. autoclass:: PadObservationsV1
 .. autoclass:: PadObservationsParallelV1
+.. autoclass:: RescaleObservationV1
+.. autoclass:: RescaleObservationParallelV1
 .. autoclass:: ReshapeObservationV1
 .. autoclass:: ReshapeObservationParallelV1
 .. autoclass:: ScaleActionV1

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -24,6 +24,10 @@ from pettingzoo.utils.wrappers.pad_observations import (
 )
 from pettingzoo.utils.wrappers.record_video import RecordVideo
 from pettingzoo.utils.wrappers.record_video_parallel import RecordVideoParallel
+from pettingzoo.utils.wrappers.rescale_observation import (
+    RescaleObservationParallelV1,
+    RescaleObservationV1,
+)
 from pettingzoo.utils.wrappers.reshape import (
     ReshapeObservationParallelV1,
     ReshapeObservationV1,
@@ -53,6 +57,8 @@ __all__ = [
     "PadObservationsV1",
     "RecordVideo",
     "RecordVideoParallel",
+    "RescaleObservationParallelV1",
+    "RescaleObservationV1",
     "ReshapeObservationParallelV1",
     "ReshapeObservationV1",
     "ScaleActionParallelV1",

--- a/pettingzoo/utils/wrappers/rescale_observation.py
+++ b/pettingzoo/utils/wrappers/rescale_observation.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from gymnasium.spaces import Box, Space
+from typing_extensions import override
+
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
+from pettingzoo.utils.wrappers.base import BaseWrapper
+from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
+
+
+def _check_range(min_obs: float, max_obs: float) -> None:
+    assert max_obs > min_obs, (
+        f"max_obs must be greater than min_obs, got min_obs={min_obs} and max_obs={max_obs}."
+    )
+
+
+def _rescaled_space(
+    space: Space[Any], min_obs: float, max_obs: float
+) -> tuple[Box, Box]:
+    """Check that space can be rescaled and return it next to its rescaled version."""
+    assert isinstance(space, Box), (
+        f"RescaleObservationV1 only works with Box observation spaces, got {space}."
+    )
+    space_dtype = np.dtype(space.dtype)
+    assert space_dtype in (np.dtype(np.float32), np.dtype(np.float64)), (
+        "RescaleObservationV1 only works with float32 or float64 Box observation "
+        f"spaces, got dtype {space.dtype}."
+    )
+    assert np.all(np.isfinite(space.low)) and np.all(np.isfinite(space.high)), (
+        "RescaleObservationV1 needs finite bounds to rescale from, but the observation "
+        f"space {space} has infinite bounds."
+    )
+    assert np.all(space.high > space.low), (
+        "RescaleObservationV1 needs every element of the observation space to have "
+        f"high > low, but the space {space} has an element with no width."
+    )
+    dtype = np.float64 if space_dtype == np.dtype(np.float64) else np.float32
+    return space, Box(low=min_obs, high=max_obs, shape=space.shape, dtype=dtype)
+
+
+def _rescale(
+    obs: Any, space: Box, rescaled: Box, min_obs: float, max_obs: float
+) -> np.ndarray[Any, Any]:
+    """Map obs from the bounds of space onto [min_obs, max_obs], element by element.
+
+    The arithmetic runs in float64 whatever the space dtype is. In float32 the
+    intermediate width can overflow to infinity, and rounding disagrees with the
+    cast gymnasium applies to the target bounds, which puts endpoints just outside
+    the rescaled space. The clip covers what is left of that.
+    """
+    low = space.low.astype(np.float64)
+    high = space.high.astype(np.float64)
+    scaled = (np.asarray(obs, dtype=np.float64) - low) / (high - low)
+    result = (scaled * (max_obs - min_obs) + min_obs).astype(space.dtype)
+    return np.clip(result, rescaled.low, rescaled.high)
+
+
+class RescaleObservationV1(BaseWrapper[AgentID, Any, ActionType]):
+    """Linearly rescales each agent's Box observation into a fixed range.
+
+    Every element is mapped from its own ``[low, high]`` in the wrapped space onto
+    ``[min_obs, max_obs]``, and the result is clipped so it always sits inside the
+    advertised space. The wrapped space has to be a float Box whose elements all
+    have finite ``low`` and ``high`` with ``high > low``, since anything else
+    gives nothing to scale from. Every space in ``possible_agents`` is checked
+    when the wrapper is built.
+
+    Ported from SuperSuit's normalize_obs_v0; the version suffix continues that numbering.
+
+    :param env: The AEC environment to wrap.
+    :param min_obs: Lower bound of the rescaled observations.
+    :param max_obs: Upper bound of the rescaled observations.
+    """
+
+    def __init__(
+        self,
+        env: AECEnv[AgentID, ObsType, ActionType],
+        min_obs: float = 0.0,
+        max_obs: float = 1.0,
+    ):
+        assert isinstance(env, AECEnv), (
+            "RescaleObservationV1 is only compatible with AEC environments, "
+            "use RescaleObservationParallelV1 instead."
+        )
+        _check_range(min_obs, max_obs)
+        super().__init__(env)
+        self.min_obs = min_obs
+        self.max_obs = max_obs
+        self._spaces: dict[AgentID, tuple[Box, Box]] = {}
+        for agent in self.env.possible_agents:
+            self._spaces_for(agent)
+
+    def _spaces_for(self, agent: AgentID) -> tuple[Box, Box]:
+        if agent not in self._spaces:
+            self._spaces[agent] = _rescaled_space(
+                self.env.observation_space(agent), self.min_obs, self.max_obs
+            )
+        return self._spaces[agent]
+
+    @override
+    def observation_space(self, agent: AgentID) -> Box:
+        return self._spaces_for(agent)[1]
+
+    @override
+    def observe(self, agent: AgentID) -> Any:
+        obs = self.env.observe(agent)
+        if obs is None:
+            return None
+        space, rescaled = self._spaces_for(agent)
+        return _rescale(obs, space, rescaled, self.min_obs, self.max_obs)
+
+    @override
+    def __str__(self) -> str:
+        return f"RescaleObservationV1<{self.env!s}>"
+
+
+class RescaleObservationParallelV1(BaseParallelWrapper[AgentID, Any, ActionType]):
+    """Linearly rescales each agent's Box observation into a fixed range.
+
+    Every element is mapped from its own ``[low, high]`` in the wrapped space onto
+    ``[min_obs, max_obs]``, and the result is clipped so it always sits inside the
+    advertised space. The wrapped space has to be a float Box whose elements all
+    have finite ``low`` and ``high`` with ``high > low``, since anything else
+    gives nothing to scale from. Every space in ``possible_agents`` is checked
+    when the wrapper is built.
+
+    Ported from SuperSuit's normalize_obs_v0; the version suffix continues that numbering.
+
+    :param env: The parallel environment to wrap.
+    :param min_obs: Lower bound of the rescaled observations.
+    :param max_obs: Upper bound of the rescaled observations.
+    """
+
+    def __init__(
+        self,
+        env: ParallelEnv[AgentID, ObsType, ActionType],
+        min_obs: float = 0.0,
+        max_obs: float = 1.0,
+    ):
+        _check_range(min_obs, max_obs)
+        super().__init__(env)
+        self.min_obs = min_obs
+        self.max_obs = max_obs
+        self._spaces: dict[AgentID, tuple[Box, Box]] = {}
+        for agent in self.env.possible_agents:
+            self._spaces_for(agent)
+
+    def _spaces_for(self, agent: AgentID) -> tuple[Box, Box]:
+        if agent not in self._spaces:
+            self._spaces[agent] = _rescaled_space(
+                self.env.observation_space(agent), self.min_obs, self.max_obs
+            )
+        return self._spaces[agent]
+
+    @override
+    def observation_space(self, agent: AgentID) -> Box:
+        return self._spaces_for(agent)[1]
+
+    def _rescale_all(self, observations: dict[AgentID, Any]) -> dict[AgentID, Any]:
+        return {
+            agent: _rescale(obs, *self._spaces_for(agent), self.min_obs, self.max_obs)
+            for agent, obs in observations.items()
+        }
+
+    @override
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[dict[AgentID, Any], dict[AgentID, dict[str, Any]]]:
+        observations, infos = self.env.reset(seed=seed, options=options)
+        return self._rescale_all(observations), infos
+
+    @override
+    def step(
+        self, actions: dict[AgentID, ActionType]
+    ) -> tuple[
+        dict[AgentID, Any],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict[str, Any]],
+    ]:
+        observations, rewards, terminations, truncations, infos = self.env.step(actions)
+        return (
+            self._rescale_all(observations),
+            rewards,
+            terminations,
+            truncations,
+            infos,
+        )
+
+    @override
+    def __str__(self) -> str:
+        return f"RescaleObservationParallelV1<{self.env!s}>"

--- a/test/rescale_observation_test.py
+++ b/test/rescale_observation_test.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pytest
+from gymnasium.spaces import Box, Discrete
+
+from pettingzoo.test import api_test, parallel_api_test
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+from pettingzoo.utils.wrappers import RescaleObservationParallelV1, RescaleObservationV1
+
+AGENTS = ["agent_0", "agent_1"]
+
+# (0.0, 1.0) is the one range where the float32 arithmetic happens to be exact.
+RANGES = [(0.0, 1.0), (0.1, 0.7), (-2.0, 4.0)]
+
+# agent_0 has scalar bounds, agent_1 has a different [low, high] per element.
+SPACES = {
+    "agent_0": Box(low=-1.0, high=3.0, shape=(2,), dtype=np.float32),
+    "agent_1": Box(
+        low=np.array([0.0, -10.0, 2.0], dtype=np.float32),
+        high=np.array([1.0, 10.0, 6.0], dtype=np.float32),
+        dtype=np.float32,
+    ),
+}
+
+FIXED_OBS = {
+    "agent_0": np.array([1.0, -1.0], dtype=np.float32),
+    "agent_1": np.array([0.25, 0.0, 6.0], dtype=np.float32),
+}
+
+# Hand computed: (obs - low) / (high - low).
+UNIT_OBS = {
+    "agent_0": np.array([0.5, 0.0], dtype=np.float32),
+    "agent_1": np.array([0.25, 0.5, 1.0], dtype=np.float32),
+}
+
+
+@functools.cache
+def obs_space(agent):
+    return SPACES[agent]
+
+
+class DummyAEC(AECEnv):
+    metadata = {"render_modes": [], "name": "dummy_aec"}
+
+    def __init__(self):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+
+    def observation_space(self, agent):
+        return obs_space(agent)
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        self._cumulative_rewards = dict.fromkeys(self.agents, 0.0)
+        self.terminations = dict.fromkeys(self.agents, False)
+        self.truncations = dict.fromkeys(self.agents, False)
+        self.infos = {a: {} for a in self.agents}
+        self._idx = 0
+        self._step_count = 0
+        self.agent_selection = self.agents[0]
+
+    def observe(self, agent):
+        return FIXED_OBS[agent]
+
+    def step(self, action):
+        self._step_count += 1
+        self._cumulative_rewards[self.agent_selection] = 0.0
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        if self._step_count >= 8:
+            self.terminations = dict.fromkeys(self.agents, True)
+        self._idx = (self._idx + 1) % len(self.agents)
+        self.agent_selection = self.agents[self._idx]
+        self._accumulate_rewards()
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class DummyParallel(ParallelEnv):
+    metadata = {"render_modes": [], "name": "dummy_parallel"}
+
+    def __init__(self):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+
+    def observation_space(self, agent):
+        return obs_space(agent)
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self._step_count = 0
+        return dict(FIXED_OBS), {a: {} for a in self.agents}
+
+    def step(self, actions):
+        self._step_count += 1
+        done = self._step_count >= 8
+        obs = dict(FIXED_OBS)
+        rewards = dict.fromkeys(self.agents, 0.0)
+        terminations = dict.fromkeys(self.agents, done)
+        truncations = dict.fromkeys(self.agents, False)
+        infos = {a: {} for a in self.agents}
+        if done:
+            self.agents = []
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+def aec_with_space(space, obs=None):
+    class FixedSpaceAEC(DummyAEC):
+        def observation_space(self, agent):
+            return space
+
+        def observe(self, agent):
+            return FIXED_OBS[agent] if obs is None else obs
+
+    return FixedSpaceAEC()
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_observation_space(agent):
+    space = RescaleObservationV1(DummyAEC(), -2.0, 4.0).observation_space(agent)
+    assert isinstance(space, Box)
+    assert space.shape == SPACES[agent].shape
+    assert space.dtype == SPACES[agent].dtype
+    assert np.all(space.low == -2.0)
+    assert np.all(space.high == 4.0)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_parallel_observation_space(agent):
+    space = RescaleObservationParallelV1(DummyParallel(), -2.0, 4.0).observation_space(
+        agent
+    )
+    assert isinstance(space, Box)
+    assert space.shape == SPACES[agent].shape
+    assert space.dtype == SPACES[agent].dtype
+    assert np.all(space.low == -2.0)
+    assert np.all(space.high == 4.0)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_observe_matches_expected(agent):
+    env = RescaleObservationV1(DummyAEC())
+    env.reset(seed=0)
+    obs = env.observe(agent)
+    assert np.allclose(obs, UNIT_OBS[agent])
+    assert obs.dtype == SPACES[agent].dtype
+    assert env.observation_space(agent).contains(obs)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_parallel_reset_and_step_match_expected(agent):
+    env = RescaleObservationParallelV1(DummyParallel())
+    obs, _ = env.reset(seed=0)
+    assert np.allclose(obs[agent], UNIT_OBS[agent])
+    assert env.observation_space(agent).contains(obs[agent])
+
+    obs, _, _, _, _ = env.step(dict.fromkeys(env.agents, 0))
+    assert np.allclose(obs[agent], UNIT_OBS[agent])
+    assert env.observation_space(agent).contains(obs[agent])
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_last_matches_expected(agent):
+    env = RescaleObservationV1(DummyAEC())
+    env.reset(seed=0)
+    while env.agent_selection != agent:
+        env.step(0)
+
+    obs, _, _, _, _ = env.last()
+    assert np.allclose(obs, UNIT_OBS[agent])
+
+
+@pytest.mark.parametrize("min_obs, max_obs", [(0.0, 1.0), (-2.0, 4.0), (-1.0, -0.5)])
+def test_midpoint_lands_in_the_middle(min_obs, max_obs):
+    # agent_0's first element sits exactly halfway through [-1, 3].
+    env = RescaleObservationV1(DummyAEC(), min_obs, max_obs)
+    env.reset(seed=0)
+    obs = env.observe("agent_0")
+    assert obs[0] == pytest.approx((min_obs + max_obs) / 2)
+    assert obs[1] == pytest.approx(min_obs)
+
+
+def test_float64_space_keeps_its_dtype():
+    space = Box(low=-1.0, high=3.0, shape=(2,), dtype=np.float64)
+    env = RescaleObservationV1(aec_with_space(space))
+    env.reset(seed=0)
+    obs = env.observe("agent_0")
+    assert env.observation_space("agent_0").dtype == np.float64
+    assert obs.dtype == np.float64
+    assert np.allclose(obs, UNIT_OBS["agent_0"])
+
+
+def test_observe_passes_through_none():
+    class NoneObsEnv(DummyAEC):
+        def observe(self, agent):
+            return None
+
+    env = RescaleObservationV1(NoneObsEnv())
+    env.reset(seed=0)
+    assert env.observe("agent_0") is None
+
+
+class OneAgentAEC(DummyAEC):
+    def __init__(self):
+        super().__init__()
+        self.possible_agents = ["agent_0"]
+
+
+def test_agent_outside_possible_agents_resolves_lazily():
+    env = RescaleObservationV1(OneAgentAEC(), -2.0, 4.0)
+    space = env.observation_space("agent_1")
+    assert space.shape == SPACES["agent_1"].shape
+    assert np.all(space.low == -2.0)
+    assert np.all(space.high == 4.0)
+
+
+def test_agent_outside_possible_agents_still_checks_its_space():
+    class LateBadSpaceAEC(OneAgentAEC):
+        def observation_space(self, agent):
+            return Discrete(3) if agent == "agent_1" else obs_space(agent)
+
+    env = RescaleObservationV1(LateBadSpaceAEC())
+    with pytest.raises(AssertionError, match="Box observation spaces"):
+        env.observation_space("agent_1")
+
+
+def test_rejects_zero_width_element():
+    space = Box(
+        low=np.array([0.0, 5.0], dtype=np.float32),
+        high=np.array([1.0, 5.0], dtype=np.float32),
+        dtype=np.float32,
+    )
+    with pytest.raises(AssertionError, match="high > low"):
+        RescaleObservationV1(aec_with_space(space))
+
+
+def test_wide_float32_space_does_not_overflow():
+    # high - low overflows to inf in float32, which used to give NaN or min_obs.
+    space = Box(low=-2e38, high=2e38, shape=(2,), dtype=np.float32)
+    obs = np.array([2e38, 0.0], dtype=np.float32)
+    env = RescaleObservationV1(aec_with_space(space, obs))
+    env.reset(seed=0)
+
+    got = env.observe("agent_0")
+    assert not np.any(np.isnan(got))
+    assert np.allclose(got, [1.0, 0.5])
+    assert env.observation_space("agent_0").contains(got)
+
+
+def test_rejects_integer_space():
+    space = Box(low=0, high=255, shape=(2,), dtype=np.uint8)
+    with pytest.raises(AssertionError, match="float32 or float64"):
+        RescaleObservationV1(aec_with_space(space))
+
+
+def test_rejects_non_box_space():
+    with pytest.raises(AssertionError, match="Box observation spaces"):
+        RescaleObservationV1(aec_with_space(Discrete(3)))
+
+
+def test_rejects_unbounded_space():
+    space = Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.float32)
+    with pytest.raises(AssertionError, match="infinite bounds"):
+        RescaleObservationV1(aec_with_space(space))
+
+
+@pytest.mark.parametrize("min_obs, max_obs", [(1.0, 1.0), (1.0, 0.0)])
+def test_rejects_bad_range(min_obs, max_obs):
+    with pytest.raises(AssertionError, match="greater than min_obs"):
+        RescaleObservationV1(DummyAEC(), min_obs, max_obs)
+    with pytest.raises(AssertionError, match="greater than min_obs"):
+        RescaleObservationParallelV1(DummyParallel(), min_obs, max_obs)
+
+
+def test_rejects_parallel_env():
+    with pytest.raises(AssertionError, match="use RescaleObservationParallelV1"):
+        RescaleObservationV1(DummyParallel())
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+@pytest.mark.parametrize("min_obs, max_obs", RANGES)
+def test_aec_observation_stays_in_the_advertised_space(agent, min_obs, max_obs):
+    env = RescaleObservationV1(DummyAEC(), min_obs, max_obs)
+    env.reset(seed=0)
+    obs = env.observe(agent)
+    assert env.observation_space(agent).contains(obs)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+@pytest.mark.parametrize("min_obs, max_obs", RANGES)
+def test_parallel_observation_stays_in_the_advertised_space(agent, min_obs, max_obs):
+    env = RescaleObservationParallelV1(DummyParallel(), min_obs, max_obs)
+    obs, _ = env.reset(seed=0)
+    assert env.observation_space(agent).contains(obs[agent])
+
+    obs, _, _, _, _ = env.step(dict.fromkeys(env.agents, 0))
+    assert env.observation_space(agent).contains(obs[agent])
+
+
+@pytest.mark.parametrize("min_obs, max_obs", RANGES)
+def test_aec_api(min_obs, max_obs):
+    api_test(RescaleObservationV1(DummyAEC(), min_obs, max_obs), num_cycles=5)
+
+
+@pytest.mark.parametrize("min_obs, max_obs", RANGES)
+def test_parallel_api(min_obs, max_obs):
+    parallel_api_test(
+        RescaleObservationParallelV1(DummyParallel(), min_obs, max_obs), num_cycles=5
+    )


### PR DESCRIPTION
# Description

Ports SuperSuit's `normalize_obs_v0` as `RescaleObservationV1` and `RescaleObservationParallelV1`, part of #1365. Linearly maps each element of a Box observation from the space's own `[low, high]` onto a target range, and advertises a Box over that range.

Classes rather than a factory function, per @virgilt's note about mirroring `gymnasium.wrappers`, and named after the Gymnasium equivalent. AEC and Parallel are both implemented directly on the PettingZoo wrapper bases. Same shape as #1415.

Named RescaleObservationV1 / RescaleObservationParallelV1: SuperSuit's normalize_obs_v0 plus one, per the review.

The arguments are `min_obs` and `max_obs`, matching Gymnasium. SuperSuit calls them `env_min` and `env_max`, which sounds like the environment's range when it's actually the output range. Defaults are unchanged at 0.0 and 1.0.

## The thing that took the longest

The naive version of this wrapper returns observations that fall outside the space it advertises, and it is not a rare corner. Doing the arithmetic in the source dtype and building the target `Box` by casting `min_obs`/`max_obs` separately gives you two different roundings:

    RescaleObservationV1(env, 0.1, 0.7)   # source Box(-1.0, 3.0, float32)
    observe   -> 0.70000005
    space.high ->  0.7, i.e. float32(0.7) == 0.69999999
    contains  -> False, and api_test fails

About 23% of random float32 endpoint cases escape, and float64 spaces are not safe either. So the rescale is computed in float64 and then clipped to the advertised bounds. `test_observation_stays_in_the_advertised_space` covers three target ranges, both classes, and fails without either half of that.

The clip also means an observation the environment emitted outside its own declared space gets clamped, where SuperSuit passed it straight through. Such an env is already violating the API, and without the clip the wrapper can't guarantee its own advertised space, but it is a behaviour change and I'd rather you knew.

Two checks are new relative to SuperSuit: the space has to be a Box, and every element needs `high > low`. The second one is why: SuperSuit divides by `high - low` unguarded, so a constant feature (`low == high` on one element, which is perfectly legal) silently produced NaN.

Also, `.astype(space.dtype)` on the way out. SuperSuit returns whatever numpy promotes to, usually float64 out of a float32 space, so its own advertised space is wrong about the dtype.

## Verification

    $ pytest test/rescale_observation_test.py -q
    43 passed, 8 warnings in 0.14s

    $ pytest test/wrapper_test.py -q
    13 passed, 18 warnings in 25.39s

Beyond the test file I swept the transform over 40000 random spaces per dtype including both endpoints, float32 and float64: no observation outside the advertised space.

## A question

`min_obs` and `max_obs` are scalars here, matching SuperSuit. Gymnasium also accepts per-element arrays, and supports an infinite target bound where the source bound is infinite too. Grow the array form now, or leave it scalar until someone asks?

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the `pre-commit` checks on the changed files, all hooks pass including `ty` and `pydocstyle`
- [ ] I have not run the full `pytest -v`, since I don't have the Atari ROMs and some of the extras installed. I ran the new test file and `test/wrapper_test.py`, both green, and the exact output is above.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

