### PR TITLE
Add PadObservationsV1 wrappers, ported from SuperSuit pad_observations_v0

### DIFF
--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -131,5 +131,7 @@ while parallel_env.agents:
 .. autoclass:: OrderEnforcingWrapper
 .. autoclass:: DtypeObservationV1
 .. autoclass:: DtypeObservationParallelV1
+.. autoclass:: PadObservations
+.. autoclass:: PadObservationsParallel
 
 ```

--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -131,7 +131,7 @@ while parallel_env.agents:
 .. autoclass:: OrderEnforcingWrapper
 .. autoclass:: DtypeObservationV1
 .. autoclass:: DtypeObservationParallelV1
-.. autoclass:: PadObservations
-.. autoclass:: PadObservationsParallel
+.. autoclass:: PadObservationsV1
+.. autoclass:: PadObservationsParallelV1
 
 ```

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -7,6 +7,10 @@ from pettingzoo.utils.wrappers.dtype import DtypeObservationV1, DtypeObservation
 from pettingzoo.utils.wrappers.multi_episode_env import MultiEpisodeEnv
 from pettingzoo.utils.wrappers.multi_episode_parallel_env import MultiEpisodeParallelEnv
 from pettingzoo.utils.wrappers.order_enforcing import OrderEnforcingWrapper
+from pettingzoo.utils.wrappers.pad_observations import (
+    PadObservations,
+    PadObservationsParallel,
+)
 from pettingzoo.utils.wrappers.record_video import RecordVideo
 from pettingzoo.utils.wrappers.record_video_parallel import RecordVideoParallel
 from pettingzoo.utils.wrappers.terminate_illegal import TerminateIllegalWrapper
@@ -22,6 +26,8 @@ __all__ = [
     "MultiEpisodeEnv",
     "MultiEpisodeParallelEnv",
     "OrderEnforcingWrapper",
+    "PadObservations",
+    "PadObservationsParallel",
     "RecordVideo",
     "RecordVideoParallel",
     "TerminateIllegalWrapper",

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -8,8 +8,8 @@ from pettingzoo.utils.wrappers.multi_episode_env import MultiEpisodeEnv
 from pettingzoo.utils.wrappers.multi_episode_parallel_env import MultiEpisodeParallelEnv
 from pettingzoo.utils.wrappers.order_enforcing import OrderEnforcingWrapper
 from pettingzoo.utils.wrappers.pad_observations import (
-    PadObservations,
-    PadObservationsParallel,
+    PadObservationsParallelV1,
+    PadObservationsV1,
 )
 from pettingzoo.utils.wrappers.record_video import RecordVideo
 from pettingzoo.utils.wrappers.record_video_parallel import RecordVideoParallel
@@ -26,8 +26,8 @@ __all__ = [
     "MultiEpisodeEnv",
     "MultiEpisodeParallelEnv",
     "OrderEnforcingWrapper",
-    "PadObservations",
-    "PadObservationsParallel",
+    "PadObservationsParallelV1",
+    "PadObservationsV1",
     "RecordVideo",
     "RecordVideoParallel",
     "TerminateIllegalWrapper",

--- a/pettingzoo/utils/wrappers/pad_observations.py
+++ b/pettingzoo/utils/wrappers/pad_observations.py
@@ -82,7 +82,7 @@ def _pad_observation(space: Space[Any], obs: Any) -> Any:
     return _pad_to(np.asarray(obs), space.shape, 0)
 
 
-class PadObservations(BaseWrapper[AgentID, Any, ActionType]):
+class PadObservationsV1(BaseWrapper[AgentID, Any, ActionType]):
     """Pads each agent's observation up to one shared observation space.
 
     The shared space covers the observation spaces of ``possible_agents``. For Box
@@ -97,16 +97,19 @@ class PadObservations(BaseWrapper[AgentID, Any, ActionType]):
     An agent whose observation is already the full shape gets the array back without a
     copy, so writing into it writes into the environment.
 
+    Ported from SuperSuit's pad_observations_v0; the version suffix continues that
+    numbering.
+
     :param env: The AEC environment to wrap.
     """
 
     def __init__(self, env: AECEnv[AgentID, ObsType, ActionType]):
         assert isinstance(env, AECEnv), (
-            "PadObservations is only compatible with AEC environments, "
-            "use PadObservationsParallel instead."
+            "PadObservationsV1 is only compatible with AEC environments, "
+            "use PadObservationsParallelV1 instead."
         )
         assert hasattr(env, "possible_agents"), (
-            "environment passed to PadObservations must have a possible_agents list."
+            "environment passed to PadObservationsV1 must have a possible_agents list."
         )
         super().__init__(env)
         spaces = [env.observation_space(agent) for agent in env.possible_agents]
@@ -123,10 +126,10 @@ class PadObservations(BaseWrapper[AgentID, Any, ActionType]):
 
     @override
     def __str__(self) -> str:
-        return f"PadObservations<{self.env!s}>"
+        return f"PadObservationsV1<{self.env!s}>"
 
 
-class PadObservationsParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
+class PadObservationsParallelV1(BaseParallelWrapper[AgentID, Any, ActionType]):
     """Pads each agent's observation up to one shared observation space.
 
     The shared space covers the observation spaces of ``possible_agents``. For Box
@@ -141,16 +144,19 @@ class PadObservationsParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
     An agent whose observation is already the full shape gets the array back without a
     copy, so writing into it writes into the environment.
 
+    Ported from SuperSuit's pad_observations_v0; the version suffix continues that
+    numbering.
+
     :param env: The parallel environment to wrap.
     """
 
     def __init__(self, env: ParallelEnv[AgentID, ObsType, ActionType]):
         assert isinstance(env, ParallelEnv), (
-            "PadObservationsParallel is only compatible with parallel environments, "
-            "use PadObservations instead."
+            "PadObservationsParallelV1 is only compatible with parallel environments, "
+            "use PadObservationsV1 instead."
         )
         assert hasattr(env, "possible_agents"), (
-            "environment passed to PadObservationsParallel must have a "
+            "environment passed to PadObservationsParallelV1 must have a "
             "possible_agents list."
         )
         super().__init__(env)
@@ -190,4 +196,4 @@ class PadObservationsParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
 
     @override
     def __str__(self) -> str:
-        return f"PadObservationsParallel<{self.env!s}>"
+        return f"PadObservationsParallelV1<{self.env!s}>"

--- a/pettingzoo/utils/wrappers/pad_observations.py
+++ b/pettingzoo/utils/wrappers/pad_observations.py
@@ -1,0 +1,193 @@
+"""Wrappers that pad every agent's observation up to a single shared space."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+from gymnasium.spaces import Box, Discrete, Space
+from typing_extensions import override
+
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
+from pettingzoo.utils.wrappers.base import BaseWrapper
+from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
+
+
+def _check_paddable(spaces: list[Space[Any]]) -> None:
+    """Checks that a list of observation spaces can be padded to a common space."""
+    assert len(spaces) > 0, "environment must have at least one possible agent"
+    first = spaces[0]
+    assert isinstance(first, (Box, Discrete)), (
+        "padding only supports Box and Discrete observation spaces, "
+        f"got {type(first).__name__}"
+    )
+
+    expected = Box if isinstance(first, Box) else Discrete
+    for space in spaces:
+        assert isinstance(space, expected), (
+            "all observation spaces must be either Box or Discrete, not a mix"
+        )
+
+    if isinstance(first, Box):
+        for space in spaces:
+            assert isinstance(space, Box)
+            assert len(first.shape) == len(space.shape), (
+                "all Box observation spaces must have the same number of dimensions"
+            )
+            assert first.dtype == space.dtype, (
+                "all Box observation spaces must have the same dtype"
+            )
+
+
+def _pad_to(array: np.ndarray, shape: tuple[int, ...], value: Any) -> np.ndarray:
+    """Pads ``array`` up to ``shape`` at the end of every axis."""
+    if array.shape == shape:
+        return array
+    pad_widths = [(0, new - old) for new, old in zip(shape, array.shape)]
+    return np.pad(array, pad_widths, constant_values=value)
+
+
+def _padded_space(spaces: list[Space[Any]]) -> Space[Any]:
+    """Builds the space every agent is padded up to."""
+    if isinstance(spaces[0], Discrete):
+        discretes = cast("list[Discrete[Any]]", spaces)
+        start = min(int(space.start) for space in discretes)
+        end = max(int(space.start) + int(space.n) for space in discretes)
+        return Discrete(end - start, start=start)
+
+    boxes = cast("list[Box]", spaces)
+    shape = tuple(int(dim) for dim in np.max([box.shape for box in boxes], axis=0))
+    # the fill values are what SuperSuit uses: a bound wide enough that padding an
+    # agent's own bounds can never tighten the shared space
+    lows = np.stack(
+        [_pad_to(box.low, shape, np.minimum(0, np.min(box.low))) for box in boxes]
+    )
+    highs = np.stack(
+        [_pad_to(box.high, shape, np.maximum(1e-5, np.max(box.high))) for box in boxes]
+    )
+    # every space has the same dtype, and padding keeps it
+    return Box(
+        low=np.min(lows, axis=0), high=np.max(highs, axis=0), dtype=lows.dtype.type
+    )
+
+
+def _pad_observation(space: Space[Any], obs: Any) -> Any:
+    """Pads a single observation up to ``space``."""
+    if obs is None:
+        return None
+    if not isinstance(space, Box):
+        # Discrete observations already fit the shared space. SuperSuit returns the
+        # space here instead of the observation, which is a bug.
+        return obs
+    return _pad_to(np.asarray(obs), space.shape, 0)
+
+
+class PadObservations(BaseWrapper[AgentID, Any, ActionType]):
+    """Pads each agent's observation up to one shared observation space.
+
+    The shared space covers the observation spaces of ``possible_agents``. For Box
+    spaces it takes the largest size along each axis, and each observation is padded
+    with zeros at the end of every axis, so the real values stay at the front. For
+    Discrete spaces it takes the range covering all of them and observations pass
+    through unchanged. Every agent then reports that same space.
+
+    Box spaces have to agree on dtype and number of dimensions. Anything other than Box
+    and Discrete is rejected.
+
+    An agent whose observation is already the full shape gets the array back without a
+    copy, so writing into it writes into the environment.
+
+    :param env: The AEC environment to wrap.
+    """
+
+    def __init__(self, env: AECEnv[AgentID, ObsType, ActionType]):
+        assert isinstance(env, AECEnv), (
+            "PadObservations is only compatible with AEC environments, "
+            "use PadObservationsParallel instead."
+        )
+        assert hasattr(env, "possible_agents"), (
+            "environment passed to PadObservations must have a possible_agents list."
+        )
+        super().__init__(env)
+        spaces = [env.observation_space(agent) for agent in env.possible_agents]
+        _check_paddable(spaces)
+        self._obs_space = _padded_space(spaces)
+
+    @override
+    def observation_space(self, agent: AgentID) -> Space[Any]:
+        return self._obs_space
+
+    @override
+    def observe(self, agent: AgentID) -> Any:
+        return _pad_observation(self._obs_space, self.env.observe(agent))
+
+    @override
+    def __str__(self) -> str:
+        return f"PadObservations<{self.env!s}>"
+
+
+class PadObservationsParallel(BaseParallelWrapper[AgentID, Any, ActionType]):
+    """Pads each agent's observation up to one shared observation space.
+
+    The shared space covers the observation spaces of ``possible_agents``. For Box
+    spaces it takes the largest size along each axis, and each observation is padded
+    with zeros at the end of every axis, so the real values stay at the front. For
+    Discrete spaces it takes the range covering all of them and observations pass
+    through unchanged. Every agent then reports that same space.
+
+    Box spaces have to agree on dtype and number of dimensions. Anything other than Box
+    and Discrete is rejected.
+
+    An agent whose observation is already the full shape gets the array back without a
+    copy, so writing into it writes into the environment.
+
+    :param env: The parallel environment to wrap.
+    """
+
+    def __init__(self, env: ParallelEnv[AgentID, ObsType, ActionType]):
+        assert isinstance(env, ParallelEnv), (
+            "PadObservationsParallel is only compatible with parallel environments, "
+            "use PadObservations instead."
+        )
+        assert hasattr(env, "possible_agents"), (
+            "environment passed to PadObservationsParallel must have a "
+            "possible_agents list."
+        )
+        super().__init__(env)
+        spaces = [env.observation_space(agent) for agent in env.possible_agents]
+        _check_paddable(spaces)
+        self._obs_space = _padded_space(spaces)
+
+    @override
+    def observation_space(self, agent: AgentID) -> Space[Any]:
+        return self._obs_space
+
+    def _pad(self, observations: dict[AgentID, Any]) -> dict[AgentID, Any]:
+        return {
+            agent: _pad_observation(self._obs_space, obs)
+            for agent, obs in observations.items()
+        }
+
+    @override
+    def reset(
+        self, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[dict[AgentID, Any], dict[AgentID, dict[str, Any]]]:
+        observations, infos = self.env.reset(seed=seed, options=options)
+        return self._pad(observations), infos
+
+    @override
+    def step(
+        self, actions: dict[AgentID, ActionType]
+    ) -> tuple[
+        dict[AgentID, Any],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict[str, Any]],
+    ]:
+        observations, rewards, terminations, truncations, infos = self.env.step(actions)
+        return self._pad(observations), rewards, terminations, truncations, infos
+
+    @override
+    def __str__(self) -> str:
+        return f"PadObservationsParallel<{self.env!s}>"

--- a/test/pad_observations_test.py
+++ b/test/pad_observations_test.py
@@ -8,7 +8,7 @@ from gymnasium.spaces import Box, Dict, Discrete
 
 from pettingzoo.test import api_test, parallel_api_test
 from pettingzoo.utils.env import AECEnv, ParallelEnv
-from pettingzoo.utils.wrappers import PadObservations, PadObservationsParallel
+from pettingzoo.utils.wrappers import PadObservationsParallelV1, PadObservationsV1
 
 AGENTS = ["agent_0", "agent_1"]
 
@@ -122,7 +122,7 @@ class DummyParallel(ParallelEnv):
 
 @pytest.mark.parametrize(
     "wrapper,dummy",
-    [(PadObservations, DummyAEC), (PadObservationsParallel, DummyParallel)],
+    [(PadObservationsV1, DummyAEC), (PadObservationsParallelV1, DummyParallel)],
 )
 def test_every_agent_gets_the_same_padded_space(wrapper, dummy):
     env = wrapper(dummy())
@@ -142,7 +142,7 @@ def test_every_agent_gets_the_same_padded_space(wrapper, dummy):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_observe_is_padded(agent):
-    env = PadObservations(DummyAEC())
+    env = PadObservationsV1(DummyAEC())
     env.reset(seed=0)
 
     obs = env.observe(agent)
@@ -152,14 +152,14 @@ def test_aec_observe_is_padded(agent):
 
 def test_largest_agent_is_untouched():
     inner = DummyAEC()
-    env = PadObservations(inner)
+    env = PadObservationsV1(inner)
     env.reset(seed=0)
     assert np.array_equal(env.observe("agent_0"), inner.observe("agent_0"))
 
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_aec_last_is_padded(agent):
-    env = PadObservations(DummyAEC())
+    env = PadObservationsV1(DummyAEC())
     env.reset(seed=0)
     while env.agent_selection != agent:
         env.step(0)
@@ -170,7 +170,7 @@ def test_aec_last_is_padded(agent):
 
 @pytest.mark.parametrize("agent", AGENTS)
 def test_parallel_reset_and_step_are_padded(agent):
-    env = PadObservationsParallel(DummyParallel())
+    env = PadObservationsParallelV1(DummyParallel())
 
     obs, _ = env.reset(seed=0)
     assert np.array_equal(obs[agent], PADDED_OBS[agent])
@@ -189,7 +189,7 @@ def test_padding_goes_at_the_end_of_every_axis():
         "agent_0": np.ones((3, 3), dtype=np.float32),
         "agent_1": np.array([[0.25, 0.75]], dtype=np.float32),
     }
-    env = PadObservations(DummyAEC(spaces, obs))
+    env = PadObservationsV1(DummyAEC(spaces, obs))
     env.reset(seed=0)
 
     expected = np.zeros((3, 3), dtype=np.float32)
@@ -202,7 +202,7 @@ def test_homogeneous_spaces_are_unchanged():
     space = Box(low=-1.0, high=1.0, shape=(2, 2), dtype=np.float32)
     spaces = dict.fromkeys(AGENTS, space)
     obs = dict.fromkeys(AGENTS, np.full((2, 2), 0.5, dtype=np.float32))
-    env = PadObservations(DummyAEC(spaces, obs))
+    env = PadObservationsV1(DummyAEC(spaces, obs))
     env.reset(seed=0)
 
     padded = env.observation_space("agent_0")
@@ -223,7 +223,7 @@ def test_negative_high_is_clamped_so_the_padding_fits():
         "agent_0": np.full((3,), -2.0, dtype=np.float32),
         "agent_1": np.array([-2.0], dtype=np.float32),
     }
-    env = PadObservations(DummyAEC(spaces, obs))
+    env = PadObservationsV1(DummyAEC(spaces, obs))
     env.reset(seed=0)
 
     space = env.observation_space("agent_1")
@@ -245,7 +245,7 @@ def test_negative_high_clamp_truncates_for_integer_spaces():
         "agent_0": np.full((3,), -5, dtype=np.int8),
         "agent_1": np.array([-5], dtype=np.int8),
     }
-    env = PadObservations(DummyAEC(spaces, obs))
+    env = PadObservationsV1(DummyAEC(spaces, obs))
     env.reset(seed=0)
 
     space = env.observation_space("agent_1")
@@ -265,7 +265,7 @@ def test_integer_box_spaces_keep_their_dtype():
         "agent_0": np.full((2, 2), 7, dtype=np.uint8),
         "agent_1": np.array([[1, 2]], dtype=np.uint8),
     }
-    env = PadObservations(DummyAEC(spaces, obs))
+    env = PadObservationsV1(DummyAEC(spaces, obs))
     env.reset(seed=0)
 
     space = env.observation_space("agent_1")
@@ -279,7 +279,7 @@ def test_integer_box_spaces_keep_their_dtype():
 def test_discrete_spaces_take_the_largest_n():
     spaces = {"agent_0": Discrete(3), "agent_1": Discrete(5)}
     obs = {"agent_0": 2, "agent_1": 4}
-    env = PadObservations(DummyAEC(spaces, obs))
+    env = PadObservationsV1(DummyAEC(spaces, obs))
     env.reset(seed=0)
 
     assert env.observation_space("agent_0") == Discrete(5)
@@ -288,7 +288,7 @@ def test_discrete_spaces_take_the_largest_n():
 
 @pytest.mark.parametrize(
     "wrapper,dummy",
-    [(PadObservations, DummyAEC), (PadObservationsParallel, DummyParallel)],
+    [(PadObservationsV1, DummyAEC), (PadObservationsParallelV1, DummyParallel)],
 )
 def test_discrete_spaces_take_the_largest_n_parallel_too(wrapper, dummy):
     spaces = {"agent_0": Discrete(3), "agent_1": Discrete(5)}
@@ -314,7 +314,7 @@ def test_discrete_spaces_take_the_largest_n_parallel_too(wrapper, dummy):
     ],
 )
 def test_discrete_start_is_covered(spaces, expected):
-    env = PadObservations(DummyAEC(spaces))
+    env = PadObservationsV1(DummyAEC(spaces))
     assert env.observation_space("agent_0") == expected
 
     for agent, space in spaces.items():
@@ -325,13 +325,13 @@ def test_discrete_start_is_covered(spaces, expected):
 def test_discrete_start_passes_the_api_test():
     spaces = {"agent_0": Discrete(3, start=5), "agent_1": Discrete(5)}
     obs = {"agent_0": np.int64(5), "agent_1": np.int64(4)}
-    api_test(PadObservations(DummyAEC(spaces, obs)), num_cycles=5)
+    api_test(PadObservationsV1(DummyAEC(spaces, obs)), num_cycles=5)
 
 
 def test_parallel_discrete_and_none_pass_through():
     spaces = {"agent_0": Discrete(3), "agent_1": Discrete(5)}
     obs = {"agent_0": 2, "agent_1": None}
-    env = PadObservationsParallel(DummyParallel(spaces, obs))
+    env = PadObservationsParallelV1(DummyParallel(spaces, obs))
 
     observations, _ = env.reset(seed=0)
     assert observations["agent_0"] == 2
@@ -347,7 +347,7 @@ def test_parallel_integer_box_spaces_keep_their_dtype():
         "agent_0": np.full((2, 2), 7, dtype=np.uint8),
         "agent_1": np.array([[1, 2]], dtype=np.uint8),
     }
-    env = PadObservationsParallel(DummyParallel(spaces, obs))
+    env = PadObservationsParallelV1(DummyParallel(spaces, obs))
     observations, _ = env.reset(seed=0)
 
     space = env.observation_space("agent_1")
@@ -365,9 +365,9 @@ def test_mixing_discrete_and_box_raises():
         "agent_1": Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32),
     }
     with pytest.raises(AssertionError, match="Box or Discrete, not a mix"):
-        PadObservations(DummyAEC(spaces))
+        PadObservationsV1(DummyAEC(spaces))
     with pytest.raises(AssertionError, match="Box or Discrete, not a mix"):
-        PadObservationsParallel(DummyParallel(spaces))
+        PadObservationsParallelV1(DummyParallel(spaces))
 
 
 def test_different_number_of_dimensions_raises():
@@ -376,7 +376,7 @@ def test_different_number_of_dimensions_raises():
         "agent_1": Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32),
     }
     with pytest.raises(AssertionError, match="same number of dimensions"):
-        PadObservations(DummyAEC(spaces))
+        PadObservationsV1(DummyAEC(spaces))
 
 
 def test_different_dtypes_raise():
@@ -385,13 +385,13 @@ def test_different_dtypes_raise():
         "agent_1": Box(low=0.0, high=1.0, shape=(2,), dtype=np.float64),
     }
     with pytest.raises(AssertionError, match="same dtype"):
-        PadObservations(DummyAEC(spaces))
+        PadObservationsV1(DummyAEC(spaces))
 
 
 def test_unsupported_space_raises():
     space = Dict({"a": Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32)})
     with pytest.raises(AssertionError, match="only supports Box and Discrete"):
-        PadObservations(DummyAEC(dict.fromkeys(AGENTS, space)))
+        PadObservationsV1(DummyAEC(dict.fromkeys(AGENTS, space)))
 
 
 def test_missing_possible_agents_raises():
@@ -401,7 +401,7 @@ def test_missing_possible_agents_raises():
             del self.possible_agents
 
     with pytest.raises(AssertionError, match="possible_agents"):
-        PadObservations(NoPossibleAgents())
+        PadObservationsV1(NoPossibleAgents())
 
 
 def test_observe_passes_through_none():
@@ -409,24 +409,24 @@ def test_observe_passes_through_none():
         def observe(self, agent):
             return None
 
-    env = PadObservations(NoneObsEnv())
+    env = PadObservationsV1(NoneObsEnv())
     env.reset(seed=0)
     assert env.observe("agent_0") is None
 
 
 def test_rejects_parallel_env():
-    with pytest.raises(AssertionError, match="PadObservationsParallel"):
-        PadObservations(DummyParallel())
+    with pytest.raises(AssertionError, match="PadObservationsParallelV1"):
+        PadObservationsV1(DummyParallel())
 
 
 def test_parallel_rejects_aec_env():
-    with pytest.raises(AssertionError, match="use PadObservations instead"):
-        PadObservationsParallel(DummyAEC())
+    with pytest.raises(AssertionError, match="use PadObservationsV1 instead"):
+        PadObservationsParallelV1(DummyAEC())
 
 
 def test_aec_api():
-    api_test(PadObservations(DummyAEC()), num_cycles=5)
+    api_test(PadObservationsV1(DummyAEC()), num_cycles=5)
 
 
 def test_parallel_api():
-    parallel_api_test(PadObservationsParallel(DummyParallel()), num_cycles=5)
+    parallel_api_test(PadObservationsParallelV1(DummyParallel()), num_cycles=5)

--- a/test/pad_observations_test.py
+++ b/test/pad_observations_test.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pytest
+from gymnasium.spaces import Box, Dict, Discrete
+
+from pettingzoo.test import api_test, parallel_api_test
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+from pettingzoo.utils.wrappers import PadObservations, PadObservationsParallel
+
+AGENTS = ["agent_0", "agent_1"]
+
+# agent_0 has the larger space, agent_1 gets padded up to it.
+OBS_SPACES = {
+    "agent_0": Box(
+        low=np.zeros((2, 3), dtype=np.float32),
+        high=np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32),
+        dtype=np.float32,
+    ),
+    "agent_1": Box(low=-1.0, high=0.5, shape=(1, 2), dtype=np.float32),
+}
+
+OBS = {
+    "agent_0": np.array([[0.5, 1.5, 2.5], [3.5, 4.5, 5.5]], dtype=np.float32),
+    "agent_1": np.array([[0.25, -0.75]], dtype=np.float32),
+}
+
+PADDED_OBS = {
+    "agent_0": OBS["agent_0"],
+    "agent_1": np.array([[0.25, -0.75, 0.0], [0.0, 0.0, 0.0]], dtype=np.float32),
+}
+
+
+class DummyAEC(AECEnv):
+    metadata = {"render_modes": [], "name": "dummy_aec"}
+
+    def __init__(self, obs_spaces=None, obs=None):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+        self._obs_spaces = dict(OBS_SPACES if obs_spaces is None else obs_spaces)
+        self._obs = dict(OBS if obs is None else obs)
+
+    def observation_space(self, agent):
+        return self._obs_spaces[agent]
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        self._cumulative_rewards = dict.fromkeys(self.agents, 0.0)
+        self.terminations = dict.fromkeys(self.agents, False)
+        self.truncations = dict.fromkeys(self.agents, False)
+        self.infos = {a: {} for a in self.agents}
+        self._idx = 0
+        self._step_count = 0
+        self.agent_selection = self.agents[0]
+
+    def observe(self, agent):
+        return self._obs[agent]
+
+    def step(self, action):
+        self._step_count += 1
+        self._cumulative_rewards[self.agent_selection] = 0.0
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        if self._step_count >= 8:
+            self.terminations = dict.fromkeys(self.agents, True)
+        self._idx = (self._idx + 1) % len(self.agents)
+        self.agent_selection = self.agents[self._idx]
+        self._accumulate_rewards()
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class DummyParallel(ParallelEnv):
+    metadata = {"render_modes": [], "name": "dummy_parallel"}
+
+    def __init__(self, obs_spaces=None, obs=None):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+        self._obs_spaces = dict(OBS_SPACES if obs_spaces is None else obs_spaces)
+        self._obs = dict(OBS if obs is None else obs)
+
+    def observation_space(self, agent):
+        return self._obs_spaces[agent]
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self._step_count = 0
+        return dict(self._obs), {a: {} for a in self.agents}
+
+    def step(self, actions):
+        self._step_count += 1
+        done = self._step_count >= 8
+        obs = dict(self._obs)
+        rewards = dict.fromkeys(self.agents, 0.0)
+        terminations = dict.fromkeys(self.agents, done)
+        truncations = dict.fromkeys(self.agents, False)
+        infos = {a: {} for a in self.agents}
+        if done:
+            self.agents = []
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    "wrapper,dummy",
+    [(PadObservations, DummyAEC), (PadObservationsParallel, DummyParallel)],
+)
+def test_every_agent_gets_the_same_padded_space(wrapper, dummy):
+    env = wrapper(dummy())
+    space = env.observation_space("agent_0")
+
+    assert space is env.observation_space("agent_1")
+    assert space.shape == (2, 3)
+    assert space.dtype == np.float32
+    # each space pads its own low with min(0, its lowest) and its own high with
+    # max(1e-5, its highest) before the elementwise min and max across agents, so
+    # agent_1's low of -1 spreads over the whole space and agent_0's high wins.
+    assert np.array_equal(space.low, np.full((2, 3), -1.0, dtype=np.float32))
+    assert np.array_equal(
+        space.high, np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+    )
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_observe_is_padded(agent):
+    env = PadObservations(DummyAEC())
+    env.reset(seed=0)
+
+    obs = env.observe(agent)
+    assert np.array_equal(obs, PADDED_OBS[agent])
+    assert env.observation_space(agent).contains(obs)
+
+
+def test_largest_agent_is_untouched():
+    inner = DummyAEC()
+    env = PadObservations(inner)
+    env.reset(seed=0)
+    assert np.array_equal(env.observe("agent_0"), inner.observe("agent_0"))
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_aec_last_is_padded(agent):
+    env = PadObservations(DummyAEC())
+    env.reset(seed=0)
+    while env.agent_selection != agent:
+        env.step(0)
+
+    obs, _, _, _, _ = env.last()
+    assert np.array_equal(obs, PADDED_OBS[agent])
+
+
+@pytest.mark.parametrize("agent", AGENTS)
+def test_parallel_reset_and_step_are_padded(agent):
+    env = PadObservationsParallel(DummyParallel())
+
+    obs, _ = env.reset(seed=0)
+    assert np.array_equal(obs[agent], PADDED_OBS[agent])
+    assert env.observation_space(agent).contains(obs[agent])
+
+    obs, _, _, _, _ = env.step(dict.fromkeys(env.agents, 0))
+    assert np.array_equal(obs[agent], PADDED_OBS[agent])
+
+
+def test_padding_goes_at_the_end_of_every_axis():
+    spaces = {
+        "agent_0": Box(low=0.0, high=1.0, shape=(3, 3), dtype=np.float32),
+        "agent_1": Box(low=0.0, high=1.0, shape=(1, 2), dtype=np.float32),
+    }
+    obs = {
+        "agent_0": np.ones((3, 3), dtype=np.float32),
+        "agent_1": np.array([[0.25, 0.75]], dtype=np.float32),
+    }
+    env = PadObservations(DummyAEC(spaces, obs))
+    env.reset(seed=0)
+
+    expected = np.zeros((3, 3), dtype=np.float32)
+    expected[0, 0] = 0.25
+    expected[0, 1] = 0.75
+    assert np.array_equal(env.observe("agent_1"), expected)
+
+
+def test_homogeneous_spaces_are_unchanged():
+    space = Box(low=-1.0, high=1.0, shape=(2, 2), dtype=np.float32)
+    spaces = dict.fromkeys(AGENTS, space)
+    obs = dict.fromkeys(AGENTS, np.full((2, 2), 0.5, dtype=np.float32))
+    env = PadObservations(DummyAEC(spaces, obs))
+    env.reset(seed=0)
+
+    padded = env.observation_space("agent_0")
+    assert padded.shape == space.shape
+    assert np.array_equal(padded.low, space.low)
+    assert np.array_equal(padded.high, space.high)
+    assert np.array_equal(env.observe("agent_0"), obs["agent_0"])
+
+
+def test_negative_high_is_clamped_so_the_padding_fits():
+    # the padded entries are zeros, which sit above every real high here, so the
+    # shared high has to be raised to 1e-5 for them
+    spaces = {
+        "agent_0": Box(low=-5.0, high=-1.0, shape=(3,), dtype=np.float32),
+        "agent_1": Box(low=-5.0, high=-1.0, shape=(1,), dtype=np.float32),
+    }
+    obs = {
+        "agent_0": np.full((3,), -2.0, dtype=np.float32),
+        "agent_1": np.array([-2.0], dtype=np.float32),
+    }
+    env = PadObservations(DummyAEC(spaces, obs))
+    env.reset(seed=0)
+
+    space = env.observation_space("agent_1")
+    assert np.allclose(space.high, np.array([-1.0, 1e-5, 1e-5], dtype=np.float32))
+    assert np.array_equal(space.low, np.full((3,), -5.0, dtype=np.float32))
+
+    padded = env.observe("agent_1")
+    assert np.array_equal(padded, np.array([-2.0, 0.0, 0.0], dtype=np.float32))
+    assert space.contains(padded)
+
+
+def test_negative_high_clamp_truncates_for_integer_spaces():
+    # same clamp, but 1e-5 truncates to 0 on the way into an int space
+    spaces = {
+        "agent_0": Box(low=-10, high=-1, shape=(3,), dtype=np.int8),
+        "agent_1": Box(low=-10, high=-1, shape=(1,), dtype=np.int8),
+    }
+    obs = {
+        "agent_0": np.full((3,), -5, dtype=np.int8),
+        "agent_1": np.array([-5], dtype=np.int8),
+    }
+    env = PadObservations(DummyAEC(spaces, obs))
+    env.reset(seed=0)
+
+    space = env.observation_space("agent_1")
+    assert np.array_equal(space.high, np.array([-1, 0, 0], dtype=np.int8))
+
+    padded = env.observe("agent_1")
+    assert np.array_equal(padded, np.array([-5, 0, 0], dtype=np.int8))
+    assert space.contains(padded)
+
+
+def test_integer_box_spaces_keep_their_dtype():
+    spaces = {
+        "agent_0": Box(low=0, high=255, shape=(2, 2), dtype=np.uint8),
+        "agent_1": Box(low=0, high=255, shape=(1, 2), dtype=np.uint8),
+    }
+    obs = {
+        "agent_0": np.full((2, 2), 7, dtype=np.uint8),
+        "agent_1": np.array([[1, 2]], dtype=np.uint8),
+    }
+    env = PadObservations(DummyAEC(spaces, obs))
+    env.reset(seed=0)
+
+    space = env.observation_space("agent_1")
+    padded = env.observe("agent_1")
+    assert space.dtype == np.uint8
+    assert padded.dtype == np.uint8
+    assert np.array_equal(padded, np.array([[1, 2], [0, 0]], dtype=np.uint8))
+    assert space.contains(padded)
+
+
+def test_discrete_spaces_take_the_largest_n():
+    spaces = {"agent_0": Discrete(3), "agent_1": Discrete(5)}
+    obs = {"agent_0": 2, "agent_1": 4}
+    env = PadObservations(DummyAEC(spaces, obs))
+    env.reset(seed=0)
+
+    assert env.observation_space("agent_0") == Discrete(5)
+    assert env.observe("agent_0") == 2
+
+
+@pytest.mark.parametrize(
+    "wrapper,dummy",
+    [(PadObservations, DummyAEC), (PadObservationsParallel, DummyParallel)],
+)
+def test_discrete_spaces_take_the_largest_n_parallel_too(wrapper, dummy):
+    spaces = {"agent_0": Discrete(3), "agent_1": Discrete(5)}
+    obs = {"agent_0": 2, "agent_1": 4}
+    env = wrapper(dummy(spaces, obs))
+    assert env.observation_space("agent_0") == Discrete(5)
+
+
+@pytest.mark.parametrize(
+    "spaces,expected",
+    [
+        # a start of 0 is the plain case: n grows, start stays put
+        ({"agent_0": Discrete(3), "agent_1": Discrete(5)}, Discrete(5)),
+        # the shared space has to reach up to agent_0's largest value of 7
+        ({"agent_0": Discrete(3, start=5), "agent_1": Discrete(5)}, Discrete(8)),
+        # nothing starts at 0, so neither does the shared space
+        (
+            {"agent_0": Discrete(3, start=5), "agent_1": Discrete(2, start=7)},
+            Discrete(4, start=5),
+        ),
+        # a bigger n does not mean a bigger range
+        ({"agent_0": Discrete(2), "agent_1": Discrete(4, start=10)}, Discrete(14)),
+    ],
+)
+def test_discrete_start_is_covered(spaces, expected):
+    env = PadObservations(DummyAEC(spaces))
+    assert env.observation_space("agent_0") == expected
+
+    for agent, space in spaces.items():
+        for obs in range(int(space.start), int(space.start) + int(space.n)):
+            assert expected.contains(obs), f"{agent} cannot observe {obs}"
+
+
+def test_discrete_start_passes_the_api_test():
+    spaces = {"agent_0": Discrete(3, start=5), "agent_1": Discrete(5)}
+    obs = {"agent_0": np.int64(5), "agent_1": np.int64(4)}
+    api_test(PadObservations(DummyAEC(spaces, obs)), num_cycles=5)
+
+
+def test_parallel_discrete_and_none_pass_through():
+    spaces = {"agent_0": Discrete(3), "agent_1": Discrete(5)}
+    obs = {"agent_0": 2, "agent_1": None}
+    env = PadObservationsParallel(DummyParallel(spaces, obs))
+
+    observations, _ = env.reset(seed=0)
+    assert observations["agent_0"] == 2
+    assert observations["agent_1"] is None
+
+
+def test_parallel_integer_box_spaces_keep_their_dtype():
+    spaces = {
+        "agent_0": Box(low=0, high=255, shape=(2, 2), dtype=np.uint8),
+        "agent_1": Box(low=0, high=255, shape=(1, 2), dtype=np.uint8),
+    }
+    obs = {
+        "agent_0": np.full((2, 2), 7, dtype=np.uint8),
+        "agent_1": np.array([[1, 2]], dtype=np.uint8),
+    }
+    env = PadObservationsParallel(DummyParallel(spaces, obs))
+    observations, _ = env.reset(seed=0)
+
+    space = env.observation_space("agent_1")
+    assert space.dtype == np.uint8
+    assert observations["agent_1"].dtype == np.uint8
+    assert np.array_equal(
+        observations["agent_1"], np.array([[1, 2], [0, 0]], dtype=np.uint8)
+    )
+    assert space.contains(observations["agent_1"])
+
+
+def test_mixing_discrete_and_box_raises():
+    spaces = {
+        "agent_0": Discrete(3),
+        "agent_1": Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32),
+    }
+    with pytest.raises(AssertionError, match="Box or Discrete, not a mix"):
+        PadObservations(DummyAEC(spaces))
+    with pytest.raises(AssertionError, match="Box or Discrete, not a mix"):
+        PadObservationsParallel(DummyParallel(spaces))
+
+
+def test_different_number_of_dimensions_raises():
+    spaces = {
+        "agent_0": Box(low=0.0, high=1.0, shape=(2, 2), dtype=np.float32),
+        "agent_1": Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32),
+    }
+    with pytest.raises(AssertionError, match="same number of dimensions"):
+        PadObservations(DummyAEC(spaces))
+
+
+def test_different_dtypes_raise():
+    spaces = {
+        "agent_0": Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32),
+        "agent_1": Box(low=0.0, high=1.0, shape=(2,), dtype=np.float64),
+    }
+    with pytest.raises(AssertionError, match="same dtype"):
+        PadObservations(DummyAEC(spaces))
+
+
+def test_unsupported_space_raises():
+    space = Dict({"a": Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32)})
+    with pytest.raises(AssertionError, match="only supports Box and Discrete"):
+        PadObservations(DummyAEC(dict.fromkeys(AGENTS, space)))
+
+
+def test_missing_possible_agents_raises():
+    class NoPossibleAgents(DummyAEC):
+        def __init__(self):
+            super().__init__()
+            del self.possible_agents
+
+    with pytest.raises(AssertionError, match="possible_agents"):
+        PadObservations(NoPossibleAgents())
+
+
+def test_observe_passes_through_none():
+    class NoneObsEnv(DummyAEC):
+        def observe(self, agent):
+            return None
+
+    env = PadObservations(NoneObsEnv())
+    env.reset(seed=0)
+    assert env.observe("agent_0") is None
+
+
+def test_rejects_parallel_env():
+    with pytest.raises(AssertionError, match="PadObservationsParallel"):
+        PadObservations(DummyParallel())
+
+
+def test_parallel_rejects_aec_env():
+    with pytest.raises(AssertionError, match="use PadObservations instead"):
+        PadObservationsParallel(DummyAEC())
+
+
+def test_aec_api():
+    api_test(PadObservations(DummyAEC()), num_cycles=5)
+
+
+def test_parallel_api():
+    parallel_api_test(PadObservationsParallel(DummyParallel()), num_cycles=5)


### PR DESCRIPTION
# Description

Ports SuperSuit's `pad_observations_v0` as `PadObservationsV1` and `PadObservationsParallelV1`, part of #1365. Pads every agent's observation up to the largest observation space across `possible_agents`, so all agents advertise the same space. Multi-agent only, so there's no Gymnasium equivalent to name it after.

Classes rather than a factory function, per @virgilt's note about mirroring `gymnasium.wrappers`. AEC and Parallel are both implemented directly on the PettingZoo wrapper bases. Same shape as #1415.

Padding goes at the end of every axis, so the real values sit at the leading corner, and the padded Box bounds are computed the way `homogenize_spaces` computes them, including the `max(1e-5, ...)` clamp on the high side. That clamp looks like a typo and isn't: it's what guarantees the zero fill is inside the advertised bounds when every real bound is negative. There are two tests on it now, including the integer case where `1e-5` truncates to 0.

## Two bugs fixed rather than ported

`homogenize_observations` returns the space object instead of the observation in its Discrete branch, so `pad_observations_v0` on an env with Discrete observations hands the agent a `Discrete(4)` object as its observation. This returns the observation.

Fixing that surfaced a second one. Taking `Discrete(max(n))` and discarding `start` gives a space that doesn't contain the observation: `Discrete(3, start=5)` alongside `Discrete(5)` advertised `Discrete(5)` for an observation of `5`, and `api_test` fails on it. The padded space is now `Discrete(end - start, start=start)` over the min start and max end, which reduces to `Discrete(max(n))` when every start is 0, so the common case is unchanged.

## One thing kept

An agent whose observation is already the full shape gets its array back without a copy, same as SuperSuit, so writing into it writes into the environment. That's in both docstrings now rather than being left as a surprise. Everyone else gets a fresh array from `np.pad`.

## Verification

    $ pytest test/pad_observations_test.py -q
    34 passed, 4 warnings in 0.13s

    $ pytest test/wrapper_test.py -q
    13 passed, 18 warnings in 23.51s

I diffed the port against SuperSuit's real `homogenize_ops` on a 4000-case fuzz over five dtypes, ranks 1 to 3, two and three agents, and random per-axis shapes and bounds, plus a 2000-case Discrete fuzz. No mismatches on the padded space or the padded observation for the Box path, and `padded_space.contains(padded_obs)` held throughout.

## A question

`observation_space(agent)` returns the same object for every agent, since the padded space is identical for all of them. That means `observation_space("agent_1").seed(0)` reseeds the generator `observation_space("agent_0").sample()` draws from. SuperSuit did the same. Want a per-agent copy instead?

Also: should a `PadActions` port of `pad_action_space_v0` follow? Padding observations alone still leaves action spaces heterogeneous, and the two are normally used together. Happy to take it if nobody else has.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the `pre-commit` checks on the changed files, all hooks pass including `ty` and `pydocstyle`
- [ ] I have not run the full `pytest -v`, since I don't have the Atari ROMs and some of the extras installed. I ran the new test file and `test/wrapper_test.py`, both green, and the exact output is above.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
