### PR TITLE
Fix empty step return in turn-based parallel conversion

### DIFF
--- a/pettingzoo/utils/conversions.py
+++ b/pettingzoo/utils/conversions.py
@@ -503,7 +503,7 @@ class turn_based_aec_to_parallel_wrapper(
     @override
     def step(self, actions):
         if not self.agents:
-            return {}, {}, {}, {}
+            return {}, {}, {}, {}, {}
         self.aec_env.step(actions[self.aec_env.agent_selection])
         rewards = {**self.aec_env.rewards}
         terminations = {**self.aec_env.terminations}

--- a/test/turn_based_conversion_test.py
+++ b/test/turn_based_conversion_test.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from pettingzoo import AECEnv
+from pettingzoo.classic import rps_v2, tictactoe_v3
+from pettingzoo.utils.conversions import turn_based_aec_to_parallel
+
+
+class EmptyAECEnv(AECEnv):
+    metadata = {"name": "empty_test_env"}
+    render_mode = None
+
+    def reset(self, seed=None, options=None):
+        self.agents = []
+        self.infos = {}
+
+    def step(self, action):
+        raise AssertionError("An empty environment must not be stepped")
+
+
+def test_turn_based_step_with_no_initial_agents():
+    env = turn_based_aec_to_parallel(EmptyAECEnv())
+    assert env.reset() == ({}, {})
+
+    for _ in range(2):
+        observations, rewards, terminations, truncations, infos = env.step({})
+        assert (observations, rewards, terminations, truncations, infos) == (
+            {},
+            {},
+            {},
+            {},
+            {},
+        )
+        assert env.agents == []
+
+
+@pytest.mark.parametrize(
+    ("env_fn", "kwargs", "actions", "final_rewards", "terminated"),
+    [
+        (tictactoe_v3.env, {}, [0, 3, 1, 4, 2], [1, -1], True),
+        (rps_v2.env, {"max_cycles": 1}, [0, 1], [-1, 1], False),
+    ],
+    ids=["termination", "truncation"],
+)
+def test_turn_based_step_after_dead_agents(
+    env_fn, kwargs, actions, final_rewards, terminated
+):
+    aec_env = env_fn(**kwargs)
+    env = turn_based_aec_to_parallel(aec_env)
+    try:
+        env.reset(seed=42)
+        agents = env.agents[:]
+        with patch.object(aec_env, "step", wraps=aec_env.step) as step:
+            for index, action in enumerate(actions):
+                observations, rewards, terminations, truncations, infos = env.step(
+                    {aec_env.agent_selection: action}
+                )
+                for result in (observations, rewards, terminations, truncations, infos):
+                    assert set(result) == set(agents)
+                if index < len(actions) - 1:
+                    assert not any(terminations.values())
+                    assert not any(truncations.values())
+                    assert env.agents == agents
+                    assert all(
+                        info["active_agent"] == aec_env.agent_selection
+                        for info in infos.values()
+                    )
+
+            assert rewards == dict(zip(agents, final_rewards))
+            assert terminations == dict.fromkeys(agents, terminated)
+            assert truncations == dict.fromkeys(agents, not terminated)
+            assert env.agents == aec_env.agents == []
+            assert [call.args[0] for call in step.call_args_list] == actions + [
+                None,
+                None,
+            ]
+
+            step.reset_mock()
+            for _ in range(2):
+                observations, rewards, terminations, truncations, infos = env.step({})
+                assert (observations, rewards, terminations, truncations, infos) == (
+                    {},
+                    {},
+                    {},
+                    {},
+                    {},
+                )
+                assert env.agents == aec_env.agents == []
+            step.assert_not_called()
+    finally:
+        env.close()


### PR DESCRIPTION
### Description

After all agents have finished, `turn_based_aec_to_parallel(...).step({})` returns only four dictionaries. Callers unpacking the five values required by `ParallelEnv.step()` fail with `ValueError: not enough values to unpack (expected 5, got 4)`.

Return five empty dictionaries from that branch. Live stepping and dead-agent cleanup remain unchanged. Regression tests cover an initially empty environment, Tic-Tac-Toe termination, and Rock-Paper-Scissors truncation, including final rewards/flags, dead-agent removal, and repeated empty steps without forwarding actions to the wrapped environment.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

### Testing

- New regressions: all three fail on upstream with the unpacking error.
- Focused new and existing tests: 12 passed (`test/turn_based_conversion_test.py`, `test/agents_done_test.py`, `test/variable_env_test.py`).
- All configured pre-commit checks passed for the changed files, including Ruff and ty; commit hooks passed.
- Full optional-environment suite not run. No environment rules, version, or documentation changes.

### Checklist

- [x] Configured pre-commit checks run on changed files
- [ ] Repository-wide `pre-commit run --all-files`
- [ ] Full `pytest -v` suite
- [x] Regression tests prove the fix
- [x] Relevant new and existing tests pass
- [x] Warnings reviewed; no new fix-related warnings
