### PR TITLE
Add ScaleActionV1 wrappers, ported from SuperSuit scale_actions_v0

### DIFF
--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -142,5 +142,7 @@ while parallel_env.agents:
 .. autoclass:: PadObservationsParallelV1
 .. autoclass:: ReshapeObservationV1
 .. autoclass:: ReshapeObservationParallelV1
+.. autoclass:: ScaleActionV1
+.. autoclass:: ScaleActionParallelV1
 
 ```

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -28,6 +28,10 @@ from pettingzoo.utils.wrappers.reshape import (
     ReshapeObservationParallelV1,
     ReshapeObservationV1,
 )
+from pettingzoo.utils.wrappers.scale_action import (
+    ScaleActionParallelV1,
+    ScaleActionV1,
+)
 from pettingzoo.utils.wrappers.terminate_illegal import TerminateIllegalWrapper
 
 __all__ = [
@@ -51,5 +55,7 @@ __all__ = [
     "RecordVideoParallel",
     "ReshapeObservationParallelV1",
     "ReshapeObservationV1",
+    "ScaleActionParallelV1",
+    "ScaleActionV1",
     "TerminateIllegalWrapper",
 ]

--- a/pettingzoo/utils/wrappers/scale_action.py
+++ b/pettingzoo/utils/wrappers/scale_action.py
@@ -1,0 +1,172 @@
+"""Wrappers that scale the bounds of a Box action space."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import gymnasium.spaces
+import numpy as np
+from gymnasium.spaces import Box
+from typing_extensions import override
+
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
+from pettingzoo.utils.wrappers.base import BaseWrapper
+from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
+
+
+def _scaled_space(
+    space: gymnasium.spaces.Space[Any], scale: float, wrapper_name: str
+) -> Box:
+    """Returns ``space`` with its bounds multiplied by ``scale``.
+
+    A negative scale maps ``low`` above ``high``, so the two are swapped to keep the
+    Box valid.
+    """
+    assert isinstance(space, Box), (
+        f"{wrapper_name} only works with Box action spaces, got {type(space).__name__}."
+    )
+    low = space.low * scale
+    high = space.high * scale
+    if scale < 0:
+        low, high = high, low
+    dtype = cast(
+        "type[np.floating[Any]] | type[np.integer[Any]]", np.dtype(space.dtype).type
+    )
+    return Box(low=low, high=high, shape=space.shape, dtype=dtype)
+
+
+def _unscaled_action(
+    action: np.ndarray, space: Box, scaled_space: Box, scale: float
+) -> np.ndarray:
+    """Maps an action from ``scaled_space`` back into ``space``.
+
+    Multiplying a bound by ``scale`` and dividing it back is not exact in floating
+    point, so an action sitting on a bound of the scaled space can come back a
+    fraction outside ``space``. Those are clipped. An action that was already
+    outside ``scaled_space`` is left alone, so wrappers further in still see it as
+    out of bounds.
+    """
+    action = np.asarray(action)
+    unscaled = (action / scale).astype(space.dtype)
+    inside = (action >= scaled_space.low) & (action <= scaled_space.high)
+    return np.where(inside, np.clip(unscaled, space.low, space.high), unscaled)
+
+
+class ScaleActionV1(BaseWrapper[AgentID, ObsType, Any]):
+    """Scales the bounds of each agent's Box action space by a constant factor.
+
+    The action space this wrapper advertises has ``low`` and ``high`` multiplied by
+    ``scale``. Actions are divided by ``scale`` before they reach the wrapped
+    environment, so an action drawn from the advertised space is a valid action for
+    the wrapped environment. Actions on a bound of the advertised space are clipped
+    to the wrapped bound, since the round trip through ``scale`` is not exact in
+    floating point. An action outside the advertised space is passed through as is.
+
+    Scaling an integer Box narrows what can be reached: at ``scale`` 0.5, a
+    ``Box(0, 10, dtype=int64)`` advertises ``Box(0, 5)`` and only even actions are
+    reachable. A bound large enough that ``bound * scale`` overflows the dtype
+    becomes infinite, and actions there stay infinite.
+
+    :param env: The AEC environment to wrap.
+    :param scale: Non-zero factor applied to the action space bounds. A negative
+        scale flips the bounds, so they are swapped to keep the Box valid.
+    """
+
+    def __init__(self, env: AECEnv[AgentID, ObsType, ActionType], scale: float):
+        assert isinstance(env, AECEnv), (
+            "ScaleActionV1 is only compatible with AEC environments, "
+            "use ScaleActionParallelV1 instead."
+        )
+        assert scale != 0, "ScaleActionV1 needs a non-zero scale."
+        super().__init__(env)
+        self.scale = scale
+        self._action_spaces: dict[AgentID, Box] = {}
+        for agent in getattr(env, "possible_agents", []):
+            self.action_space(agent)
+
+    @override
+    def action_space(self, agent: AgentID) -> Box:
+        if agent not in self._action_spaces:
+            self._action_spaces[agent] = _scaled_space(
+                self.env.action_space(agent), self.scale, "ScaleActionV1"
+            )
+        return self._action_spaces[agent]
+
+    @override
+    def step(self, action: np.ndarray | None) -> None:
+        if action is not None:
+            agent = self.agent_selection
+            space = self.env.action_space(agent)
+            assert isinstance(space, Box), (
+                "ScaleActionV1 only works with Box action spaces."
+            )
+            action = _unscaled_action(
+                action, space, self.action_space(agent), self.scale
+            )
+        self.env.step(action)
+
+    @override
+    def __str__(self) -> str:
+        return f"ScaleActionV1<{self.env!s}>"
+
+
+class ScaleActionParallelV1(BaseParallelWrapper[AgentID, ObsType, Any]):
+    """Scales the bounds of each agent's Box action space by a constant factor.
+
+    The action space this wrapper advertises has ``low`` and ``high`` multiplied by
+    ``scale``. Actions are divided by ``scale`` before they reach the wrapped
+    environment, so an action drawn from the advertised space is a valid action for
+    the wrapped environment. Actions on a bound of the advertised space are clipped
+    to the wrapped bound, since the round trip through ``scale`` is not exact in
+    floating point. An action outside the advertised space is passed through as is.
+
+    Scaling an integer Box narrows what can be reached: at ``scale`` 0.5, a
+    ``Box(0, 10, dtype=int64)`` advertises ``Box(0, 5)`` and only even actions are
+    reachable. A bound large enough that ``bound * scale`` overflows the dtype
+    becomes infinite, and actions there stay infinite.
+
+    :param env: The parallel environment to wrap.
+    :param scale: Non-zero factor applied to the action space bounds. A negative
+        scale flips the bounds, so they are swapped to keep the Box valid.
+    """
+
+    def __init__(self, env: ParallelEnv[AgentID, ObsType, ActionType], scale: float):
+        assert scale != 0, "ScaleActionParallelV1 needs a non-zero scale."
+        super().__init__(env)
+        self.scale = scale
+        self._action_spaces: dict[AgentID, Box] = {}
+        for agent in getattr(env, "possible_agents", []):
+            self.action_space(agent)
+
+    @override
+    def action_space(self, agent: AgentID) -> Box:
+        if agent not in self._action_spaces:
+            self._action_spaces[agent] = _scaled_space(
+                self.env.action_space(agent), self.scale, "ScaleActionParallelV1"
+            )
+        return self._action_spaces[agent]
+
+    @override
+    def step(
+        self, actions: dict[AgentID, Any]
+    ) -> tuple[
+        dict[AgentID, ObsType],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict[str, Any]],
+    ]:
+        unscaled = {}
+        for agent, action in actions.items():
+            space = self.env.action_space(agent)
+            assert isinstance(space, Box), (
+                "ScaleActionParallelV1 only works with Box action spaces."
+            )
+            unscaled[agent] = _unscaled_action(
+                action, space, self.action_space(agent), self.scale
+            )
+        return self.env.step(unscaled)
+
+    @override
+    def __str__(self) -> str:
+        return f"ScaleActionParallelV1<{self.env!s}>"

--- a/test/scale_action_test.py
+++ b/test/scale_action_test.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pytest
+from gymnasium.spaces import Box, Discrete
+
+from pettingzoo.test import api_test, parallel_api_test
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+from pettingzoo.utils.wrappers import ScaleActionParallelV1, ScaleActionV1
+
+AGENTS = ["agent_0", "agent_1"]
+
+OBS = np.array([0.5, -0.5], dtype=np.float32)
+OBS_SPACE = Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32)
+
+
+@functools.cache
+def act_space(agent):
+    if agent == "agent_0":
+        return Box(low=-1.0, high=1.0, shape=(3,), dtype=np.float32)
+    return Box(low=0.0, high=10.0, shape=(3,), dtype=np.float32)
+
+
+class DummyAEC(AECEnv):
+    metadata = {"render_modes": [], "name": "dummy_aec"}
+
+    def __init__(self, action_space_fn=act_space):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+        self._action_space_fn = action_space_fn
+        self.received = {}
+
+    def observation_space(self, agent):
+        return OBS_SPACE
+
+    @functools.cache
+    def action_space(self, agent):
+        return self._action_space_fn(agent)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        self._cumulative_rewards = dict.fromkeys(self.agents, 0.0)
+        self.terminations = dict.fromkeys(self.agents, False)
+        self.truncations = dict.fromkeys(self.agents, False)
+        self.infos = {a: {} for a in self.agents}
+        self.received = {}
+        self._idx = 0
+        self._step_count = 0
+        self.agent_selection = self.agents[0]
+
+    def observe(self, agent):
+        return OBS
+
+    def step(self, action):
+        self.received[self.agent_selection] = action
+        self._step_count += 1
+        self._cumulative_rewards[self.agent_selection] = 0.0
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        if self._step_count >= 8:
+            self.terminations = dict.fromkeys(self.agents, True)
+        self._idx = (self._idx + 1) % len(self.agents)
+        self.agent_selection = self.agents[self._idx]
+        self._accumulate_rewards()
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class DummyParallel(ParallelEnv):
+    metadata = {"render_modes": [], "name": "dummy_parallel"}
+
+    def __init__(self, action_space_fn=act_space):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+        self._action_space_fn = action_space_fn
+        self.received = {}
+
+    def observation_space(self, agent):
+        return OBS_SPACE
+
+    @functools.cache
+    def action_space(self, agent):
+        return self._action_space_fn(agent)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self.received = {}
+        self._step_count = 0
+        return dict.fromkeys(self.agents, OBS), {a: {} for a in self.agents}
+
+    def step(self, actions):
+        self.received = dict(actions)
+        self._step_count += 1
+        done = self._step_count >= 8
+        obs = dict.fromkeys(self.agents, OBS)
+        rewards = dict.fromkeys(self.agents, 0.0)
+        terminations = dict.fromkeys(self.agents, done)
+        truncations = dict.fromkeys(self.agents, False)
+        infos = {a: {} for a in self.agents}
+        if done:
+            self.agents = []
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+def discrete_space(agent):
+    return Discrete(5)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_action_space_bounds(agent):
+    space = ScaleActionV1(DummyAEC(), 2.0).action_space(agent)
+    inner = act_space(agent)
+    assert isinstance(space, Box)
+    assert space.shape == inner.shape
+    assert space.dtype == inner.dtype
+    assert np.allclose(space.low, inner.low * 2.0)
+    assert np.allclose(space.high, inner.high * 2.0)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_parallel_action_space_bounds(agent):
+    space = ScaleActionParallelV1(DummyParallel(), 0.5).action_space(agent)
+    inner = act_space(agent)
+    assert np.allclose(space.low, inner.low * 0.5)
+    assert np.allclose(space.high, inner.high * 0.5)
+
+
+def test_symmetric_box_stays_symmetric():
+    space = ScaleActionV1(DummyAEC(), 3.0).action_space("agent_0")
+    assert np.allclose(space.low, -3.0)
+    assert np.allclose(space.high, 3.0)
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_scale_one_is_a_noop(agent):
+    inner = DummyAEC()
+    env = ScaleActionV1(inner, 1.0)
+    assert env.action_space(agent) == act_space(agent)
+
+    env.reset(seed=0)
+    action = np.array([0.25, 0.5, 1.0], dtype=np.float32)
+    while env.agent_selection != agent:
+        env.step(np.zeros(3, dtype=np.float32))
+    env.step(action)
+    assert np.allclose(inner.received[agent], action)
+
+
+def test_out_of_range_action_is_passed_through():
+    """The wrapper rescales, it does not sanitise. Out of range stays out of range."""
+    inner = DummyAEC()
+    env = ScaleActionV1(inner, 2.0)
+    env.reset(seed=0)
+    env.step(np.array([100.0, -100.0, 0.0], dtype=np.float32))
+    assert np.allclose(inner.received["agent_0"], [50.0, -50.0, 0.0])
+
+
+def test_endpoint_of_advertised_space_lands_on_inner_bound():
+    """The float round trip overshoots at the bounds, so the bounds are clipped."""
+    inner_space = Box(low=-1.7, high=1.7, shape=(1,), dtype=np.float32)
+    inner = DummyAEC(lambda agent: inner_space)
+    env = ScaleActionV1(inner, 3.0)
+    env.reset(seed=0)
+
+    high = env.action_space("agent_0").high.copy()
+    assert float(high[0]) / 3.0 > float(inner_space.high[0])  # the overshoot
+    env.step(high)
+    assert inner.received["agent_0"] == inner_space.high
+
+
+def test_aec_step_divides_by_scale():
+    inner = DummyAEC()
+    env = ScaleActionV1(inner, 2.0)
+    env.reset(seed=0)
+
+    env.step(np.array([2.0, -1.0, 0.5], dtype=np.float32))
+    received = inner.received["agent_0"]
+    assert np.allclose(received, [1.0, -0.5, 0.25])
+    assert received.dtype == act_space("agent_0").dtype
+
+
+def test_parallel_step_divides_by_scale():
+    inner = DummyParallel()
+    env = ScaleActionParallelV1(inner, 2.0)
+    env.reset(seed=0)
+
+    env.step(
+        {
+            "agent_0": np.array([2.0, -1.0, 0.5], dtype=np.float32),
+            "agent_1": np.array([20.0, 10.0, 0.0], dtype=np.float32),
+        }
+    )
+    assert np.allclose(inner.received["agent_0"], [1.0, -0.5, 0.25])
+    assert np.allclose(inner.received["agent_1"], [10.0, 5.0, 0.0])
+
+
+@pytest.mark.parametrize("scale", [0.1, 0.5, 1.0, 2.0, 3.0, 10.0, -0.3, -2.0])
+@pytest.mark.parametrize("bound", [1.0, 1.7, 3.3])
+def test_action_from_advertised_space_is_valid_inside(scale, bound):
+    """Anything the advertised space accepts has to be valid for the wrapped env."""
+    inner_space = Box(low=-bound, high=bound, shape=(2,), dtype=np.float32)
+    inner = DummyAEC(lambda agent: inner_space)
+    env = ScaleActionV1(inner, scale)
+    env.reset(seed=0)
+
+    space = env.action_space("agent_0")
+    space.seed(0)
+    actions = [space.low.copy(), space.high.copy()]
+    actions += [space.sample() for _ in range(50)]
+
+    for action in actions:
+        assert space.contains(action)
+        agent = env.agent_selection
+        env.step(action)
+        received = inner.received[agent]
+        assert inner_space.contains(received)
+        expected = np.clip(
+            np.asarray(action, dtype=np.float64) / scale,
+            inner_space.low,
+            inner_space.high,
+        )
+        assert np.allclose(received, expected, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize("scale", [0.1, 3.0, -0.3])
+def test_parallel_action_from_advertised_space_is_valid_inside(scale):
+    inner_space = Box(low=-1.7, high=1.7, shape=(2,), dtype=np.float32)
+    inner = DummyParallel(lambda agent: inner_space)
+    env = ScaleActionParallelV1(inner, scale)
+    env.reset(seed=0)
+
+    space = env.action_space("agent_0")
+    space.seed(0)
+    for action in [space.low.copy(), space.high.copy()] + [space.sample()]:
+        env.step(dict.fromkeys(AGENTS, action))
+        expected = np.clip(
+            np.asarray(action, dtype=np.float64) / scale,
+            inner_space.low,
+            inner_space.high,
+        )
+        for agent in AGENTS:
+            assert inner_space.contains(inner.received[agent])
+            assert np.allclose(inner.received[agent], expected, rtol=1e-6, atol=1e-6)
+
+
+def test_negative_scale_swaps_bounds():
+    env = ScaleActionV1(DummyAEC(), -2.0)
+    space = env.action_space("agent_1")
+    inner = act_space("agent_1")
+    assert np.allclose(space.low, inner.high * -2.0)
+    assert np.allclose(space.high, inner.low * -2.0)
+
+
+def test_negative_scale_maps_back_into_inner_space():
+    inner = DummyAEC()
+    env = ScaleActionV1(inner, -2.0)
+    env.reset(seed=0)
+    env.step(np.zeros(3, dtype=np.float32))  # agent_0's turn
+
+    env.step(np.array([-20.0, -10.0, 0.0], dtype=np.float32))
+    received = inner.received["agent_1"]
+    assert np.allclose(received, [10.0, 5.0, 0.0])
+    assert act_space("agent_1").contains(received)
+
+
+def test_zero_scale_is_rejected():
+    with pytest.raises(AssertionError):
+        ScaleActionV1(DummyAEC(), 0)
+    with pytest.raises(AssertionError):
+        ScaleActionParallelV1(DummyParallel(), 0)
+
+
+def test_non_box_action_space_is_rejected():
+    with pytest.raises(AssertionError):
+        ScaleActionV1(DummyAEC(discrete_space), 2.0)
+    with pytest.raises(AssertionError):
+        ScaleActionParallelV1(DummyParallel(discrete_space), 2.0)
+
+
+def test_none_action_passes_through():
+    inner = DummyAEC()
+    env = ScaleActionV1(inner, 2.0)
+    env.reset(seed=0)
+    env.step(None)
+    assert inner.received["agent_0"] is None
+
+
+def test_aec_api():
+    api_test(ScaleActionV1(DummyAEC(), 2.0), num_cycles=5)
+
+
+def test_parallel_api():
+    parallel_api_test(ScaleActionParallelV1(DummyParallel(), 2.0), num_cycles=5)
+
+
+def test_rejects_parallel_env():
+    with pytest.raises(AssertionError):
+        ScaleActionV1(DummyParallel(), 2.0)


### PR DESCRIPTION
# Description

Ports SuperSuit's `scale_actions_v0` as `ScaleActionV1` and `ScaleActionParallelV1`, part of #1365. The advertised Box action space has its `low` and `high` multiplied by `scale`, and an action submitted against that space is mapped back into the environment's own space.

Classes rather than a factory function, per @virgilt's note about mirroring `gymnasium.wrappers`. AEC and Parallel are both implemented directly on the PettingZoo wrapper bases. Same shape as #1415.

## This one changes behaviour, on purpose

`scale_actions_v0` scales the bounds by `scale` and then also multiplies the incoming action by `scale`. So an action sampled from the space the wrapper advertises reaches the environment `scale**2` times too large. For `scale > 1` that is out of range: on `Box(-1, 1)` at `scale=2`, 1975 of 2000 sampled actions land outside the inner space, and at `scale=3.7` all 2000 do. For `scale < 1` it stays in range but can never reach the full space.

There's no reading of `scale` under which both halves are right, so I treated it as a bug rather than a convention. This PR keeps the advertised space as SuperSuit had it and divides the action instead of multiplying it, so `env.action_space(agent).sample()` is always valid for the wrapped env. That is the direction `gymnasium.wrappers.RescaleAction` goes: advertise the new interval, map back into the inner one.

I'd rather you knew about this than discovered it, so: **anyone porting from `scale_actions_v0` will see different behaviour.** If you'd rather the port reproduce SuperSuit exactly, bug included, say so and I'll change it.

## The endpoints need a clip, and it is not unconditional

`low * scale` is computed in the space's dtype and the inverse is not exact, so the endpoint of the advertised space maps an ULP outside the inner space. On `Box(-1.7, 1.7, float32)` at `scale=3.0` the env receives `1.7000001668930054` against a bound of `1.7000000476837158`, and with `AssertOutOfBoundsWrapper` underneath that's a crash. It fails for every scale that isn't a power of two, and float64 is no safer, since `x * s / s` is not exact in any finite precision.

The clip is elementwise and conditional on the submitted action having been inside the advertised space. An unconditional clip would silently sanitise genuinely out-of-range actions, which hides caller bugs and duplicates `ClipOutOfBoundsWrapper`. So valid in gives valid out, and out of range stays out of range for `AssertOutOfBoundsWrapper` to catch.

## Three smaller deviations

A negative `scale` swaps the bounds and reflects, rather than letting `Box` raise `ValueError` on `low > high` the way SuperSuit does. `scale=0` is rejected, where SuperSuit gave you a degenerate `Box(0, 0)`. And the inner dtype and shape are preserved, where SuperSuit's `Box(low=..., high=...)` dropped both and silently made everything float32.

## Verification

    $ pytest test/scale_action_test.py -q
    46 passed, 2 warnings in 0.22s

    $ pytest test/wrapper_test.py -q
    13 passed, 18 warnings in 23.24s

`test_action_from_advertised_space_is_valid_inside` steps the env across seven scales and three bounds, including both endpoints, and asserts both that the inner space contains what it received and that the value is the expected inverse. The value assertion matters: once the clip is in, containment alone passes for almost any transformation.

## A question

Once the direction is fixed, `ScaleActionV1(env, s)` is exactly `RescaleAction(env, low*s, high*s)`, the proportional special case of Gymnasium's wrapper. Would you rather have a full multi-agent `RescaleAction(env, min_action, max_action)` matching Gymnasium's signature, with the scalar case falling out of it, instead of a separate scalar-only wrapper?

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the `pre-commit` checks on the changed files, all hooks pass including `ty` and `pydocstyle`
- [ ] I have not run the full `pytest -v`, since I don't have the Atari ROMs and some of the extras installed. I ran the new test file and `test/wrapper_test.py`, both green, and the exact output is above.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
