### PR TITLE
Run docs CI on Python 3.12

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,14 +8,14 @@ permissions:
 jobs:
     docs:
         name: Generate Website
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         env:
             SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
             - uses: actions/checkout@v7
             - uses: actions/setup-python@v7
               with:
-                  python-version: '3.11'
+                  python-version: '3.12'
             - name: Install dependencies
               run: pip install -r docs/requirements.txt
             - name: Install PettingZoo

--- a/.github/workflows/docs-manual-versioning.yml
+++ b/.github/workflows/docs-manual-versioning.yml
@@ -30,7 +30,7 @@ jobs:
                   ref: ${{ inputs.commit }}
             - uses: actions/setup-python@v7
               with:
-                  python-version: '3.11'
+                  python-version: '3.12'
             - name: Install dependencies
               run: pip install -r docs/requirements.txt
             - name: Install PettingZoo

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -12,16 +12,16 @@ permissions:
 
 jobs:
     docs-test:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         strategy:
             matrix:
                 group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         steps:
             - uses: actions/checkout@v7
-            - name: Set up Python 3.11
+            - name: Set up Python 3.12
               uses: actions/setup-python@v7
               with:
-                  python-version: '3.11'
+                  python-version: '3.12'
             - name: Install dependencies
               run: |
                   sudo apt-get install python3-opengl xvfb

--- a/.github/workflows/docs-versioning.yml
+++ b/.github/workflows/docs-versioning.yml
@@ -16,7 +16,7 @@ jobs:
             - uses: actions/checkout@v7
             - uses: actions/setup-python@v7
               with:
-                  python-version: '3.11'
+                  python-version: '3.12'
             - name: Get tag
               id: tag
               uses: dawidd6/action-get-tag@v1
@@ -47,6 +47,7 @@ jobs:
 
             - name: Upload to GitHub Pages
               uses: JamesIves/github-pages-deploy-action@v4
+              if: ${{ !contains(github.ref_name, 'a') }}
               with:
                   folder: _build
                   clean-exclude: |


### PR DESCRIPTION
# Description

Related to #1442. Gymnasium's docs workflows run on Python 3.12 / `ubuntu-latest`. Ours were still 3.11 on `ubuntu-22.04` (`build-docs`, `docs-test`, and the two versioning jobs).

Also copies Gymnasium's `if: ${{ !contains(github.ref_name, 'a') }}` on the root Pages deploy in `docs-versioning.yml`, so an alpha tag still writes its version folder but does not replace the current site.

`pre-commit run --files` on the four workflow files is green.

## Type of change

- This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
