### PR TITLE
Treat a seed of 0 as a seed in the multi-episode wrappers

### DIFF
--- a/pettingzoo/utils/wrappers/multi_episode_env.py
+++ b/pettingzoo/utils/wrappers/multi_episode_env.py
@@ -75,7 +75,7 @@ class MultiEpisodeEnv(BaseWrapper[AgentID, ObsType, ActionType]):
         # if no more agents and haven't had enough episodes,
         # increment the number of episodes and the seed for reset
         self._episodes_elapsed += 1
-        self._seed = self._seed + 1 if self._seed else None
+        self._seed = self._seed + 1 if self._seed is not None else None
         super().reset(seed=self._seed, options=self._options)
 
     @override

--- a/pettingzoo/utils/wrappers/multi_episode_parallel_env.py
+++ b/pettingzoo/utils/wrappers/multi_episode_parallel_env.py
@@ -104,6 +104,6 @@ class MultiEpisodeParallelEnv(BaseParallelWrapper[AgentID, ObsType, ActionType])
         # at the reset points
         # increment the number of episodes and the seed for reset
         self._episodes_elapsed += 1
-        self._seed = self._seed + 1 if self._seed else None
+        self._seed = self._seed + 1 if self._seed is not None else None
         obs, info = super().reset(seed=self._seed, options=self._options)
         return obs, rew, term, trunc, info

--- a/test/wrapper_test.py
+++ b/test/wrapper_test.py
@@ -5,6 +5,7 @@ import pytest
 from pettingzoo.butterfly import pistonball_v6
 from pettingzoo.classic import texas_holdem_no_limit_v6, tictactoe_v3
 from pettingzoo.utils.wrappers import (
+    BaseParallelWrapper,
     BaseWrapper,
     MultiEpisodeEnv,
     MultiEpisodeParallelEnv,
@@ -72,6 +73,63 @@ def test_multi_episode_parallel_env_wrapper(num_episodes) -> None:
     assert steps == num_episodes * 125, (
         f"Expected to have 125 steps per episode, got {steps / num_episodes}."
     )
+
+
+def test_multi_episode_env_wrapper_seeds_every_episode() -> None:
+    """A seed of 0 is a seed: every episode after it is seeded too."""
+
+    class RecordSeeds(BaseWrapper):
+        def __init__(self, env):
+            super().__init__(env)
+            self.seeds: list[int | None] = []
+
+        def reset(self, seed=None, options=None):
+            self.seeds.append(seed)
+            super().reset(seed=seed, options=options)
+
+    inner = RecordSeeds(texas_holdem_no_limit_v6.env(num_players=3))
+    env = MultiEpisodeEnv(inner, num_episodes=3)
+    env.reset(seed=0)
+
+    for agent in env.agent_iter():
+        obs, rew, term, trunc, info = env.last()
+
+        if term or trunc:
+            action = None
+        else:
+            action_space = env.action_space(agent)
+            action_space.seed(0)
+            action = action_space.sample(mask=obs["action_mask"])
+
+        env.step(action)
+
+    env.close()
+
+    assert inner.seeds == [0, 1, 2]
+
+
+def test_multi_episode_parallel_env_wrapper_seeds_every_episode() -> None:
+    """A seed of 0 is a seed: every episode after it is seeded too."""
+
+    class RecordSeeds(BaseParallelWrapper):
+        def __init__(self, env):
+            super().__init__(env)
+            self.seeds: list[int | None] = []
+
+        def reset(self, seed=None, options=None):
+            self.seeds.append(seed)
+            return super().reset(seed=seed, options=options)
+
+    inner = RecordSeeds(pistonball_v6.parallel_env())
+    env = MultiEpisodeParallelEnv(inner, num_episodes=3)
+    env.reset(seed=0)
+
+    while env.agents:
+        env.step({agent: env.action_space(agent).low for agent in env.agents})
+
+    env.close()
+
+    assert inner.seeds == [0, 1, 2]
 
 
 def _do_game(env: TerminateIllegalWrapper, seed: int) -> None:


### PR DESCRIPTION
## Summary

Both multi-episode wrappers bump the seed for each internal reset:

```python
self._seed = self._seed + 1 if self._seed else None
```

`0` is falsy, so a run started with `reset(seed=0)` seeds its first episode and no other. Every later episode resets with `seed=None`, and the run stops being reproducible halfway through — silently, and only for that one seed value.

Recording the seeds the wrapped environment is reset with, over three episodes started at `reset(seed=0)`:

| | seeds the inner env receives |
|---|---|
| `reset(seed=0)` | `[0, None, None]` |
| `reset(seed=1)` | `[1, 2, 3]` |

`MultiEpisodeEnv` and `MultiEpisodeParallelEnv` carry the same line, so both are affected. The wrappers are documented for building evaluation environments, which is exactly where a seed silently going missing costs the most.

## Changes

* `pettingzoo/utils/wrappers/multi_episode_env.py` and `multi_episode_parallel_env.py` — `if self._seed is not None`, so `0` is treated as the seed it is. Nothing else changes: `reset(seed=None)` still leaves every episode unseeded.
* `test/wrapper_test.py` — one test per wrapper. A small recording wrapper sits between the multi-episode wrapper and the environment and collects the seeds it is reset with; the run starts at `reset(seed=0)` and the collected seeds must be `[0, 1, 2]`.

## Verification

`test/wrapper_test.py`: **15 passed**.

With the fix reverted and the tests kept, both fail with `[0, None, None] == [0, 1, 2]`, at index 1. The tests detect the defect rather than passing regardless.

`ruff check` and `ruff format --check` are clean on all three files.
