### PR TITLE
Apply ruff autofixes to the ClipReward/wrapper test files

### DIFF
--- a/pettingzoo/utils/wrappers/color_reduction.py
+++ b/pettingzoo/utils/wrappers/color_reduction.py
@@ -89,7 +89,9 @@ class ColorReductionObservationV1(BaseWrapper[AgentID, Any, ActionType]):
         return f"ColorReductionObservationV1<{self.env!s}>"
 
 
-class ColorReductionObservationParallelV1(BaseParallelWrapper[AgentID, Any, ActionType]):
+class ColorReductionObservationParallelV1(
+    BaseParallelWrapper[AgentID, Any, ActionType]
+):
     """Reduces an image observation to a single channel.
 
     ``"full"`` converts to grayscale with the luminance weights

--- a/test/color_reduction_test.py
+++ b/test/color_reduction_test.py
@@ -9,8 +9,8 @@ from gymnasium.spaces import Box, Discrete
 from pettingzoo.test import api_test, parallel_api_test
 from pettingzoo.utils.env import AECEnv, ParallelEnv
 from pettingzoo.utils.wrappers import (
-    ColorReductionObservationV1,
     ColorReductionObservationParallelV1,
+    ColorReductionObservationV1,
 )
 
 AGENTS = ["agent_0", "agent_1"]
@@ -148,9 +148,9 @@ def test_aec_observation_space_drops_channel_axis(mode, agent):
 
 @pytest.mark.parametrize("mode", ["full", "R", "G", "B"])
 def test_parallel_observation_space_drops_channel_axis(mode):
-    space = ColorReductionObservationParallelV1(DummyParallel(), mode).observation_space(
-        "agent_0"
-    )
+    space = ColorReductionObservationParallelV1(
+        DummyParallel(), mode
+    ).observation_space("agent_0")
     assert space.shape == (2, 2)
     assert space.dtype == np.uint8
 
@@ -195,7 +195,9 @@ def test_aec_single_channel_modes(mode, channel, agent):
 
 @pytest.mark.parametrize("mode,channel", [("R", 0), ("G", 1), ("B", 2)])
 def test_aec_single_channel_modes_keep_the_input_dtype(mode, channel):
-    env = ColorReductionObservationV1(DummyAEC(space=FLOAT_SPACE, obs=float_obs()), mode)
+    env = ColorReductionObservationV1(
+        DummyAEC(space=FLOAT_SPACE, obs=float_obs()), mode
+    )
     env.reset(seed=0)
 
     space = env.observation_space("agent_0")
@@ -294,7 +296,8 @@ def test_observe_passes_through_none():
 def test_aec_str():
     inner = DummyAEC()
     assert (
-        str(ColorReductionObservationV1(inner)) == f"ColorReductionObservationV1<{inner}>"
+        str(ColorReductionObservationV1(inner))
+        == f"ColorReductionObservationV1<{inner}>"
     )
 
 
@@ -311,7 +314,9 @@ def test_aec_api():
 
 
 def test_parallel_api():
-    parallel_api_test(ColorReductionObservationParallelV1(DummyParallel()), num_cycles=5)
+    parallel_api_test(
+        ColorReductionObservationParallelV1(DummyParallel()), num_cycles=5
+    )
 
 
 def test_rejects_parallel_env():

--- a/test/dtype_test.py
+++ b/test/dtype_test.py
@@ -8,7 +8,7 @@ from gymnasium.spaces import Box, Discrete
 
 from pettingzoo.test import api_test, parallel_api_test
 from pettingzoo.utils.env import AECEnv, ParallelEnv
-from pettingzoo.utils.wrappers import DtypeObservationV1, DtypeObservationParallelV1
+from pettingzoo.utils.wrappers import DtypeObservationParallelV1, DtypeObservationV1
 
 AGENTS = ["agent_0", "agent_1"]
 
@@ -277,7 +277,9 @@ def test_impossible_cast_names_the_wrapper_and_agent():
 
 def test_str():
     inner = DummyAEC()
-    assert str(DtypeObservationV1(inner, np.float32)) == f"DtypeObservationV1<{inner!s}>"
+    assert (
+        str(DtypeObservationV1(inner, np.float32)) == f"DtypeObservationV1<{inner!s}>"
+    )
     inner = DummyParallel()
     assert (
         str(DtypeObservationParallelV1(inner, np.float32))

--- a/test/reshape_test.py
+++ b/test/reshape_test.py
@@ -8,7 +8,7 @@ from gymnasium.spaces import Box, Discrete
 
 from pettingzoo.test import api_test, parallel_api_test
 from pettingzoo.utils.env import AECEnv, ParallelEnv
-from pettingzoo.utils.wrappers import ReshapeObservationV1, ReshapeObservationParallelV1
+from pettingzoo.utils.wrappers import ReshapeObservationParallelV1, ReshapeObservationV1
 
 AGENTS = ["agent_0", "agent_1"]
 


### PR DESCRIPTION
`pre-commit` is failing on main. `ruff check` reports three I001 (unsorted import
block) errors and `ruff format` wants three files reformatted. Running the repo's
own pinned hooks (ruff 0.14.10) fixes all of them mechanically:

```
before: Found 3 errors. / 3 files would be reformatted
after:  All checks passed! / 265 files already formatted
```

Import ordering and line wrapping only — no logic touched. Verified
behaviour-neutral: the three affected test files give 4 failed / 106 passed both
before and after, the same four failures. Those four also fail on unmodified
main, so they are pre-existing and out of scope here.

This also clears the red `pre-commit` check on #1435, which picked the failure up
by merging main.