### PR TITLE
Add ClipRewardV1 wrappers, ported from SuperSuit clip_reward_v0

### DIFF
--- a/docs/api/wrappers/pz_wrappers.md
+++ b/docs/api/wrappers/pz_wrappers.md
@@ -131,6 +131,8 @@ while parallel_env.agents:
 .. autoclass:: CaptureStdoutWrapper
 .. autoclass:: AssertOutOfBoundsWrapper
 .. autoclass:: ClipOutOfBoundsWrapper
+.. autoclass:: ClipRewardV1
+.. autoclass:: ClipRewardParallelV1
 .. autoclass:: OrderEnforcingWrapper
 .. autoclass:: AgentIndicatorV1
 .. autoclass:: AgentIndicatorParallelV1

--- a/pettingzoo/utils/wrappers/__init__.py
+++ b/pettingzoo/utils/wrappers/__init__.py
@@ -7,6 +7,7 @@ from pettingzoo.utils.wrappers.base import BaseWrapper
 from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
 from pettingzoo.utils.wrappers.capture_stdout import CaptureStdoutWrapper
 from pettingzoo.utils.wrappers.clip_out_of_bounds import ClipOutOfBoundsWrapper
+from pettingzoo.utils.wrappers.clip_reward import ClipRewardParallelV1, ClipRewardV1
 from pettingzoo.utils.wrappers.color_reduction import (
     ColorReductionObservationParallelV1,
     ColorReductionObservationV1,
@@ -54,6 +55,8 @@ __all__ = [
     "BaseWrapper",
     "CaptureStdoutWrapper",
     "ClipOutOfBoundsWrapper",
+    "ClipRewardParallelV1",
+    "ClipRewardV1",
     "ColorReductionObservationParallelV1",
     "ColorReductionObservationV1",
     "DtypeObservationParallelV1",

--- a/pettingzoo/utils/wrappers/clip_reward.py
+++ b/pettingzoo/utils/wrappers/clip_reward.py
@@ -1,0 +1,125 @@
+"""Wrappers that clip each agent's per-step reward into a closed interval."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from typing_extensions import override
+
+from pettingzoo.utils.env import ActionType, AECEnv, AgentID, ObsType, ParallelEnv
+from pettingzoo.utils.wrappers.base import BaseWrapper
+from pettingzoo.utils.wrappers.base_parallel import BaseParallelWrapper
+
+
+def _clip_reward(reward: float, min_reward: float, max_reward: float) -> float:
+    if reward < min_reward:
+        return min_reward
+    if reward > max_reward:
+        return max_reward
+    return reward
+
+
+class ClipRewardV1(BaseWrapper[AgentID, ObsType, ActionType]):
+    """Clips each agent's per-step reward into ``[min_reward, max_reward]``.
+
+    After every ``reset`` and ``step`` the inner ``rewards`` dict is clipped and
+    the running total is rebuilt from that, so :meth:`~pettingzoo.utils.env.AECEnv.last`
+    reports the sum of clipped steps. That is SuperSuit's ``clip_reward_v0``.
+
+    :param env: The AEC environment to wrap.
+    :param min_reward: Lower bound, inclusive. Default ``-1``.
+    :param max_reward: Upper bound, inclusive. Default ``1``.
+    """
+
+    def __init__(
+        self,
+        env: AECEnv[AgentID, ObsType, ActionType],
+        min_reward: float = -1,
+        max_reward: float = 1,
+    ):
+        assert isinstance(env, AECEnv), (
+            "ClipRewardV1 is only compatible with AEC environments, "
+            "use ClipRewardParallelV1 instead."
+        )
+        assert min_reward <= max_reward, (
+            f"min_reward ({min_reward}) must be <= max_reward ({max_reward})."
+        )
+        super().__init__(env)
+        self.min_reward = min_reward
+        self.max_reward = max_reward
+
+    def _clip_and_accumulate(self, agent: AgentID | None = None) -> None:
+        self.rewards = {
+            a: _clip_reward(reward, self.min_reward, self.max_reward)
+            for a, reward in self.env.rewards.items()
+        }
+        if agent is None:
+            self._cumulative_rewards = dict.fromkeys(self.env._cumulative_rewards, 0.0)
+        else:
+            # Zero the agent that just stepped, matching SuperSuit, then add
+            # this step's clipped rewards onto the running totals.
+            self._cumulative_rewards[agent] = 0.0
+        self._accumulate_rewards()
+
+    @override
+    def reset(self, seed: int | None = None, options: dict[str, Any] | None = None):
+        self.env.reset(seed=seed, options=options)
+        self._clip_and_accumulate()
+
+    @override
+    def step(self, action: ActionType) -> None:
+        agent = self.env.agent_selection
+        self.env.step(action)
+        self._clip_and_accumulate(agent)
+
+    @override
+    def __str__(self) -> str:
+        return f"ClipRewardV1<{self.env!s}>"
+
+
+class ClipRewardParallelV1(BaseParallelWrapper[AgentID, ObsType, ActionType]):
+    """Clips each agent's per-step reward into ``[min_reward, max_reward]``.
+
+    SuperSuit's ``clip_reward_v0`` has no Parallel implementation of its own.
+    This one clips the reward dict that :meth:`step` returns.
+
+    :param env: The parallel environment to wrap.
+    :param min_reward: Lower bound, inclusive. Default ``-1``.
+    :param max_reward: Upper bound, inclusive. Default ``1``.
+    """
+
+    def __init__(
+        self,
+        env: ParallelEnv[AgentID, ObsType, ActionType],
+        min_reward: float = -1,
+        max_reward: float = 1,
+    ):
+        assert min_reward <= max_reward, (
+            f"min_reward ({min_reward}) must be <= max_reward ({max_reward})."
+        )
+        super().__init__(env)
+        self.min_reward = min_reward
+        self.max_reward = max_reward
+
+    def _clip(self, rewards: dict[AgentID, float]) -> dict[AgentID, float]:
+        return {
+            agent: _clip_reward(reward, self.min_reward, self.max_reward)
+            for agent, reward in rewards.items()
+        }
+
+    @override
+    def step(
+        self, actions: dict[AgentID, ActionType]
+    ) -> tuple[
+        dict[AgentID, ObsType],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict[str, Any]],
+    ]:
+        observations, rewards, terminations, truncations, infos = self.env.step(actions)
+        return observations, self._clip(rewards), terminations, truncations, infos
+
+    @override
+    def __str__(self) -> str:
+        return f"ClipRewardParallelV1<{self.env!s}>"

--- a/test/clip_reward_test.py
+++ b/test/clip_reward_test.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pytest
+from gymnasium.spaces import Box, Discrete
+
+from pettingzoo.test import api_test, parallel_api_test
+from pettingzoo.utils.env import AECEnv, ParallelEnv
+from pettingzoo.utils.wrappers import ClipRewardParallelV1, ClipRewardV1
+
+AGENTS = ["agent_0", "agent_1"]
+OBS = np.array([0.25, 0.75], dtype=np.float32)
+RAW_REWARD = 10.0
+
+
+@functools.cache
+def obs_space(agent):
+    return Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32)
+
+
+class DummyAEC(AECEnv):
+    """Gives RAW_REWARD to the agent that just stepped."""
+
+    metadata = {"render_modes": [], "name": "dummy_aec"}
+
+    def __init__(self):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+
+    def observation_space(self, agent):
+        return obs_space(agent)
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self.rewards = dict.fromkeys(self.agents, 0.0)
+        self._cumulative_rewards = dict.fromkeys(self.agents, 0.0)
+        self.terminations = dict.fromkeys(self.agents, False)
+        self.truncations = dict.fromkeys(self.agents, False)
+        self.infos = {a: {} for a in self.agents}
+        self._idx = 0
+        self._step_count = 0
+        self.agent_selection = self.agents[0]
+
+    def observe(self, agent):
+        return OBS
+
+    def step(self, action):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            self._was_dead_step(action)
+            return
+        self._step_count += 1
+        self._clear_rewards()
+        self.rewards[self.agent_selection] = RAW_REWARD
+        if self._step_count >= 8:
+            self.terminations = dict.fromkeys(self.agents, True)
+        self._idx = (self._idx + 1) % len(self.agents)
+        self.agent_selection = self.agents[self._idx]
+        self._accumulate_rewards()
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class DummyParallel(ParallelEnv):
+    metadata = {"render_modes": [], "name": "dummy_parallel"}
+
+    def __init__(self):
+        super().__init__()
+        self.possible_agents = list(AGENTS)
+
+    def observation_space(self, agent):
+        return obs_space(agent)
+
+    @functools.cache
+    def action_space(self, agent):
+        return Discrete(2)
+
+    def reset(self, seed=None, options=None):
+        self.agents = list(self.possible_agents)
+        self._step_count = 0
+        return dict.fromkeys(self.agents, OBS), {a: {} for a in self.agents}
+
+    def step(self, actions):
+        self._step_count += 1
+        done = self._step_count >= 8
+        obs = dict.fromkeys(self.agents, OBS)
+        rewards = dict.fromkeys(self.agents, RAW_REWARD)
+        terminations = dict.fromkeys(self.agents, done)
+        truncations = dict.fromkeys(self.agents, False)
+        infos = {a: {} for a in self.agents}
+        if done:
+            self.agents = []
+        return obs, rewards, terminations, truncations, infos
+
+    def render(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class NegativeAEC(DummyAEC):
+    def step(self, action):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            self._was_dead_step(action)
+            return
+        self._step_count += 1
+        self._clear_rewards()
+        self.rewards[self.agent_selection] = -RAW_REWARD
+        if self._step_count >= 8:
+            self.terminations = dict.fromkeys(self.agents, True)
+        self._idx = (self._idx + 1) % len(self.agents)
+        self.agent_selection = self.agents[self._idx]
+        self._accumulate_rewards()
+
+
+def test_aec_clips_step_reward():
+    env = ClipRewardV1(DummyAEC(), min_reward=-1, max_reward=1)
+    env.reset(seed=0)
+    env.step(0)
+    assert env.rewards["agent_0"] == 1.0
+    assert env.rewards["agent_1"] == 0.0
+
+
+def test_aec_last_reports_clipped_reward():
+    env = ClipRewardV1(DummyAEC(), min_reward=-1, max_reward=1)
+    env.reset(seed=0)
+    env.step(0)
+    env.step(0)
+    # agent_0 has just become current again; last() is its clipped step.
+    _, cumulative, _, _, _ = env.last()
+    assert cumulative == 1.0
+
+
+def test_aec_clips_negative_rewards():
+    env = ClipRewardV1(NegativeAEC(), min_reward=-1, max_reward=1)
+    env.reset(seed=0)
+    env.step(0)
+    assert env.rewards["agent_0"] == -1.0
+
+
+def test_aec_in_range_reward_is_unchanged():
+    env = ClipRewardV1(DummyAEC(), min_reward=-20, max_reward=20)
+    env.reset(seed=0)
+    env.step(0)
+    assert env.rewards["agent_0"] == RAW_REWARD
+
+
+def test_parallel_clips_step_reward():
+    env = ClipRewardParallelV1(DummyParallel(), min_reward=-1, max_reward=1)
+    env.reset(seed=0)
+    _, rewards, _, _, _ = env.step(dict.fromkeys(AGENTS, 0))
+    assert rewards == {"agent_0": 1.0, "agent_1": 1.0}
+
+
+def test_parallel_in_range_reward_is_unchanged():
+    env = ClipRewardParallelV1(DummyParallel(), min_reward=-20, max_reward=20)
+    env.reset(seed=0)
+    _, rewards, _, _, _ = env.step(dict.fromkeys(AGENTS, 0))
+    assert rewards == {"agent_0": RAW_REWARD, "agent_1": RAW_REWARD}
+
+
+def test_defaults_are_minus_one_and_one():
+    env = ClipRewardV1(DummyAEC())
+    env.reset(seed=0)
+    env.step(0)
+    assert env.rewards["agent_0"] == 1.0
+    assert env.min_reward == -1
+    assert env.max_reward == 1
+
+
+def test_inverted_bounds_raise():
+    with pytest.raises(AssertionError, match="min_reward"):
+        ClipRewardV1(DummyAEC(), min_reward=1, max_reward=-1)
+    with pytest.raises(AssertionError, match="min_reward"):
+        ClipRewardParallelV1(DummyParallel(), min_reward=1, max_reward=-1)
+
+
+def test_rejects_parallel_env():
+    with pytest.raises(AssertionError, match="ClipRewardParallelV1"):
+        ClipRewardV1(DummyParallel())
+
+
+def test_str():
+    assert str(ClipRewardV1(DummyAEC())).startswith("ClipRewardV1<")
+    assert str(ClipRewardParallelV1(DummyParallel())).startswith(
+        "ClipRewardParallelV1<"
+    )
+
+
+def test_aec_api():
+    api_test(ClipRewardV1(DummyAEC()), num_cycles=5)
+
+
+def test_parallel_api():
+    parallel_api_test(ClipRewardParallelV1(DummyParallel()), num_cycles=10)


### PR DESCRIPTION
# Description

Ports SuperSuit's `clip_reward_v0` as `ClipRewardV1` and `ClipRewardParallelV1`, part of #1365. Each agent's per-step reward is clipped into `[min_reward, max_reward]` (defaults `-1` and `1`).

Classes rather than a factory function, per the Gymnasium `ClipReward` shape. AEC and Parallel are both implemented directly on the PettingZoo wrapper bases. SuperSuit only wrapped AEC; the Parallel class is new.

On AEC, the inner `rewards` dict is clipped after every `reset`/`step` and the running total is rebuilt from that, so `last()` reports the sum of clipped steps. That is what SuperSuit did.

## Verification

    $ pytest test/clip_reward_test.py -q
    12 passed, 32 warnings in 1.71s

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the `pre-commit` checks on the changed files, all hooks pass including `ty` and `pydocstyle`
- [ ] I have not run the full `pytest -v`, since I don't have the Atari ROMs and some of the extras installed. I ran the new test file, which is green, and the exact output is above.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes