### PR TITLE
Fix api_test failures (#1414) from DummyAEC envs that never retire dead agents

### DIFF
--- a/test/color_reduction_test.py
+++ b/test/color_reduction_test.py
@@ -75,6 +75,12 @@ class DummyAEC(AECEnv):
         return self._obs[agent]
 
     def step(self, action):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            self._was_dead_step(action)
+            return
         self._step_count += 1
         self._cumulative_rewards[self.agent_selection] = 0.0
         self.rewards = dict.fromkeys(self.agents, 0.0)

--- a/test/dtype_test.py
+++ b/test/dtype_test.py
@@ -54,6 +54,12 @@ class DummyAEC(AECEnv):
         return FIXED_OBS[agent]
 
     def step(self, action):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            self._was_dead_step(action)
+            return
         self._step_count += 1
         self._cumulative_rewards[self.agent_selection] = 0.0
         self.rewards = dict.fromkeys(self.agents, 0.0)

--- a/test/pad_observations_test.py
+++ b/test/pad_observations_test.py
@@ -64,6 +64,12 @@ class DummyAEC(AECEnv):
         return self._obs[agent]
 
     def step(self, action):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            self._was_dead_step(action)
+            return
         self._step_count += 1
         self._cumulative_rewards[self.agent_selection] = 0.0
         self.rewards = dict.fromkeys(self.agents, 0.0)

--- a/test/rescale_observation_test.py
+++ b/test/rescale_observation_test.py
@@ -71,6 +71,12 @@ class DummyAEC(AECEnv):
         return FIXED_OBS[agent]
 
     def step(self, action):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            self._was_dead_step(action)
+            return
         self._step_count += 1
         self._cumulative_rewards[self.agent_selection] = 0.0
         self.rewards = dict.fromkeys(self.agents, 0.0)

--- a/test/reshape_test.py
+++ b/test/reshape_test.py
@@ -61,6 +61,12 @@ class DummyAEC(AECEnv):
         return FIXED_OBS[agent]
 
     def step(self, action):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            self._was_dead_step(action)
+            return
         self._step_count += 1
         self._cumulative_rewards[self.agent_selection] = 0.0
         self.rewards = dict.fromkeys(self.agents, 0.0)

--- a/test/scale_action_test.py
+++ b/test/scale_action_test.py
@@ -55,6 +55,12 @@ class DummyAEC(AECEnv):
         return OBS
 
     def step(self, action):
+        if (
+            self.terminations[self.agent_selection]
+            or self.truncations[self.agent_selection]
+        ):
+            self._was_dead_step(action)
+            return
         self.received[self.agent_selection] = action
         self._step_count += 1
         self._cumulative_rewards[self.agent_selection] = 0.0
@@ -220,6 +226,9 @@ def test_action_from_advertised_space_is_valid_inside(scale, bound):
     actions += [space.sample() for _ in range(50)]
 
     for action in actions:
+        # the dummy env terminates every 8 steps
+        if any(env.terminations.values()) or any(env.truncations.values()):
+            env.reset(seed=0)
         assert space.contains(action)
         agent = env.agent_selection
         env.step(action)


### PR DESCRIPTION
# Description

#1414 introduced additional API tests, which test cases introduced in #1426, #1427, #1428, #1429, #1432, #1433 would fail because, for whatever reason, they define some `DummyAEC` and `DummyParallel` classes.

Fixes #1244

## Type of change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

### Screenshots

> Please attach before and after screenshots of the change if applicable.
> To upload images to a PR -- simply drag and drop or copy paste.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have run `pytest -v` and no errors are present.
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I solved any possible warnings that `pytest -v` has generated that are related to my code to the best of my knowledge.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
You can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
