### PR TITLE
Add Sphinx linkcheck workflow

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,44 @@
+---
+name: Check documentation links
+
+on:
+    schedule:
+    # 00:00 UTC on the 1st and 15th of every month (~every two weeks)
+        - cron: 0 0 1,15 * *
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    linkcheck:
+        name: Sphinx linkcheck
+        runs-on: ubuntu-latest
+        env:
+            SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        steps:
+            - uses: actions/checkout@v7
+
+            - uses: actions/setup-python@v7
+              with:
+                  python-version: '3.12'
+
+            - name: Install dependencies
+              run: pip install -r docs/requirements.txt
+
+            - name: Install PettingZoo
+              run: pip install .[all]
+
+            - name: Generate environment docs
+              run: python docs/_scripts/gen_envs_mds.py && python docs/_scripts/gen_envs_display.py
+
+            - name: Check links
+              run: python docs/_scripts/linkcheck.py -v
+
+            - name: Upload linkcheck report
+              if: always()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: linkcheck-report
+                  path: _build/linkcheck/

--- a/docs/_scripts/linkcheck.py
+++ b/docs/_scripts/linkcheck.py
@@ -1,0 +1,28 @@
+"""Run Sphinx's linkcheck builder against the docs.
+
+Usage:
+    python docs/_scripts/linkcheck.py [extra sphinx-build args]
+
+Exits with sphinx-build's return code so it can be wired into CI.
+"""
+
+import os
+import subprocess
+import sys
+
+DOCS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BUILD_DIR = os.path.join(os.path.dirname(DOCS_DIR), "_build", "linkcheck")
+
+
+if __name__ == "__main__":
+    cmd = [
+        sys.executable,
+        "-m",
+        "sphinx",
+        "-b",
+        "linkcheck",
+        DOCS_DIR,
+        BUILD_DIR,
+        *sys.argv[1:],
+    ]
+    sys.exit(subprocess.call(cmd))


### PR DESCRIPTION
# Description

Related to #1442. Gymnasium has a scheduled Sphinx linkcheck (`linkcheck.yml` + `docs/_scripts/linkcheck.py`). We did not, so a dead docs link only showed up when someone clicked it.

Same shape: 00:00 UTC on the 1st and 15th, plus `workflow_dispatch`. It generates the env pages first (`gen_envs_mds.py` / `gen_envs_display.py`), then `sphinx -b linkcheck`, and uploads the report even if the job fails. Install is `pip install .[all]` instead of Gymnasium's extra set.

Does not run on PRs, same as Gymnasium. `pre-commit` on the two new files is green; I did not run a full local sphinx linkcheck.

## Type of change

- This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have run `pytest -v` and no errors are present.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
